### PR TITLE
added rector for Environment in Nette 0.9

### DIFF
--- a/src/Rector/Contrib/Nette/Environment/NetteEnvironmentRector.php
+++ b/src/Rector/Contrib/Nette/Environment/NetteEnvironmentRector.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Rector\Contrib\Nette\Environment;
+
+use Rector\Rector\AbstractClassReplacerRector;
+
+final class NetteEnvironmentRector extends AbstractClassReplacerRector
+{
+    /**
+     * @return string[]
+     */
+    protected function getOldToNewClasses(): array
+    {
+        return [
+            'Environment' => 'Nette\Environment',
+        ];
+    }
+}

--- a/src/config/level/nette/nette09.yml
+++ b/src/config/level/nette/nette09.yml
@@ -1,0 +1,2 @@
+rectors:
+    - Rector\Rector\Contrib\Nette\Environment\NetteEnvironmentRector

--- a/tests/Rector/Contrib/Nette/Environment/NetteEnvironmentRector/Correct/correct.php.inc
+++ b/tests/Rector/Contrib/Nette/Environment/NetteEnvironmentRector/Correct/correct.php.inc
@@ -1,0 +1,3 @@
+<?php
+
+$variable = \Nette\Environment::getVariable('nameOfVariable');

--- a/tests/Rector/Contrib/Nette/Environment/NetteEnvironmentRector/Test.php
+++ b/tests/Rector/Contrib/Nette/Environment/NetteEnvironmentRector/Test.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Tests\Rector\Contrib\Nette\Environment\NetteEnvironmentRector;
+
+use Rector\Rector\Contrib\Nette\Environment\NetteEnvironmentRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class Test extends AbstractRectorTestCase
+{
+    public function test(): void
+    {
+        $this->doTestFileMatchesExpectedContent(
+            __DIR__ . '/Wrong/wrong.php.inc',
+            __DIR__ . '/Correct/correct.php.inc'
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getRectorClasses(): array
+    {
+        return [NetteEnvironmentRector::class];
+    }
+}

--- a/tests/Rector/Contrib/Nette/Environment/NetteEnvironmentRector/Wrong/wrong.php.inc
+++ b/tests/Rector/Contrib/Nette/Environment/NetteEnvironmentRector/Wrong/wrong.php.inc
@@ -1,0 +1,3 @@
+<?php
+
+$variable = Environment::getVariable('nameOfVariable');


### PR DESCRIPTION
Rector convert from `Environment` class from Nette 0.9.x to 2.0.x

I added configuration for Nette 0.9.x too. :-)