### PR TITLE
[PHPUnit] Support assertNotSame in AssertSameBoolNullToSpecificMethodRector

### DIFF
--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertSameBoolNullToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertSameBoolNullToSpecificMethodRector.php
@@ -11,12 +11,12 @@ use Rector\Rector\AbstractRector;
 
 /**
  * Before:
- * - $this->assertSame({keyword}}, $anything);
- * - $this->assertNotSame({keyword}}, $anything);
+ * - $this->assertSame(null, $anything);
+ * - $this->assertNotSame(false, $anything);
  *
  * After:
- * - $this->assert{keyword}($anything);
- * - $this->assertNot{keyword}($anything);
+ * - $this->assertNull($anything);
+ * - $this->assertNotFalse($anything);
  */
 final class AssertSameBoolNullToSpecificMethodRector extends AbstractRector
 {

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertSameBoolNullToSpecificMethodRector/Correct/correct.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertSameBoolNullToSpecificMethodRector/Correct/correct.php.inc
@@ -4,8 +4,7 @@ final class MyTest extends \PHPUnit\Framework\TestCase
 {
     public function test()
     {
-        $this->assertNull('second argument');
-        $this->assertFalse('second argument');
-        $this->assertTrue('second argument');
+        $this->assertNull('something');
+        $this->assertNotFalse('something', 'message');
     }
 }

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertSameBoolNullToSpecificMethodRector/Wrong/wrong.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertSameBoolNullToSpecificMethodRector/Wrong/wrong.php.inc
@@ -4,8 +4,7 @@ final class MyTest extends \PHPUnit\Framework\TestCase
 {
     public function test()
     {
-        $this->assertSame(null, 'second argument');
-        $this->assertSame(false, 'second argument');
-        $this->assertSame(true, 'second argument');
+        $this->assertSame(null, 'something');
+        $this->assertNotSame(false, 'something', 'message');
     }
 }


### PR DESCRIPTION
Sometimes we need to refactor the not variation of `assertSame`: `assertNotSame`. This PR adds this :smile_cat:  