### PR TITLE
First try to fix assertArrayHasKey

### DIFF
--- a/src/Rector/Contrib/PHPUnit/SpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethodRector.php
@@ -3,6 +3,7 @@
 namespace Rector\Rector\Contrib\PHPUnit;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\Empty_;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
@@ -120,6 +121,12 @@ final class SpecificMethodRector extends AbstractRector
 
         if ($funcCallOrEmptyNode instanceof Empty_) {
             $methodCallNode->args[0] = $funcCallOrEmptyNode->expr;
+        }
+
+        $arrayNode = $funcCallOrEmptyNode->args[1]->value ?? null;
+
+        if ($arrayNode instanceof Array_) {
+            $methodCallNode->args[1] = $arrayNode;
         }
     }
 


### PR DESCRIPTION
@TomasVotruba I got something, but now the custom message has been overwritten. I guess we will need to create a new `SpecificMethodArrayRector` or something, so we can keep the Singular Responsibility for each class, and also when I implement new Rectors for `array`s, it will be easier. Actually, I think we'll need to work in `AbstractRector` as well. If you can guide me :+1: 