### PR TITLE
[NodeChanger] Create MethodNameChanger

### DIFF
--- a/src/NodeChanger/MethodNameChanger.php
+++ b/src/NodeChanger/MethodNameChanger.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace Rector\NodeChanger;
+
+use PhpParser\Node;
+use PhpParser\Node\Identifier;
+
+final class MethodNameChanger
+{
+    /**
+     * @param string[] $renameMethodMap
+     */
+    public function renameNode(Node $node, array $renameMethodMap): ?Node
+    {
+        $oldNodeMethodName = $node->name->toString();
+
+        $node->name = new Identifier($renameMethodMap[$oldNodeMethodName]);
+
+        return $node;
+    }
+}

--- a/src/NodeChanger/MethodNameChanger.php
+++ b/src/NodeChanger/MethodNameChanger.php
@@ -3,6 +3,7 @@
 namespace Rector\NodeChanger;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Identifier;
 
 final class MethodNameChanger
@@ -10,7 +11,7 @@ final class MethodNameChanger
     /**
      * @param string[] $renameMethodMap
      */
-    public function renameNode(Node $node, array $renameMethodMap): ?Node
+    public function renameNode(MethodCall $node, array $renameMethodMap): ?Node
     {
         $oldNodeMethodName = $node->name->toString();
 

--- a/src/Rector/Contrib/PHPUnit/SpecificMethodCountRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethodCountRector.php
@@ -5,9 +5,9 @@ namespace Rector\Rector\Contrib\PHPUnit;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Identifier;
 use PhpParser\Node\Scalar\LNumber;
 use Rector\NodeAnalyzer\MethodCallAnalyzer;
+use Rector\NodeChanger\MethodNameChanger;
 use Rector\Rector\AbstractRector;
 
 /**
@@ -48,9 +48,15 @@ final class SpecificMethodCountRector extends AbstractRector
      */
     private $methodCallAnalyzer;
 
-    public function __construct(MethodCallAnalyzer $methodCallAnalyzer)
+    /**
+     * @var MethodNameChanger
+     */
+    private $methodNameChanger;
+
+    public function __construct(MethodCallAnalyzer $methodCallAnalyzer, MethodNameChanger $methodNameChanger)
     {
         $this->methodCallAnalyzer = $methodCallAnalyzer;
+        $this->methodNameChanger = $methodNameChanger;
     }
 
     public function isCandidate(Node $node): bool
@@ -87,9 +93,7 @@ final class SpecificMethodCountRector extends AbstractRector
      */
     public function refactor(Node $methodCallNode): ?Node
     {
-        $oldMethodName = $methodCallNode->name->toString();
-
-        $methodCallNode->name = new Identifier($this->renameMethodsMap[$oldMethodName]);
+        $this->methodNameChanger->renameNode($methodCallNode, $this->renameMethodsMap);
 
         /** @var FuncCall $secondArgument */
         $secondArgument = $methodCallNode->args[1]->value;


### PR DESCRIPTION
This resolves #201, creating a `NodeChanger\MethodNameChanger` to delegate the function or rename a Node method name. Implemented it in `SpecificMethodCountRector` for tests, but if @TomasVotruba agreed, let's constantly use in `Rector`s.