### PR TITLE
namespace rector fix

### DIFF
--- a/src/Rector/Dynamic/NamespaceReplacerRector.php
+++ b/src/Rector/Dynamic/NamespaceReplacerRector.php
@@ -185,11 +185,10 @@ final class NamespaceReplacerRector extends AbstractRector
     {
         /** @var FullyQualified $resolvedName */
         $resolvedName = $nameNode->getAttribute(Attribute::RESOLVED_NAME);
-        $fullyQualifiedName = $resolvedName->toString();
         $completeNewName = $this->resolveNewNameFromNode($resolvedName);
 
         // first dummy implementation - improve
-        $cutOffFromTheLeft = strlen($fullyQualifiedName) - strlen($nameNode->toString());
+        $cutOffFromTheLeft = strlen($completeNewName) - strlen($nameNode->toString());
 
         return substr($completeNewName, $cutOffFromTheLeft);
     }

--- a/tests/Rector/Dynamic/NamespaceReplacerRector/Test.php
+++ b/tests/Rector/Dynamic/NamespaceReplacerRector/Test.php
@@ -28,6 +28,11 @@ final class Test extends AbstractConfigurableRectorTestCase
             __DIR__ . '/wrong/wrong4.php.inc',
             __DIR__ . '/correct/correct4.php.inc'
         );
+
+        $this->doTestFileMatchesExpectedContent(
+            __DIR__ . '/wrong/wrong5.php.inc',
+            __DIR__ . '/correct/correct5.php.inc'
+        );
     }
 
     protected function provideConfig(): string

--- a/tests/Rector/Dynamic/NamespaceReplacerRector/config/rector.yml
+++ b/tests/Rector/Dynamic/NamespaceReplacerRector/config/rector.yml
@@ -2,4 +2,5 @@ rectors:
     Rector\Rector\Dynamic\NamespaceReplacerRector:
         'OldNamespace': 'NewNamespace'
         'OldNamespaceWith\OldSplitNamespace': 'NewNamespaceWith\NewSplitNamespace'
+        'Old\Long\AnyNamespace': 'Short\AnyNamespace'
         'PHPUnit_Framework_': 'PHPUnit\Framework\'

--- a/tests/Rector/Dynamic/NamespaceReplacerRector/correct/correct5.php.inc
+++ b/tests/Rector/Dynamic/NamespaceReplacerRector/correct/correct5.php.inc
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Short\AnyNamespace;
+
+class SomeClass
+{
+    public function someClass()
+    {
+        return new SomeClass;
+    }
+}

--- a/tests/Rector/Dynamic/NamespaceReplacerRector/wrong/wrong5.php.inc
+++ b/tests/Rector/Dynamic/NamespaceReplacerRector/wrong/wrong5.php.inc
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Old\Long\AnyNamespace;
+
+class SomeClass
+{
+    public function someClass()
+    {
+        return new SomeClass;
+    }
+}


### PR DESCRIPTION
Hey, this PR fixes bug, where namespace rector generated wrong class names. I was unable fix one test error, which was already present as it wants me to "Use service and constructor injection rather than instantiation", but service container is not instantiated yet. Have a nice day:)