### PR TITLE
[CS] Add Sniff to check missing return type-hinting

### DIFF
--- a/easy-coding-standard.neon
+++ b/easy-coding-standard.neon
@@ -7,6 +7,8 @@ includes:
 checkers:
     - SlevomatCodingStandard\Sniffs\Classes\UnusedPrivateElementsSniff
 
+    - SlevomatCodingStandard\Sniffs\TypeHints\TypeHintDeclarationSniff
+
     # Metrics
     PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LineLengthSniff:
         absoluteLineLimit: 120


### PR DESCRIPTION
As suggested in #233 by @TomasVotruba, we must check if we type-hinted our functions.

Did I configure it correctly?