### PR TITLE
Prefer level shortcuts insetad of config files in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,18 @@ E.g. Do you need to upgrade to Nette 2.4?
 1. Run rector on your `/src` directory
 
 ```bash
-vendor/bin/rector process src --config vendor/bin/rector/src/config/level/nette/nette24.yml
+vendor/bin/rector process src --level nette24
 ```
 
-Too long? Try `--level` shortcut:
+Which is just a shortcut for using complete path with `--config` option:
+```bash
+vendor/bin/rector process src --config vendor/rector/rector/src/config/level/nette/nette24.yml
+```
+
+You can also use your own config file:
 
 ```bash
-vendor/bin/rector process src --level nette24
+vendor/bin/rector process src --config your-own-config.yml
 ```
 
 2. Check the Git


### PR DESCRIPTION
I read from top to bottom, meaning I first struggled to get the proper path to yml file for `--config` option working (the readme contained a wrong example - which I also fixed).

Only after I made it, I found on next line in the readme I could just use the shortcut 🙃 .

IMHO the shortcut for `--level` is more simpler usage, and the `--config` is meant for some specific use-cases, so I would first suggest using this one, which will IMHO work for most of people.