### PR TITLE
[PHPUnit] Add NarrowMethodsRector

### DIFF
--- a/easy-coding-standard.neon
+++ b/easy-coding-standard.neon
@@ -44,3 +44,9 @@ parameters:
         PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\EmptyStatementSniff:
             # intentionally
             - packages/BetterReflection/src/Reflector/SmartClassReflector.php
+
+    skip_codes:
+        SlevomatCodingStandard\Sniffs\TypeHints\TypeHintDeclarationSniff.MissingParameterTypeHint:
+            # forcing "mixed" types
+            - src/Node/NodeFactory.php
+            - packages/NodeTypeResolver/tests/AbstractNodeTypeResolverTest.php

--- a/packages/NodeTypeResolver/tests/AbstractNodeTypeResolverTest.php
+++ b/packages/NodeTypeResolver/tests/AbstractNodeTypeResolverTest.php
@@ -48,9 +48,6 @@ abstract class AbstractNodeTypeResolverTest extends AbstractContainerAwareTestCa
         return $newStmts;
     }
 
-    /**
-     * @param mixed $expectedContent
-     */
     protected function doTestAttributeEquals(Node $node, string $attribute, $expectedContent): void
     {
         $this->assertSame($expectedContent, $node->getAttribute($attribute));

--- a/packages/ReflectionDocBlock/src/NodeAnalyzer/DocBlockAnalyzer.php
+++ b/packages/ReflectionDocBlock/src/NodeAnalyzer/DocBlockAnalyzer.php
@@ -175,7 +175,6 @@ final class DocBlockAnalyzer
      * Magic untill, since object is read only
      *
      * @param object $object
-     * @param mixed $value
      */
     private function setPrivatePropertyValue($object, string $name, $value): void
     {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -39,6 +39,10 @@ parameters:
         - '#Instanceof between PhpParser\\Node\\Expr\|string and PhpParser\\Node\\Name will always evaluate to false#'
         - '#Method Rector\\BetterReflection\\Reflector\\SmartClassReflector::reflect\(\) should return Rector\\BetterReflection\\Reflection\\ReflectionClass\|null but returns Rector\\BetterReflection\\Reflection\\Reflection#'
 
+        # known value of Name of MethodCall
+        - '#Call to an undefined method PhpParser\\Node\\Expr\|PhpParser\\Node\\Name::toString\(\)#'
+        - '#Cannot call method toString\(\) on PhpParser\\Node\\Expr\|string#'
+
         # buggy
         - '#Parameter \#1 \$classLikeNode of method Rector\\NodeAnalyzer\\ClassLikeAnalyzer::resolveExtendsTypes\(\) expects PhpParser\\Node\\Stmt\\Class_\|PhpParser\\Node\\Stmt\\Interface_, PhpParser\\Node\\Stmt\\ClassLike given#'
         - '#Parameter \#1 \$functionLikeNode of method Rector\\NodeTypeResolver\\TypeContext::getFunctionReflection\(\) expects PhpParser\\Node\\Expr\\Closure\|PhpParser\\Node\\Stmt\\ClassMethod\|PhpParser\\Node\\Stmt\\Function_, PhpParser\\Node\\FunctionLike given#'

--- a/src/Node/NodeFactory.php
+++ b/src/Node/NodeFactory.php
@@ -175,9 +175,6 @@ final class NodeFactory
         return new Expression($assign);
     }
 
-    /**
-     * @param mixed $argument
-     */
     public function createArg($argument): Arg
     {
         $value = BuilderHelpers::normalizeValue($argument);

--- a/src/Rector/Contrib/PHPUnit/SpecificMethodBoolNullRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethodBoolNullRector.php
@@ -19,6 +19,15 @@ use Rector\Rector\AbstractRector;
 final class SpecificMethodBoolNullRector extends AbstractRector
 {
     /**
+     * @var string[]
+     */
+    private $constValueToMethodNames = [
+        'null' => 'assertNull',
+        'true' => 'assertTrue',
+        'false' => 'assertFalse',
+    ];
+
+    /**
      * @var MethodCallAnalyzer
      */
     private $methodCallAnalyzer;
@@ -54,11 +63,8 @@ final class SpecificMethodBoolNullRector extends AbstractRector
         }
 
         $costName = $firstArgumentValue->name->toString();
-        if ($costName === 'null') {
-            return true;
-        }
 
-        return false;
+        return isset($this->constValueToMethodNames[$costName]);
     }
 
     /**
@@ -66,7 +72,12 @@ final class SpecificMethodBoolNullRector extends AbstractRector
      */
     public function refactor(Node $methodCallNode): ?Node
     {
-        $methodCallNode->name = new Identifier('assertNull');
+        /** @var ConstFetch $constFetchNode */
+        $constFetchNode = $methodCallNode->args[0]->value;
+        $constValue = $constFetchNode->name->toString();
+
+        $newMethodName = $this->constValueToMethodNames[$constValue];
+        $methodCallNode->name = new Identifier($newMethodName);
 
         $methodArguments = $methodCallNode->args;
         array_shift($methodArguments);

--- a/src/Rector/Contrib/PHPUnit/SpecificMethodBoolNullRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethodBoolNullRector.php
@@ -1,0 +1,78 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Rector\Contrib\PHPUnit;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use Rector\NodeAnalyzer\MethodCallAnalyzer;
+use Rector\Rector\AbstractRector;
+
+/**
+ * Before:
+ * - $this->assertSame(null, $anything);
+ *
+ * After:
+ * - $this->assertNull($anything);
+ */
+final class SpecificMethodBoolNullRector extends AbstractRector
+{
+    /**
+     * @var MethodCallAnalyzer
+     */
+    private $methodCallAnalyzer;
+
+    /**
+     * @var string|null
+     */
+    private $activeFuncCallName;
+
+    public function __construct(MethodCallAnalyzer $methodCallAnalyzer)
+    {
+        $this->methodCallAnalyzer = $methodCallAnalyzer;
+    }
+
+    public function isCandidate(Node $node): bool
+    {
+        $this->activeFuncCallName = null;
+
+        if (! $this->methodCallAnalyzer->isTypesAndMethods(
+            $node,
+            ['PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase'],
+            ['assertSame']
+        )) {
+            return false;
+        }
+
+        /** @var MethodCall $methodCallNode */
+        $methodCallNode = $node;
+
+        $firstArgumentValue = $methodCallNode->args[0]->value;
+        if (! $firstArgumentValue instanceof ConstFetch) {
+            return false;
+        }
+
+        $costName = $firstArgumentValue->name->toString();
+        if ($costName === 'null') {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param MethodCall $methodCallNode
+     */
+    public function refactor(Node $methodCallNode): ?Node
+    {
+        $methodCallNode->name = new Identifier('assertNull');
+
+        $methodArguments = $methodCallNode->args;
+        array_shift($methodArguments);
+
+        $methodCallNode->args = $methodCallNode;
+
+        return $methodCallNode;
+    }
+}

--- a/src/Rector/Contrib/PHPUnit/SpecificMethodBoolNullRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethodBoolNullRector.php
@@ -71,7 +71,7 @@ final class SpecificMethodBoolNullRector extends AbstractRector
         $methodArguments = $methodCallNode->args;
         array_shift($methodArguments);
 
-        $methodCallNode->args = $methodCallNode;
+        $methodCallNode->args = $methodArguments;
 
         return $methodCallNode;
     }

--- a/src/Rector/Contrib/PHPUnit/SpecificMethodObjectAttributeRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethodObjectAttributeRector.php
@@ -1,0 +1,95 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Rector\Contrib\PHPUnit;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Isset_;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\LNumber;
+use PhpParser\Node\Scalar\String_;
+use Rector\NodeAnalyzer\MethodCallAnalyzer;
+use Rector\Rector\AbstractRector;
+
+/**
+ * Before:
+ * - $this->assertSame(5, count($anything));
+ *
+ * After:
+ * - $this->assertCount(5, $anything);
+ */
+final class SpecificMethodObjectAttributeRector extends AbstractRector
+{
+    /**
+     * @var MethodCallAnalyzer
+     */
+    private $methodCallAnalyzer;
+
+    /**
+     * @var string|null
+     */
+    private $activeFuncCallName;
+
+    public function __construct(MethodCallAnalyzer $methodCallAnalyzer)
+    {
+        $this->methodCallAnalyzer = $methodCallAnalyzer;
+    }
+
+    public function isCandidate(Node $node): bool
+    {
+        $this->activeFuncCallName = null;
+
+        if (! $this->methodCallAnalyzer->isTypesAndMethods(
+            $node,
+            ['PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase'],
+            ['assertTrue', 'assertFalse']
+        )) {
+            return false;
+        }
+
+        /** @var MethodCall $methodCallNode */
+        $methodCallNode = $node;
+
+        $firstArgumentValue = $methodCallNode->args[0]->value;
+
+        // is property access
+        if (! $firstArgumentValue instanceof Isset_) {
+            return false;
+        }
+
+        /** @var Isset_ $issetNode */
+        $issetNode = $firstArgumentValue;
+
+        return $issetNode->vars[0] instanceof PropertyFetch;
+    }
+
+    /**
+     * @param MethodCall $methodCallNode
+     */
+    public function refactor(Node $methodCallNode): ?Node
+    {
+        // rename method
+        if ($methodCallNode->name->toString() === 'assertTrue') {
+            $methodCallNode->name = new Identifier('assertObjectHasAttribute');
+        } else {
+            $methodCallNode->name = new Identifier('assertObjectNotHasAttribute');
+        }
+
+        // move isset to property and object
+        /** @var Isset_ $issetNode */
+        $issetNode = $methodCallNode->args[0]->value;
+
+        /** @var PropertyFetch $propertyFetchNode */
+        $propertyFetchNode = $issetNode->vars[0];
+
+        // and set as arguments
+        $methodCallNode->args = [
+            new String_($propertyFetchNode->name->toString()),
+            $propertyFetchNode->var
+        ];
+
+        return $methodCallNode;
+    }
+}

--- a/src/Rector/Contrib/PHPUnit/SpecificMethodObjectAttributeRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethodObjectAttributeRector.php
@@ -3,12 +3,11 @@
 namespace Rector\Rector\Contrib\PHPUnit;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\Isset_;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Identifier;
-use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Scalar\String_;
 use Rector\NodeAnalyzer\MethodCallAnalyzer;
 use Rector\Rector\AbstractRector;
@@ -86,8 +85,8 @@ final class SpecificMethodObjectAttributeRector extends AbstractRector
 
         // and set as arguments
         $methodCallNode->args = [
-            new String_($propertyFetchNode->name->toString()),
-            $propertyFetchNode->var
+            new Arg(new String_($propertyFetchNode->name->toString())),
+            new Arg($propertyFetchNode->var),
         ];
 
         return $methodCallNode;

--- a/src/config/level/phpunit/phpunit60.yml
+++ b/src/config/level/phpunit/phpunit60.yml
@@ -20,3 +20,4 @@ rectors:
     Rector\Rector\Contrib\PHPUnit\SpecificMethodRector: ~
     Rector\Rector\Contrib\PHPUnit\SpecificMethodBoolNullRector: ~
     Rector\Rector\Contrib\PHPUnit\SpecificMethodCountRector: ~
+    Rector\Rector\Contrib\PHPUnit\SpecificMethodObjectAttributeRector: ~

--- a/src/config/level/phpunit/phpunit60.yml
+++ b/src/config/level/phpunit/phpunit60.yml
@@ -2,6 +2,7 @@ rectors:
     Rector\Rector\Contrib\PHPUnit\ExceptionAnnotationRector: ~
     Rector\Rector\Contrib\PHPUnit\GetMockRector: ~
     Rector\Rector\Contrib\PHPUnit\SpecificMethodRector: ~
+    Rector\Rector\Contrib\PHPUnit\SpecificMethodBoolNullRector: ~
 
     # ref. https://github.com/sebastianbergmann/phpunit/compare/5.7.9...6.0.0
     Rector\Rector\Dynamic\PseudoNamespaceToNamespaceRector:

--- a/src/config/level/phpunit/phpunit60.yml
+++ b/src/config/level/phpunit/phpunit60.yml
@@ -1,8 +1,6 @@
 rectors:
     Rector\Rector\Contrib\PHPUnit\ExceptionAnnotationRector: ~
     Rector\Rector\Contrib\PHPUnit\GetMockRector: ~
-    Rector\Rector\Contrib\PHPUnit\SpecificMethodRector: ~
-    Rector\Rector\Contrib\PHPUnit\SpecificMethodBoolNullRector: ~
 
     # ref. https://github.com/sebastianbergmann/phpunit/compare/5.7.9...6.0.0
     Rector\Rector\Dynamic\PseudoNamespaceToNamespaceRector:
@@ -17,3 +15,8 @@ rectors:
         'PHPUnit\Framework\TestClass':
             'setExpectedException': 'expectedException'
             'setExpectedExceptionRegExp': 'expectedException'
+
+    # possibly earlier
+    Rector\Rector\Contrib\PHPUnit\SpecificMethodRector: ~
+    Rector\Rector\Contrib\PHPUnit\SpecificMethodBoolNullRector: ~
+    Rector\Rector\Contrib\PHPUnit\SpecificMethodCountRector: ~

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethodBoolNullRector/Correct/correct.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethodBoolNullRector/Correct/correct.php.inc
@@ -5,5 +5,7 @@ final class MyTest extends \PHPUnit\Framework\TestCase
     public function test()
     {
         $this->assertNull('second argument');
+        $this->assertFalse('second argument');
+        $this->assertTrue('second argument');
     }
 }

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethodBoolNullRector/Correct/correct.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethodBoolNullRector/Correct/correct.php.inc
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+final class MyTest extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $this->assertNull('second argument');
+    }
+}

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethodBoolNullRector/Test.php
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethodBoolNullRector/Test.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Tests\Rector\Contrib\PHPUnit\SpecificMethodBoolNullRector;
+
+use Rector\Rector\Contrib\PHPUnit\SpecificMethodBoolNullRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class Test extends AbstractRectorTestCase
+{
+    public function test(): void
+    {
+        $this->doTestFileMatchesExpectedContent(
+            __DIR__ . '/Wrong/wrong.php.inc',
+            __DIR__ . '/Correct/correct.php.inc'
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getRectorClasses(): array
+    {
+        return [SpecificMethodBoolNullRector::class];
+    }
+}

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethodBoolNullRector/Wrong/wrong.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethodBoolNullRector/Wrong/wrong.php.inc
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+final class MyTest extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $this->assertSame(null, 'second argument');
+    }
+}

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethodBoolNullRector/Wrong/wrong.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethodBoolNullRector/Wrong/wrong.php.inc
@@ -5,5 +5,7 @@ final class MyTest extends \PHPUnit\Framework\TestCase
     public function test()
     {
         $this->assertSame(null, 'second argument');
+        $this->assertSame(false, 'second argument');
+        $this->assertSame(true, 'second argument');
     }
 }

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethodCountRector/Correct/correct.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethodCountRector/Correct/correct.php.inc
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+final class MyTest extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $this->assertCount(5, $something);
+    }
+}

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethodCountRector/Test.php
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethodCountRector/Test.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Tests\Rector\Contrib\PHPUnit\SpecificMethodCountRector;
+
+use Rector\Rector\Contrib\PHPUnit\SpecificMethodCountRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class Test extends AbstractRectorTestCase
+{
+    public function test(): void
+    {
+        $this->doTestFileMatchesExpectedContent(
+            __DIR__ . '/Wrong/wrong.php.inc',
+            __DIR__ . '/Correct/correct.php.inc'
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getRectorClasses(): array
+    {
+        return [SpecificMethodCountRector::class];
+    }
+}

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethodCountRector/Wrong/wrong.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethodCountRector/Wrong/wrong.php.inc
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+final class MyTest extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $this->assertSame(5, count($something));
+    }
+}

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethodObjectAttributeRector/Correct/correct.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethodObjectAttributeRector/Correct/correct.php.inc
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+final class MyTest extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $this->assertObjectHasAttribute('value1', $node);
+        $this->assertObjectNotHasAttribute('value2', $node);
+    }
+}

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethodObjectAttributeRector/Test.php
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethodObjectAttributeRector/Test.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Tests\Rector\Contrib\PHPUnit\SpecificMethodObjectAttributeRector;
+
+use Rector\Rector\Contrib\PHPUnit\SpecificMethodObjectAttributeRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class Test extends AbstractRectorTestCase
+{
+    public function test(): void
+    {
+        $this->doTestFileMatchesExpectedContent(
+            __DIR__ . '/Wrong/wrong.php.inc',
+            __DIR__ . '/Correct/correct.php.inc'
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getRectorClasses(): array
+    {
+        return [SpecificMethodObjectAttributeRector::class];
+    }
+}

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethodObjectAttributeRector/Wrong/wrong.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethodObjectAttributeRector/Wrong/wrong.php.inc
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+final class MyTest extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $this->assertTrue(isset($node->value1));
+        $this->assertFalse(isset($node->value2));
+    }
+}


### PR DESCRIPTION
Closes #187

- `assertCount` instead of `count` function;
- `assertTrue` instead of strict comparison with `true` keyword;
- `assertFalse` instead of strict comparison with `false` keyword;
- `assertNull` instead of strict comparison with `null` keyword;
- `assertObjectHasAttribute` and `assertObjectNotHasAttribute` instead of `isset` function.


Thaks @carusogabriel  for inspiration