### PR TITLE
[PHPUnit] Support keyword in uppercase at AssertSameBoolNullToSpecificMethodRector

### DIFF
--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertSameBoolNullToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertSameBoolNullToSpecificMethodRector.php
@@ -62,7 +62,7 @@ final class AssertSameBoolNullToSpecificMethodRector extends AbstractRector
             return false;
         }
 
-        $this->constantName = $firstArgumentValue->name->toString();
+        $this->constantName = strtolower($firstArgumentValue->name->toString());
 
         return isset($this->constValueToNewMethodNames[$this->constantName]);
     }

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertSameBoolNullToSpecificMethodRector/Wrong/wrong.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertSameBoolNullToSpecificMethodRector/Wrong/wrong.php.inc
@@ -4,7 +4,7 @@ final class MyTest extends \PHPUnit\Framework\TestCase
 {
     public function test()
     {
-        $this->assertSame(null, 'something');
+        $this->assertSame(NULL, 'something');
         $this->assertNotSame(false, 'something', 'message');
     }
 }


### PR DESCRIPTION
As the purpose of `Rector` is to upgrade legacy apps, some of them do not follow the `PSR-2` recommendation to [define keywords in lowercase](http://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull). This PR fix some cases that we could face it :+1: 