### PR TITLE
[PHPUnit] Support variables as argument in AssertCompareToSpecificMethodRector

### DIFF
--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertCompareToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertCompareToSpecificMethodRector.php
@@ -5,6 +5,7 @@ namespace Rector\Rector\Contrib\PHPUnit\SpecificMethod;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Scalar\String_;
@@ -66,7 +67,8 @@ final class AssertCompareToSpecificMethodRector extends AbstractRector
 
         $firstArgumentValue = $methodCallNode->args[0]->value;
         if (! $firstArgumentValue instanceof LNumber &&
-            ! $firstArgumentValue instanceof String_
+            ! $firstArgumentValue instanceof String_ &&
+            ! $firstArgumentValue instanceof Variable
         ) {
             return false;
         }

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertCompareToSpecificMethodRector/Correct/correct.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertCompareToSpecificMethodRector/Correct/correct.php.inc
@@ -5,7 +5,7 @@ final class MyTest extends \PHPUnit\Framework\TestCase
     public function test()
     {
         $this->assertCount(5, $something);
-        $this->assertNotCount(5, $something, 'third argument');
+        $this->assertNotCount($count, $something, 'third argument');
         $this->assertInternalType('string', $something);
     }
 }

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertCompareToSpecificMethodRector/Wrong/wrong.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertCompareToSpecificMethodRector/Wrong/wrong.php.inc
@@ -5,7 +5,7 @@ final class MyTest extends \PHPUnit\Framework\TestCase
     public function test()
     {
         $this->assertSame(5, count($something));
-        $this->assertNotEquals(5, sizeof($something), 'third argument');
+        $this->assertNotEquals($count, sizeof($something), 'third argument');
         $this->assertEquals('string', gettype($something));
     }
 }


### PR DESCRIPTION
Most of the time, people already store what they expected in a `$variable`, and them pass it to the `PHPUnit` assert method. This PR adds support to this.

@TomasVotruba Should we create a method `resolveFirstArgument`, or `Variable`, `LNumber` and `String` have something in common that we could check? Maybe [`Cast`](https://github.com/nikic/PHP-Parser/tree/master/lib/PhpParser/Node/Expr/Cast)?