### PR TITLE
docs - extract install for old PHP into docs folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Rector **upgrades your application** for you, with focus on open-source projects
 composer require --dev rector/rector @dev nikic/php-parser 'dev-master#5900d78 as v3.1.1'
 ```
 
+Do you have old PHP or dependencies in conflict? Ok, [it is not problem](/docs/HowUseWithOldPhp.md).
+
 ## How To Reconstruct your Code?
 
 ### A. Prepared Sets
@@ -271,20 +273,3 @@ Just follow 3 rules:
     ```
 
 We would be happy to merge your feature then.
-
-
-### How to use on PHP < 7.1 on Incompatible Composer Dependencies
-
-You must have an isolated environment with PHP 7.1 (for example in a Docker container). When you have it then run following command:
-
-```
-composer create-project rector/rector path-to-rector
-```
-
-You will be able to run all commands in the following manner:
-
-```
-path-to-rector/bin/rector process /var/www/old-project --config path-to-rector/src/config/level/symfony/symfony33.yml
-# or for short
-path-to-rector/bin/rector process /var/www/old-project --level symfony33
-```

--- a/docs/HowUseWithOldPhp.md
+++ b/docs/HowUseWithOldPhp.md
@@ -1,0 +1,15 @@
+### How to use on PHP < 7.1 on Incompatible Composer Dependencies
+
+You must have an isolated environment with PHP 7.1 (for example in a Docker container). When you have it then run following command:
+
+```
+composer create-project rector/rector path-to-rector
+```
+
+You will be able to run all commands in the following manner:
+
+```
+path-to-rector/bin/rector process /var/www/old-project --config path-to-rector/src/config/level/symfony/symfony33.yml
+# or for short
+path-to-rector/bin/rector process /var/www/old-project --level symfony33
+```


### PR DESCRIPTION
It is part of my ideas for issue #133.

What do you mean about it? For now are installation steps in one place.