### PR TITLE
Extend SpecificMethodCountRector

### DIFF
--- a/src/Rector/Contrib/PHPUnit/SpecificMethodCountRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethodCountRector.php
@@ -58,7 +58,7 @@ final class SpecificMethodCountRector extends AbstractRector
         if (! $this->methodCallAnalyzer->isTypesAndMethods(
             $node,
             ['PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase'],
-            ['assertSame', 'assertEquals', 'assertNotSame', 'assertNotEquals']
+            array_keys($this->renameMethodsMap)
         )) {
             return false;
         }

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethodCountRector/Correct/correct.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethodCountRector/Correct/correct.php.inc
@@ -4,13 +4,13 @@ final class MyTest extends \PHPUnit\Framework\TestCase
 {
     public function test()
     {
-        $this->assertCount(5, $something);
-        $this->assertNotCount(5, $something);
-        $this->assertCount(5, $something);
-        $this->assertNotCount(5, $something);
-        $this->assertCount(5, $something);
-        $this->assertNotCount(5, $something);
-        $this->assertCount(5, $something);
-        $this->assertNotCount(5, $something);
+        $this->assertCount(5, $something, 'third argument');
+        $this->assertNotCount(5, $something, 'third argument');
+        $this->assertCount(5, $something, 'third argument');
+        $this->assertNotCount(5, $something, 'third argument');
+        $this->assertCount(5, $something, 'third argument');
+        $this->assertNotCount(5, $something, 'third argument');
+        $this->assertCount(5, $something, 'third argument');
+        $this->assertNotCount(5, $something, 'third argument');
     }
 }

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethodCountRector/Correct/correct.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethodCountRector/Correct/correct.php.inc
@@ -5,5 +5,12 @@ final class MyTest extends \PHPUnit\Framework\TestCase
     public function test()
     {
         $this->assertCount(5, $something);
+        $this->assertNotCount(5, $something);
+        $this->assertCount(5, $something);
+        $this->assertNotCount(5, $something);
+        $this->assertCount(5, $something);
+        $this->assertNotCount(5, $something);
+        $this->assertCount(5, $something);
+        $this->assertNotCount(5, $something);
     }
 }

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethodCountRector/Wrong/wrong.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethodCountRector/Wrong/wrong.php.inc
@@ -4,13 +4,13 @@ final class MyTest extends \PHPUnit\Framework\TestCase
 {
     public function test()
     {
-        $this->assertSame(5, count($something));
-        $this->assertNotSame(5, count($something));
-        $this->assertEquals(5, count($something));
-        $this->assertNotEquals(5, count($something));
-        $this->assertSame(5, sizeof($something));
-        $this->assertNotSame(5, sizeof($something));
-        $this->assertEquals(5, sizeof($something));
-        $this->assertNotEquals(5, sizeof($something));
+        $this->assertSame(5, count($something), 'third argument');
+        $this->assertNotSame(5, count($something), 'third argument');
+        $this->assertEquals(5, count($something), 'third argument');
+        $this->assertNotEquals(5, count($something), 'third argument');
+        $this->assertSame(5, sizeof($something), 'third argument');
+        $this->assertNotSame(5, sizeof($something), 'third argument');
+        $this->assertEquals(5, sizeof($something), 'third argument');
+        $this->assertNotEquals(5, sizeof($something), 'third argument');
     }
 }

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethodCountRector/Wrong/wrong.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethodCountRector/Wrong/wrong.php.inc
@@ -5,5 +5,12 @@ final class MyTest extends \PHPUnit\Framework\TestCase
     public function test()
     {
         $this->assertSame(5, count($something));
+        $this->assertNotSame(5, count($something));
+        $this->assertEquals(5, count($something));
+        $this->assertNotEquals(5, count($something));
+        $this->assertSame(5, sizeof($something));
+        $this->assertNotSame(5, sizeof($something));
+        $this->assertEquals(5, sizeof($something));
+        $this->assertNotEquals(5, sizeof($something));
     }
 }


### PR DESCRIPTION
I extended `SpecificMethodCountRector` and now we can work with `assertEquals`, `assertNotEquals` and `assertNotSame`. Also, `sizeof`, an alias to `count` is also detected now.