### PR TITLE
[PHPUnit] Create AssertComparisonToSpecificMethodRector

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,6 +10,7 @@ parameters:
         - '#Access to an undefined property PhpParser\\Node::\$name#' # 13 off
         - '#Parameter \#1 \$node of method Rector\\NodeAnalyzer\\ClassConstAnalyzer::isNames\(\) expects PhpParser\\Node\\Expr\\ClassConstFetch, PhpParser\\Node given#'
         - '#Parameter \#1 \$classNode of method Rector\\NodeTypeResolver\\TypesExtractor\\ConstructorPropertyTypesExtractor::extractFromClassNode\(\) expects PhpParser\\Node\\Stmt\\Class_, PhpParser\\Node\\Stmt\\ClassLike given#'
+        - '#Call to an undefined method PhpParser\\Node\\Expr\\BinaryOp::getOperatorSigil\(\)#'        
 
         # subtype
         - '#Property PhpParser\\Node\\Param::\$type \(PhpParser\\Node\\Name|PhpParser\\Node\\NullableType\|string\|null\) does not accept PhpParser\\Node\\Identifier|PhpParser\\Node\\Name\|PhpParser\\Node\\NullableType#'

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertComparisonToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertComparisonToSpecificMethodRector.php
@@ -1,0 +1,124 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Rector\Contrib\PHPUnit\SpecificMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\BinaryOp;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use Rector\NodeAnalyzer\MethodCallAnalyzer;
+use Rector\Rector\AbstractRector;
+
+/**
+ * - Before:
+ * - $this->assertTrue($foo === $bar, 'message');
+ * - $this->assertFalse($foo >= $bar, 'message');
+ *
+ * - After:
+ * - $this->assertSame($bar, $foo, 'message');
+ * - $this->assertLessThanOrEqual($bar, $foo, 'message');
+ */
+final class AssertComparisonToSpecificMethodRector extends AbstractRector
+{
+    /**
+     * @var string[][]|false[][]
+     */
+    private $defaultOldToNewMethods = [
+        '===' => ['assertSame', 'assertNotSame'],
+        '!==' => ['assertNotSame', 'assertSame'],
+        '==' => ['assertEquals', 'assertNotEquals'],
+        '!=' => ['assertNotEquals', 'assertEquals'],
+        '<>' => ['assertNotEquals', 'assertEquals'],
+        '>' => ['assertGreaterThan', 'assertLessThan'],
+        '<' => ['assertLessThan', 'assertGreaterThan'],
+        '>=' => ['assertGreaterThanOrEqual', 'assertLessThanOrEqual'],
+        '<=' => ['assertLessThanOrEqual', 'assertGreaterThanOrEqual'],
+    ];
+
+    /**
+     * @var MethodCallAnalyzer
+     */
+    private $methodCallAnalyzer;
+
+    /**
+     * @var string|null
+     */
+    private $activeOpSignal;
+
+    public function __construct(MethodCallAnalyzer $methodCallAnalyzer)
+    {
+        $this->methodCallAnalyzer = $methodCallAnalyzer;
+    }
+
+    public function isCandidate(Node $node): bool
+    {
+        if (! $this->methodCallAnalyzer->isTypesAndMethods(
+            $node,
+            ['PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase'],
+            ['assertTrue', 'assertFalse']
+        )) {
+            return false;
+        }
+
+        /** @var MethodCall $methodCallNode */
+        $methodCallNode = $node;
+
+        $firstArgumentValue = $methodCallNode->args[0]->value;
+        if (! $firstArgumentValue instanceof BinaryOp) {
+            return false;
+        }
+
+        $opCallSignal = $firstArgumentValue->getOperatorSigil();
+        if (! isset($this->defaultOldToNewMethods[$opCallSignal])) {
+            return false;
+        }
+
+        $this->activeOpSignal = $opCallSignal;
+
+        return true;
+    }
+
+    /**
+     * @param MethodCall $methodCallNode
+     */
+    public function refactor(Node $methodCallNode): ?Node
+    {
+        $this->renameMethod($methodCallNode);
+        $this->changeOrderArguments($methodCallNode);
+
+        return $methodCallNode;
+    }
+
+    public function changeOrderArguments(MethodCall $methodCallNode): void
+    {
+        $oldArguments = $methodCallNode->args;
+        /** @var BinaryOp $expression */
+        $expression = $oldArguments[0]->value;
+
+        $firstArgument = $expression->right;
+        $secondArgument = $expression->left;
+
+        unset($oldArguments[0]);
+
+        $methodCallNode->args = array_merge([
+            new Arg($firstArgument),
+            new Arg($secondArgument),
+        ], $oldArguments);
+    }
+
+    private function renameMethod(MethodCall $methodCallNode): void
+    {
+        /** @var Identifier $identifierNode */
+        $identifierNode = $methodCallNode->name;
+        $oldMethodName = $identifierNode->toString();
+
+        [$trueMethodName, $falseMethodName] = $this->defaultOldToNewMethods[$this->activeOpSignal];
+
+        if ($oldMethodName === 'assertTrue' && $trueMethodName) {
+            $methodCallNode->name = new Identifier($trueMethodName);
+        } elseif ($oldMethodName === 'assertFalse' && $falseMethodName) {
+            $methodCallNode->name = new Identifier($falseMethodName);
+        }
+    }
+}

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertComparisonToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertComparisonToSpecificMethodRector.php
@@ -3,7 +3,6 @@
 namespace Rector\Rector\Contrib\PHPUnit\SpecificMethod;
 
 use PhpParser\Node;
