### PR TITLE
Add more tests for SpecificMethodsRector

### DIFF
--- a/tests/Rector/Contrib/PHPUnit/SpecificMethodRector/Correct/correct.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethodRector/Correct/correct.php.inc
@@ -5,5 +5,13 @@ final class MyTest extends \PHPUnit\Framework\TestCase
     public function test()
     {
         $this->assertIsReadable('...', 'second argument');
+        $this->assertArrayHasKey('...', ['...'], 'second argument');
+        $this->assertEmpty('...', 'second argument');
+        $this->assertFileExists('...', 'second argument');
+        $this->assertDirectoryExists('...', 'second argument');
+        $this->assertInfinite('...', 'second argument');
+        $this->assertNull('...', 'second argument');
+        $this->assertIsWritable('...', 'second argument');
+        $this->assertNan('...', 'second argument');
     }
 }

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethodRector/Wrong/wrong.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethodRector/Wrong/wrong.php.inc
@@ -5,5 +5,13 @@ final class MyTest extends \PHPUnit\Framework\TestCase
     public function test()
     {
         $this->assertTrue(is_readable('...'), 'second argument');
+        $this->assertTrue(array_key_exists('...', ['...']), 'second argument');
+        $this->assertTrue(empty('...'), 'second argument');
+        $this->assertTrue(file_exists('...'), 'second argument');
+        $this->assertTrue(is_dir('...'), 'second argument');
+        $this->assertTrue(is_infinite('...'), 'second argument');
+        $this->assertTrue(is_null('...'), 'second argument');
+        $this->assertTrue(is_writable('...'), 'second argument');
+        $this->assertTrue(is_nan('...'), 'second argument');
     }
 }


### PR DESCRIPTION
@TomasVotruba Tomáš, I was trying to use `rector` in some `PHPUnit` refractories, but `assertEmpty` and `assertArrayHasKey` wasn't working properly. Adding some tests I could verify that:
```diff
1) Rector\Tests\Rector\Contrib\PHPUnit\SpecificMethodRector\Test::test
Original file "/var/www/rector/tests/Rector/Contrib/PHPUnit/SpecificMethodRector/Wrong/wrong.php.inc" did not match the result.
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-        $this->assertArrayHasKey('...', ['...'], 'second argument');\n
-        $this->assertEmpty('...', 'second argument');\n
+        $this->assertArrayHasKey('...', 'second argument');\n
+        $this->assertTrue(empty('...'), 'second argument');\n
```
What do I need to study to fix this? Nikitas's PHP-Parser?