### PR TITLE
[PHPUnit] Add in_array and array_search to SpecificMethodRector

### DIFF
--- a/src/Rector/Contrib/PHPUnit/SpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethodRector.php
@@ -27,6 +27,8 @@ final class SpecificMethodRector extends AbstractRector
     private $oldToNewMethods = [
         'is_readable' => ['assertIsReadable', 'assertNotIsReadable'],
         'array_key_exists' => ['assertArrayHasKey', 'assertArrayNotHasKey'],
+        'array_search' => ['assertContains', 'assertNotContains'],
+        'in_array' => ['assertContains', 'assertNotContains'],
         'empty' => ['assertEmpty', 'assertNotEmpty'],
         'file_exists' => ['assertFileExists', 'assertFileNotExists'],
         'is_dir' => ['assertDirectoryExists', 'assertDirectoryNotExists'],

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethodRector/Correct/correct.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethodRector/Correct/correct.php.inc
@@ -4,14 +4,16 @@ final class MyTest extends \PHPUnit\Framework\TestCase
 {
     public function test()
     {
-        $this->assertIsReadable('...', 'second argument');
-        $this->assertArrayHasKey('...', ['...'], 'second argument');
-        $this->assertEmpty('...', 'second argument');
-        $this->assertFileExists('...', 'second argument');
-        $this->assertDirectoryExists('...', 'second argument');
-        $this->assertInfinite('...', 'second argument');
-        $this->assertNull('...', 'second argument');
-        $this->assertIsWritable('...', 'second argument');
-        $this->assertNan('...', 'second argument');
+        $this->assertArrayHasKey('...', ['...'], 'argument');
+        $this->assertContains('...', ['...'], 'argument');
+        $this->assertNotIsReadable('...');
+        $this->assertEmpty('...');
+        $this->assertFileNotExists('...');
+        $this->assertDirectoryExists('...');
+        $this->assertFinite('...');
+        $this->assertNan('...');
+        $this->assertNotNull('...');
+        $this->assertIsWritable('...');
+        $this->assertNotContains('...', ['...'], 'argument');
     }
 }

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethodRector/Wrong/wrong.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethodRector/Wrong/wrong.php.inc
@@ -4,14 +4,16 @@ final class MyTest extends \PHPUnit\Framework\TestCase
 {
     public function test()
     {
-        $this->assertTrue(is_readable('...'), 'second argument');
-        $this->assertTrue(array_key_exists('...', ['...']), 'second argument');
-        $this->assertTrue(empty('...'), 'second argument');
-        $this->assertTrue(file_exists('...'), 'second argument');
-        $this->assertTrue(is_dir('...'), 'second argument');
-        $this->assertTrue(is_infinite('...'), 'second argument');
-        $this->assertTrue(is_null('...'), 'second argument');
-        $this->assertTrue(is_writable('...'), 'second argument');
-        $this->assertTrue(is_nan('...'), 'second argument');
+        $this->assertTrue(array_key_exists('...', ['...']), 'argument');
+        $this->assertTrue(in_array('...', ['...']), 'argument');
+        $this->assertFalse(is_readable('...'));
+        $this->assertTrue(empty('...'));
+        $this->assertFalse(file_exists('...'));
+        $this->assertTrue(is_dir('...'));
+        $this->assertFalse(is_infinite('...'));
+        $this->assertTrue(is_nan('...'));
+        $this->assertFalse(is_null('...'));
+        $this->assertTrue(is_writable('...'));
+        $this->assertFalse(array_search('...', ['...']), 'argument');
     }
 }


### PR DESCRIPTION
While refactoring tests, I discovery that `assertTrue(in_array('foo', $anything))` could be refactored to `assertContains('foo', $anything)`. Soo, why not have a `Rector` for that? :sweat_smile: 

@TomasVotruba May I have you opinions before stand this to also support `array_search`? :innocent: 