### PR TITLE
[PHPUnit] Add get_class to AssertCompareToSpecificMethodRector

### DIFF
--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertCompareToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertCompareToSpecificMethodRector.php
@@ -33,6 +33,7 @@ final class AssertCompareToSpecificMethodRector extends AbstractRector
         'count' => ['assertCount', 'assertNotCount'],
         'sizeof' => ['assertCount', 'assertNotCount'],
         'gettype' => ['assertInternalType', 'assertNotInternalType'],
+        'get_class' => ['assertInstanceOf', 'assertNotInstanceOf'],
     ];
 
     /**


### PR DESCRIPTION
An easy refactor when checking instances. This assertion:
```php
$this->assertSame('Foo', get_class($foo));
```
Can became:
```php
$this->assertInstanceOf('Foo', $foo);
```