### PR TITLE
[PHPUnit] Create AssertFalseStrposToContainsRector

### DIFF
--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertFalseStrposToContainsRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertFalseStrposToContainsRector.php
@@ -1,0 +1,91 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Rector\Contrib\PHPUnit\SpecificMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use Rector\NodeAnalyzer\MethodCallAnalyzer;
+use Rector\Rector\AbstractRector;
+
+/**
+ * Before:
+ * - $this->assertFalse(strpos($anything, 'foo'), 'message');
+ * - $this->assertNotFalse(strpos($anything, 'foo'), 'message');
+ *
+ * After:
+ * - $this->assertNotContains('foo', $anything, 'message');
+ * - $this->assertContains('foo', $anything, 'message');
+ */
+final class AssertFalseStrposToContainsRector extends AbstractRector
+{
+    /**
+     * @var MethodCallAnalyzer
+     */
+    private $methodCallAnalyzer;
+
+    public function __construct(MethodCallAnalyzer $methodCallAnalyzer)
+    {
+        $this->methodCallAnalyzer = $methodCallAnalyzer;
+    }
+
+    public function isCandidate(Node $node): bool
+    {
+        if (! $this->methodCallAnalyzer->isTypesAndMethods(
+            $node,
+            ['PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase'],
+            ['assertFalse', 'assertNotFalse']
+        )) {
+            return false;
+        }
+
+        $firstArgumentValue = $node->args[0]->value;
+
+        if (! $firstArgumentValue instanceof FuncCall) {
+            return false;
+        }
+
+        $strposNode = $firstArgumentValue->name->toString();
+
+        return $strposNode === 'strpos';
+    }
+
+    /**
+     * @param MethodCall $methodCallNode
+     */
+    public function refactor(Node $methodCallNode): ?Node
+    {
+        $this->renameMethod($methodCallNode);
+        $this->changeOrderArguments($methodCallNode);
+
+        return $methodCallNode;
+    }
+
+    public function changeOrderArguments(MethodCall $methodCallNode): void
+    {
+        /** @var Identifier $oldArguments */
+        $oldArguments = $methodCallNode->args;
+        $strposArguments = $oldArguments[0]->value;
+
+        $firstArgument = $strposArguments->args[1];
+        $secondArgument = $strposArguments->args[0];
+
+        unset($oldArguments[0]);
+
+        $methodCallNode->args = array_merge([
+            $firstArgument, $secondArgument,
+        ], $oldArguments);
+    }
+
+    private function renameMethod(MethodCall $methodCallNode): void
+    {
+        $oldMethodName = $methodCallNode->name->toString();
+
+        if ($oldMethodName === 'assertFalse') {
+            $methodCallNode->name = new Identifier('assertNotContains');
+        } else {
+            $methodCallNode->name = new Identifier('assertContains');
+        }
+    }
+}

--- a/src/config/level/phpunit/phpunit-specific-method.yml
+++ b/src/config/level/phpunit/phpunit-specific-method.yml
@@ -2,6 +2,7 @@ rectors:
     Rector\Rector\Contrib\PHPUnit\SpecificMethod\AssertComparisonToSpecificMethodRector: ~
     Rector\Rector\Contrib\PHPUnit\SpecificMethod\AssertTrueFalseToSpecificMethodRector: ~
     Rector\Rector\Contrib\PHPUnit\SpecificMethod\AssertSameBoolNullToSpecificMethodRector: ~
+    Rector\Rector\Contrib\PHPUnit\SpecificMethod\AssertFalseStrposToContainsRector: ~
     Rector\Rector\Contrib\PHPUnit\SpecificMethod\AssertTrueFalseInternalTypeToSpecificMethodRector: ~
     Rector\Rector\Contrib\PHPUnit\SpecificMethod\AssertCompareToSpecificMethodRector: ~
     Rector\Rector\Contrib\PHPUnit\SpecificMethod\AssertTrueIssetToObjectHasAttributeRector: ~

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertFalseStrposToContainsRector/AssertFalseStrposToContainsRectorTest.php
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertFalseStrposToContainsRector/AssertFalseStrposToContainsRectorTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Tests\Rector\Contrib\PHPUnit\SpecificMethod\AssertFalseStrposToContainsRector;
+
+use Rector\Rector\Contrib\PHPUnit\SpecificMethod\AssertFalseStrposToContainsRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AssertFalseStrposToContainsRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideWrongToFixedFiles()
+     */
+    public function test(string $wrong, string $fixed): void
+    {
+        $this->doTestFileMatchesExpectedContent($wrong, $fixed);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function provideWrongToFixedFiles(): array
+    {
+        return [
+            [__DIR__ . '/Wrong/wrong.php.inc', __DIR__ . '/Correct/correct.php.inc'],
+        ];
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getRectorClasses(): array
+    {
+        return [AssertFalseStrposToContainsRector::class];
+    }
+}

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertFalseStrposToContainsRector/Correct/correct.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertFalseStrposToContainsRector/Correct/correct.php.inc
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+final class MyTest extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $this->assertContains('foo', $node);
+        $this->assertNotContains('foo', $node, 'message');
+    }
+}

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertFalseStrposToContainsRector/Wrong/wrong.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertFalseStrposToContainsRector/Wrong/wrong.php.inc
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+final class MyTest extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $this->assertNotFalse(strpos($node, 'foo'));
+        $this->assertFalse(strpos($node, 'foo'), 'message');
+    }
+}


### PR DESCRIPTION
We commonly assert for substring in `PHPUnit` with `strpos`:
```php
$this->assertTrue(strpos('foo', 'f') !== false);
```
But we can simplify this with `assertContains`, as [it handles it](https://github.com/sebastianbergmann/phpunit/blob/master/src/Framework/Constraint/StringContains.php#L82):
```php
$this->assertContains('f', 'foo');
```
As we already have `AssertComparisonToSpecificMethodRector`, that changes the first code to:
```php
$this->assertNotSame(false, strpos('foo', 'f'));
```
And `AssertSameBoolNullToSpecificMethodRector` that changes to:
```php
$this->assertNotFalse(strpos('foo', 'f'));
```
I've created `AssertFalseStrposToContainsRector` to finish this refaction :nerd_face: 