### PR TITLE
[MethodCallTypeResolver] Extend method resolveMethodCallName

### DIFF
--- a/packages/NodeTypeResolver/src/PerNodeTypeResolver/MethodCallTypeResolver.php
+++ b/packages/NodeTypeResolver/src/PerNodeTypeResolver/MethodCallTypeResolver.php
@@ -5,9 +5,8 @@ namespace Rector\NodeTypeResolver\PerNodeTypeResolver;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Scalar\MagicConst\Class_;
+use PhpParser\Node\Identifier;
 use Rector\BetterReflection\Reflector\MethodReflector;
 use Rector\Node\Attribute;
 use Rector\NodeTypeResolver\Contract\PerNodeTypeResolver\PerNodeTypeResolverInterface;
@@ -73,21 +72,13 @@ final class MethodCallTypeResolver implements PerNodeTypeResolverInterface
         return $this->resolveMethodReflectionReturnTypes($methodCallNode, $methodCallVariableType, $methodCallName);
     }
 
-    private function resolveMethodCallName(MethodCall $methodCallNode): string
+    private function resolveMethodCallName(MethodCall $methodCallNode): ?string
     {
-        if ($methodCallNode->name instanceof Variable) {
-            return (string) $methodCallNode->name->name;
+        if ($methodCallNode->name instanceof Identifier) {
+            return $methodCallNode->name->toString();
         }
 
-        if ($methodCallNode->name instanceof PropertyFetch) {
-            return (string) $methodCallNode->name->name;
-        }
-
-        if ($methodCallNode->name instanceof Class_) {
-            return $methodCallNode->name->getName();
-        }
-
-        return (string) $methodCallNode->name;
+        return null;
     }
 
     private function getVariableToAssignTo(MethodCall $methodCallNode): ?string

--- a/packages/NodeTypeResolver/src/PerNodeTypeResolver/MethodCallTypeResolver.php
+++ b/packages/NodeTypeResolver/src/PerNodeTypeResolver/MethodCallTypeResolver.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Scalar\MagicConst\Class_;
 use Rector\BetterReflection\Reflector\MethodReflector;
 use Rector\Node\Attribute;
 use Rector\NodeTypeResolver\Contract\PerNodeTypeResolver\PerNodeTypeResolverInterface;
@@ -72,15 +73,18 @@ final class MethodCallTypeResolver implements PerNodeTypeResolverInterface
         return $this->resolveMethodReflectionReturnTypes($methodCallNode, $methodCallVariableType, $methodCallName);
     }
 
-    private function resolveMethodCallName(MethodCall $methodCallNode): ?string
+    private function resolveMethodCallName(MethodCall $methodCallNode): string
     {
         if ($methodCallNode->name instanceof Variable) {
             return (string) $methodCallNode->name->name;
         }
 
         if ($methodCallNode->name instanceof PropertyFetch) {
-            // not implemented yet
-            return null;
+            return (string) $methodCallNode->name->name;
+        }
+
+        if ($methodCallNode->name instanceof Class_) {
+            return $methodCallNode->name->getName();
         }
 
         return (string) $methodCallNode->name;

--- a/packages/NodeTypeResolver/tests/PerNodeTypeResolver/AssignTypeResolver/AssignTypeResolverTest.php
+++ b/packages/NodeTypeResolver/tests/PerNodeTypeResolver/AssignTypeResolver/AssignTypeResolverTest.php
@@ -46,4 +46,34 @@ final class AssignTypeResolverTest extends AbstractNodeTypeResolverTest
             $this->nodeTypeResolver->resolve($variableNodes[1])
         );
     }
+
+    public function testMethodCallOnClassConstant(): void
+    {
+        $variableNodes = $this->getNodesForFileOfType(__DIR__ . '/Source/ClassConstant.php.inc', Variable::class);
+
+        $this->assertSame(
+            ['Nette\Config\Configurator', 'Nette\Object'],
+            $this->nodeTypeResolver->resolve($variableNodes[0])
+        );
+
+        $this->assertSame(
+            ['Nette\Config\Configurator', 'Nette\Object'],
+            $this->nodeTypeResolver->resolve($variableNodes[2])
+        );
+    }
+
+    public function testMethodCallOnPropertyFetch(): void
+    {
+        $variableNodes = $this->getNodesForFileOfType(__DIR__ . '/Source/PropertyFetch.php.inc', Variable::class);
+
+        $this->assertSame(
+            ['Nette\Config\Configurator', 'Nette\Object'],
+            $this->nodeTypeResolver->resolve($variableNodes[0])
+        );
+
+        $this->assertSame(
+            ['Nette\Config\Configurator', 'Nette\Object'],
+            $this->nodeTypeResolver->resolve($variableNodes[2])
+        );
+    }
 }

--- a/packages/NodeTypeResolver/tests/PerNodeTypeResolver/AssignTypeResolver/Source/ClassConstant.php.inc
+++ b/packages/NodeTypeResolver/tests/PerNodeTypeResolver/AssignTypeResolver/Source/ClassConstant.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+use Nette\Config\Configurator;
+
+$configurator = new Configurator;
+
+$container = $configurator->{__CLASS__}();

--- a/packages/NodeTypeResolver/tests/PerNodeTypeResolver/AssignTypeResolver/Source/PropertyFetch.php.inc
+++ b/packages/NodeTypeResolver/tests/PerNodeTypeResolver/AssignTypeResolver/Source/PropertyFetch.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+use Nette\Config\Configurator;
+
+$configurator = new Configurator;
+
+$files = $configurator->files;


### PR DESCRIPTION
One more bug discovered in #208:
```sh
PHP Recoverable fatal error:  Object of class PhpParser\Node\Scalar\MagicConst\Class_ could not be converted to string in /home/carusogabriel/.composer/vendor/rector/rector/packages/NodeTypeResolver/src/PerNodeTypeResolver/MethodCallTypeResolver.php on line 83
```