-use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\BinaryOp;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Identifier;
@@ -102,8 +101,8 @@ final class AssertComparisonToSpecificMethodRector extends AbstractRector
         unset($oldArguments[0]);
 
         $methodCallNode->args = array_merge([
-            new Arg($firstArgument),
-            new Arg($secondArgument),
+            $firstArgument,
+            $secondArgument,
         ], $oldArguments);
     }
 

--- a/src/config/level/phpunit/phpunit-specific-method.yml
+++ b/src/config/level/phpunit/phpunit-specific-method.yml
@@ -1,4 +1,5 @@
 rectors:
+    Rector\Rector\Contrib\PHPUnit\SpecificMethod\AssertComparisonToSpecificMethodRector: ~
     Rector\Rector\Contrib\PHPUnit\SpecificMethod\AssertTrueFalseToSpecificMethodRector: ~
     Rector\Rector\Contrib\PHPUnit\SpecificMethod\AssertSameBoolNullToSpecificMethodRector: ~
     Rector\Rector\Contrib\PHPUnit\SpecificMethod\AssertTrueFalseInternalTypeToSpecificMethodRector: ~

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertComparisonToSpecificMethodRector/AssertComparisonToSpecificMethodRectorTest.php
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertComparisonToSpecificMethodRector/AssertComparisonToSpecificMethodRectorTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Tests\Rector\Contrib\PHPUnit\SpecificMethod\AssertComparisonToSpecificMethodRector;
+
+use Rector\Rector\Contrib\PHPUnit\SpecificMethod\AssertComparisonToSpecificMethodRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AssertComparisonToSpecificMethodRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideWrongToFixedFiles()
+     */
+    public function test(string $wrong, string $fixed): void
+    {
+        $this->doTestFileMatchesExpectedContent($wrong, $fixed);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function provideWrongToFixedFiles(): array
+    {
+        return [
+            [__DIR__ . '/Wrong/wrong.php.inc', __DIR__ . '/Correct/correct.php.inc'],
+        ];
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getRectorClasses(): array
+    {
+        return [AssertComparisonToSpecificMethodRector::class];
+    }
+}

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertComparisonToSpecificMethodRector/Correct/correct.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertComparisonToSpecificMethodRector/Correct/correct.php.inc
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+final class MyTest extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $this->assertNotSame($anything, $something);
+        $this->assertGreaterThan(2, count($something));
+        $this->assertLessThanOrEqual(5, count($something), 'message');
+    }
+}

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertComparisonToSpecificMethodRector/Wrong/wrong.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertComparisonToSpecificMethodRector/Wrong/wrong.php.inc
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+final class MyTest extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $this->assertFalse($something === $anything);
+        $this->assertTrue(count($something) > 2);
+        $this->assertFalse(count($something) >= 5, 'message');
+    }
+}


### PR DESCRIPTION
As suggested in #216, I've created a new `AssertComparisonToSpecificMethodRector`, so we can refactor comparisons to better `PHPUnit` assertion methods. 

I just need to add a new error to `ignoreErrors` section in `phpstan.neon`, because the `PhpParser\Node\Expr\BinaryOp::getOperatorSigil()` method [is abstract](https://github.com/nikic/PHP-Parser/blob/master/lib/PhpParser/Node/Expr/BinaryOp.php#L39), so, it raises this error. Otherwise, everything should be ready to go :mrs_claus: 