### PR TITLE
Clean comments that do not break PHPStan

### DIFF
--- a/bin/rector.php
+++ b/bin/rector.php
@@ -34,11 +34,8 @@ try {
     }
 
     // 3. Run Console Application
-    /** @var Application $application */
     $application = $container->get(Application::class);
-    /** @var InputInterface $input */
     $input = $container->get(InputInterface::class);
-    /** @var OutputInterface $output */
     $output = $container->get(OutputInterface::class);
     $statusCode = $application->run($input, $output);
     exit($statusCode);

--- a/packages/NodeTraverserQueue/src/BetterNodeFinder.php
+++ b/packages/NodeTraverserQueue/src/BetterNodeFinder.php
@@ -20,7 +20,6 @@ final class BetterNodeFinder
 
     public function findFirstAncestorInstanceOf(Node $node, string $type): ?Node
     {
-        /** @var Node|null $currentNode */
         $currentNode = $node->getAttribute(Attribute::PARENT_NODE);
 
         while ($currentNode !== null) {

--- a/packages/NodeTypeResolver/src/PerNodeCallerTypeResolver/MethodCallCallerTypeResolver.php
+++ b/packages/NodeTypeResolver/src/PerNodeCallerTypeResolver/MethodCallCallerTypeResolver.php
@@ -6,7 +6,6 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Identifier;
 use Rector\BetterReflection\Reflector\MethodReflector;
 use Rector\NodeTypeResolver\Contract\PerNodeCallerTypeResolver\PerNodeCallerTypeResolverInterface;
 use Rector\NodeTypeResolver\NodeTypeResolver;
@@ -56,7 +55,6 @@ final class MethodCallCallerTypeResolver implements PerNodeCallerTypeResolverInt
         if ($methodCallNode->var instanceof MethodCall) {
             $parentReturnTypes = $this->resolve($methodCallNode->var);
 
-            /** @var Identifier $identifierNode */
             $identifierNode = $methodCallNode->var->name;
 
             $methodName = $identifierNode->toString();

--- a/packages/NodeTypeResolver/src/PerNodeTypeResolver/AssignTypeResolver.php
+++ b/packages/NodeTypeResolver/src/PerNodeTypeResolver/AssignTypeResolver.php
@@ -51,7 +51,6 @@ final class AssignTypeResolver implements PerNodeTypeResolverInterface, NodeType
         $variableTypes = $this->resolveTypeForRightSide($assignNode);
 
         if ($variableTypes) {
-            /** @var Variable $variableNode */
             $variableNode = $assignNode->var;
             $variableName = (string) $variableNode->name;
             $this->typeContext->addVariableWithTypes($variableName, $variableTypes);

--- a/packages/NodeTypeResolver/src/PerNodeTypeResolver/MethodCallTypeResolver.php
+++ b/packages/NodeTypeResolver/src/PerNodeTypeResolver/MethodCallTypeResolver.php
@@ -49,8 +49,6 @@ final class MethodCallTypeResolver implements PerNodeTypeResolverInterface
     public function resolve(Node $methodCallNode): array
     {
         // 1. get $anotherVar type
-
-        /** @var Variable|mixed $variableNode */
         $variableNode = $methodCallNode->var;
 
         if (! $variableNode instanceof Variable) {

--- a/packages/NodeTypeResolver/src/PerNodeTypeResolver/NameTypeResolver.php
+++ b/packages/NodeTypeResolver/src/PerNodeTypeResolver/NameTypeResolver.php
@@ -100,7 +100,6 @@ final class NameTypeResolver implements PerNodeTypeResolverInterface
 
     private function resolveFullyQualifiedName(Node $nameNode, string $stringName): string
     {
-        /** @var Name|null $name */
         $name = $nameNode->getAttribute(Attribute::RESOLVED_NAME);
         if ($name instanceof Name) {
             return $name->toString();

--- a/packages/NodeTypeResolver/src/PerNodeTypeResolver/NewTypeResolver.php
+++ b/packages/NodeTypeResolver/src/PerNodeTypeResolver/NewTypeResolver.php
@@ -6,7 +6,6 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
 use Rector\Exception\NotImplementedException;
@@ -56,7 +55,6 @@ final class NewTypeResolver implements PerNodeTypeResolverInterface, NodeTypeRes
                 return [];
             }
 
-            /** @var Variable $variableNode */
             $variableNode = $newNode->class->var;
 
             if ($variableNode->name !== 'this') {
@@ -68,7 +66,6 @@ final class NewTypeResolver implements PerNodeTypeResolverInterface, NodeTypeRes
             }
 
             // can be anything (dynamic)
-            /** @var Identifier $identifierNode */
             $identifierNode = $newNode->class->name;
 
             $propertyName = $identifierNode->toString();

--- a/packages/NodeTypeResolver/src/TypeContext.php
+++ b/packages/NodeTypeResolver/src/TypeContext.php
@@ -4,7 +4,6 @@ namespace Rector\NodeTypeResolver;
 
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\FunctionLike;
-use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
@@ -80,7 +79,6 @@ final class TypeContext
         $this->classLikeNode = $classLikeNode;
 
         if ($this->classLikeAnalyzer->isNormalClass($classLikeNode)) {
-            /** @var Class_ $classLikeNode */
             $this->propertyTypes = $this->constructorPropertyTypesExtractor->extractFromClassNode($classLikeNode);
         }
     }
@@ -154,7 +152,6 @@ final class TypeContext
             return $this->methodReflector->reflectClassMethod($className, $methodName);
         }
 
-        /** @var Function_ $functionLikeNode */
         $functionName = (string) $functionLikeNode->name;
         if (! function_exists($functionName)) {
             return null;

--- a/packages/NodeTypeResolver/src/TypesExtractor/ConstructorPropertyTypesExtractor.php
+++ b/packages/NodeTypeResolver/src/TypesExtractor/ConstructorPropertyTypesExtractor.php
@@ -47,7 +47,6 @@ final class ConstructorPropertyTypesExtractor
                 continue;
             }
 
-            /** @var ClassMethod $inClassNode */
             return $this->extractPropertiesFromConstructorMethodNode($inClassNode, $constructorParametersWithTypes);
         }
 
@@ -129,14 +128,10 @@ final class ConstructorPropertyTypesExtractor
                 continue;
             }
 
-            /** @var Expression $inConstructorNode */
-            /** @var Assign $assignNode */
             $assignNode = $inConstructorNode->expr;
 
-            /** @var PropertyFetch $propertyFetchNode */
             $propertyFetchNode = $assignNode->var;
 
-            /** @var Identifier $identifierNode */
             $identifierNode = $propertyFetchNode->name;
 
             $propertyName = $identifierNode->toString();

--- a/packages/NodeTypeResolver/tests/PerNodeCallerTypeResolver/MethodCallCallerTypeResolver/NestedMethodCallTest.php
+++ b/packages/NodeTypeResolver/tests/PerNodeCallerTypeResolver/MethodCallCallerTypeResolver/NestedMethodCallTest.php
@@ -3,7 +3,6 @@
 namespace Rector\NodeTypeResolver\Tests\PerNodeCallerTypeResolver\MethodCallCallerTypeResolver;
 
 use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Identifier;
 use Rector\NodeTypeResolver\Tests\PerNodeCallerTypeResolver\AbstractNodeCallerTypeResolverTest;
 
 final class NestedMethodCallTest extends AbstractNodeCallerTypeResolverTest
@@ -41,7 +40,6 @@ final class NestedMethodCallTest extends AbstractNodeCallerTypeResolverTest
     {
         $node = $this->formChainMethodCallNodes[$nodeId];
 
-        /** @var Identifier $identifierNode */
         $identifierNode = $node->name;
         $this->assertSame($methodName, $identifierNode->toString());
 
@@ -78,7 +76,6 @@ final class NestedMethodCallTest extends AbstractNodeCallerTypeResolverTest
 
     public function testOnNestedDifferentMethodCall(): void
     {
-        /** @var MethodCall[] $methodCallNodes */
         $methodCallNodes = $this->getNodesForFileOfType(
             __DIR__ . '/NestedMethodCallSource/OnMethodCallCallDifferentType.php.inc',
             MethodCall::class
@@ -86,7 +83,6 @@ final class NestedMethodCallTest extends AbstractNodeCallerTypeResolverTest
 
         $this->assertCount(2, $methodCallNodes);
 
-        /** @var Identifier $identifierNode */
         $identifierNode = $methodCallNodes[0]->name;
         $this->assertSame('setScope', $identifierNode->toString());
 
@@ -95,7 +91,6 @@ final class NestedMethodCallTest extends AbstractNodeCallerTypeResolverTest
             $this->nodeCallerTypeResolver->resolve($methodCallNodes[0])
         );
 
-        /** @var Identifier $identifierNode */
         $identifierNode = $methodCallNodes[1]->name;
         $this->assertSame('register', $identifierNode->toString());
 
@@ -117,7 +112,6 @@ final class NestedMethodCallTest extends AbstractNodeCallerTypeResolverTest
     {
         $node = $this->nestedMethodCallNodes[$nodeId];
 
-        /** @var Identifier $identifierNode */
         $identifierNode = $node->name;
         $this->assertSame($methodName, $identifierNode->toString());
 

--- a/packages/ReflectionDocBlock/src/NodeAnalyzer/NamespaceAnalyzer.php
+++ b/packages/ReflectionDocBlock/src/NodeAnalyzer/NamespaceAnalyzer.php
@@ -4,7 +4,6 @@ namespace Rector\ReflectionDocBlock\NodeAnalyzer;
 
 use Nette\Utils\Strings;
 use PhpParser\Node;
-use PhpParser\Node\Stmt\Use_;
 use Rector\Node\Attribute;
 
 /**
@@ -14,7 +13,6 @@ final class NamespaceAnalyzer
 {
     public function isUseStatementAlreadyPresent(Node $node, string $useName): bool
     {
-        /** @var Use_[] $useNodes */
         $useNodes = $node->getAttribute(Attribute::USE_NODES);
         if (! count($useNodes)) {
             return false;
@@ -35,7 +33,6 @@ final class NamespaceAnalyzer
      */
     public function resolveTypeToFullyQualified(array $types, Node $node): string
     {
-        /** @var Use_[] $useNodes */
         $useNodes = (array) $node->getAttribute(Attribute::USE_NODES);
         foreach ($useNodes as $useNode) {
             $useUseNode = $useNode->uses[0];

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -18,7 +18,6 @@ parameters:
         # known values
         - '#Method Rector\\Node\\NodeFactory::create(Null|False|True)Constant\(\) should return PhpParser\\Node\\Expr\\ConstFetch but returns PhpParser\\Node\\Expr#'
         - '#Method Rector\\Node\\NodeFactory::createNamespace\(\) should return PhpParser\\Node\\Stmt\\Namespace_ but returns PhpParser\\Node#'
-        - '#Calling method toString\(\) on possibly null value of type PhpParser\\Node\\Name\\FullyQualified\|null#'
         - '#Calling method toString\(\) on possibly null value of type PhpParser\\Node\\Name\|null#'
         - '#Calling method getText\(\) on possibly null value of type PhpParser\\Comment\\Doc\|null#'
         - '#Calling method getParentClassNames\(\) on possibly null value of type Rector\\BetterReflection\\Reflection\\ReflectionClass\|null#'
@@ -47,7 +46,6 @@ parameters:
         - '#Access to an undefined property PhpParser\\Node\\Arg|PhpParser\\Node\\Expr\|PhpParser\\Node\\Param::\$value#'
         - '#Call to an undefined method PhpParser\\BuilderFactory::args\(\)#'
         - "#Casting to string something that's already string#"
-        - '#Call to an undefined method PhpParser\\Node\\Stmt\\UseUse::getAlias\(\)#'
         - '#Call to an undefined method PhpParser\\PrettyPrinter\\Standard::printFormatPreserving\(\)#'
         - '#Array \(array<Rector\\BetterReflection\\Reflection\\ReflectionClass>\) does not accept Rector\\BetterReflection\\Reflection\\Reflection#'
 

--- a/src/Builder/ConstructorMethodBuilder.php
+++ b/src/Builder/ConstructorMethodBuilder.php
@@ -2,11 +2,9 @@
 
 namespace Rector\Builder;
 
-use PhpParser\Builder\Method;
 use PhpParser\Builder\Param;
 use PhpParser\BuilderFactory;
 use PhpParser\Node\Stmt\Class_;
-use PhpParser\Node\Stmt\ClassMethod;
 use Rector\Builder\Class_\Property;
 use Rector\Node\NodeFactory;
 
@@ -40,7 +38,6 @@ final class ConstructorMethodBuilder
 
         $propertyAssignNode = $this->nodeFactory->createPropertyAssignment($property->getName());
 
-        /** @var ClassMethod $constructorMethod */
         if ($constructorMethod) {
             // has parameter already?
             foreach ($constructorMethod->params as $constructorParameter) {
@@ -57,7 +54,6 @@ final class ConstructorMethodBuilder
             return;
         }
 
-        /** @var Method $constructorMethod */
         $constructorMethod = $this->builderFactory->method('__construct')
             ->makePublic()
             ->addParam($this->createParameter($property->getTypes(), $property->getName()))

--- a/src/NodeAnalyzer/ClassConstAnalyzer.php
+++ b/src/NodeAnalyzer/ClassConstAnalyzer.php
@@ -4,6 +4,7 @@ namespace Rector\NodeAnalyzer;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Name\FullyQualified;
 use Rector\Node\Attribute;
 
@@ -18,7 +19,6 @@ final class ClassConstAnalyzer
             return false;
         }
 
-        /** @var ClassConstFetch $node */
         return $this->isNames($node, $constantNames);
     }
 
@@ -52,7 +52,7 @@ final class ClassConstAnalyzer
      */
     private function isNames(ClassConstFetch $node, array $names): bool
     {
-        /** @var Node\Identifier $identifierNode */
+        /** @var Identifier $identifierNode */
         $identifierNode = $node->name;
 
         $nodeConstantName = $identifierNode->toString();

--- a/src/NodeAnalyzer/ClassLikeAnalyzer.php
+++ b/src/NodeAnalyzer/ClassLikeAnalyzer.php
@@ -110,7 +110,6 @@ final class ClassLikeAnalyzer
 
         $interfaces = $classNode->implements;
         foreach ($interfaces as $interface) {
-            /** @var FullyQualified $interface */
             $types[] = $interface->toString();
         }
 

--- a/src/NodeAnalyzer/ClassMethodAnalyzer.php
+++ b/src/NodeAnalyzer/ClassMethodAnalyzer.php
@@ -32,7 +32,6 @@ final class ClassMethodAnalyzer
             return false;
         }
 
-        /** @var MethodCall $node */
         return in_array($node->name->toString(), $methods, true);
     }
 

--- a/src/NodeAnalyzer/Contrib/Symfony/ContainerCallAnalyzer.php
+++ b/src/NodeAnalyzer/Contrib/Symfony/ContainerCallAnalyzer.php
@@ -41,7 +41,6 @@ final class ContainerCallAnalyzer
             return false;
         }
 
-        /** @var MethodCall $methodCallNode */
         $methodCallNode = $methodCall->var;
 
         if (! $methodCallNode->var instanceof Variable) {

--- a/src/NodeAnalyzer/MethodArgumentAnalyzer.php
+++ b/src/NodeAnalyzer/MethodArgumentAnalyzer.php
@@ -41,7 +41,6 @@ final class MethodArgumentAnalyzer
             return false;
         }
 
-        /** @var MethodCall $node */
         if (! $node->args[0]->value instanceof String_) {
             return false;
         }

--- a/src/NodeAnalyzer/MethodCallAnalyzer.php
+++ b/src/NodeAnalyzer/MethodCallAnalyzer.php
@@ -72,7 +72,6 @@ final class MethodCallAnalyzer
             return false;
         }
 
-        /** @var MethodCall $node */
         return in_array($node->name->toString(), $methods, true);
     }
 
@@ -85,7 +84,6 @@ final class MethodCallAnalyzer
             return false;
         }
 
-        /** @var MethodCall $node */
         return $node->name->toString() === $method;
     }
 
@@ -156,7 +154,6 @@ final class MethodCallAnalyzer
             return false;
         }
 
-        /** @var MethodCall $node */
         $nodeMethodName = $node->name->name;
 
         $publicMethodNames = $this->getPublicMethodNamesForType($type);

--- a/src/NodeAnalyzer/PropertyFetchAnalyzer.php
+++ b/src/NodeAnalyzer/PropertyFetchAnalyzer.php
@@ -31,7 +31,6 @@ final class PropertyFetchAnalyzer
             return false;
         }
 
-        /** @var PropertyFetch $node */
         $nodePropertyName = $node->name->toString();
 
         return $nodePropertyName === $property;
@@ -55,7 +54,6 @@ final class PropertyFetchAnalyzer
             return false;
         }
 
-        /** @var Node\Identifier $identifierNode */
         $identifierNode = $node->name;
 
         $nodePropertyName = $identifierNode->toString();
@@ -74,7 +72,6 @@ final class PropertyFetchAnalyzer
             return false;
         }
 
-        /** @var Node\Identifier $identifierNode */
         $identifierNode = $node->name;
 
         $nodePropertyName = $identifierNode->toString();
@@ -93,7 +90,6 @@ final class PropertyFetchAnalyzer
             return false;
         }
 
-        /** @var Node\Identifier $identifierNode */
         $identifierNode = $node->name;
 
         return in_array($identifierNode->toString(), $properties, true);
@@ -125,7 +121,6 @@ final class PropertyFetchAnalyzer
             return false;
         }
 
-        /** @var PropertyFetch $node */
         return in_array($node->name->toString(), $propertyNames, true);
     }
 

--- a/src/NodeAnalyzer/StaticMethodCallAnalyzer.php
+++ b/src/NodeAnalyzer/StaticMethodCallAnalyzer.php
@@ -38,7 +38,6 @@ final class StaticMethodCallAnalyzer
             return false;
         }
 
-        /** @var StaticCall $node */
         return (string) $node->name === $method;
     }
 
@@ -53,7 +52,6 @@ final class StaticMethodCallAnalyzer
             return false;
         }
 
-        /** @var StaticCall $node */
         $currentMethodName = (string) $node->name;
 
         foreach ($methodNames as $methodName) {

--- a/src/Rector/Contrib/Nette/Application/InjectPropertyRector.php
+++ b/src/Rector/Contrib/Nette/Application/InjectPropertyRector.php
@@ -5,7 +5,6 @@ namespace Rector\Rector\Contrib\Nette\Application;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Property;
-use PhpParser\Node\Stmt\PropertyProperty;
 use PhpParser\Node\VarLikeIdentifier;
 use Rector\Builder\Class_\ClassPropertyCollector;
 use Rector\Node\Attribute;
@@ -71,7 +70,6 @@ final class InjectPropertyRector extends AbstractRector
     {
         $propertyTypes = $this->nodeTypeResolver->resolve($propertyNode);
 
-        /** @var PropertyProperty $propertyPropertyNode */
         $propertyPropertyNode = $propertyNode->props[0];
 
         /** @var VarLikeIdentifier $varLikeIdentifierNode */

--- a/src/Rector/Contrib/Nette/Application/TemplateMagicInvokeFilterCallRector.php
+++ b/src/Rector/Contrib/Nette/Application/TemplateMagicInvokeFilterCallRector.php
@@ -4,7 +4,6 @@ namespace Rector\Rector\Contrib\Nette\Application;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Identifier;
 use Rector\Node\MethodCallNodeFactory;
 use Rector\Node\NodeFactory;
 use Rector\NodeAnalyzer\MethodCallAnalyzer;
@@ -74,7 +73,6 @@ final class TemplateMagicInvokeFilterCallRector extends AbstractRector
 
     private function changeToInvokeFilterMethodCall(MethodCall $methodCallNode): void
     {
-        /** @var Identifier $identifierNode */
         $identifierNode = $methodCallNode->name;
 
         $filterName = $identifierNode->toString();

--- a/src/Rector/Contrib/Nette/Bootstrap/RemoveConfiguratorConstantsRector.php
+++ b/src/Rector/Contrib/Nette/Bootstrap/RemoveConfiguratorConstantsRector.php
@@ -5,7 +5,6 @@ namespace Rector\Rector\Contrib\Nette\Bootstrap;
 use PhpParser\Node;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\String_;
 use Rector\Node\Attribute;
 use Rector\Rector\AbstractRector;
@@ -41,7 +40,6 @@ final class RemoveConfiguratorConstantsRector extends AbstractRector
 
     private function getClassNameFromClassConstFetch(ClassConstFetch $classConstFetchNode): string
     {
-        /** @var FullyQualified|null $fqnName */
         $fqnName = $classConstFetchNode->class->getAttribute(Attribute::RESOLVED_NAME);
 
         if ($fqnName === null && $classConstFetchNode->class instanceof Variable) {

--- a/src/Rector/Contrib/Nette/DI/CompilerCompileArgumentsRector.php
+++ b/src/Rector/Contrib/Nette/DI/CompilerCompileArgumentsRector.php
@@ -44,7 +44,6 @@ final class CompilerCompileArgumentsRector extends AbstractRector
             return false;
         }
 
-        /** @var MethodCall $node */
         return count($node->args) >= 1;
     }
 

--- a/src/Rector/Contrib/Nette/DI/CompilerGenerateCodeArgumentsRector.php
+++ b/src/Rector/Contrib/Nette/DI/CompilerGenerateCodeArgumentsRector.php
@@ -41,7 +41,6 @@ final class CompilerGenerateCodeArgumentsRector extends AbstractRector
             return false;
         }
 
-        /** @var MethodCall $node */
         return count($node->args) >= 1;
     }
 

--- a/src/Rector/Contrib/Nette/DI/ExpandFunctionToParametersArrayRector.php
+++ b/src/Rector/Contrib/Nette/DI/ExpandFunctionToParametersArrayRector.php
@@ -5,6 +5,7 @@ namespace Rector\Rector\Contrib\Nette\DI;
 use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Scalar\String_;
 use Rector\Node\Attribute;
 use Rector\Node\NodeFactory;
 use Rector\NodeAnalyzer\MethodArgumentAnalyzer;
@@ -73,7 +74,7 @@ final class ExpandFunctionToParametersArrayRector extends AbstractRector
      */
     public function refactor(Node $methodCallNode): ?Node
     {
-        /** @var Node\Scalar\String_ $argument */
+        /** @var String_ $argument */
         $argument = $methodCallNode->args[0]->value;
         $argument->value = Strings::trim($argument->value, '%');
 

--- a/src/Rector/Contrib/Nette/Forms/FormSetRequiredRector.php
+++ b/src/Rector/Contrib/Nette/Forms/FormSetRequiredRector.php
@@ -60,7 +60,6 @@ final class FormSetRequiredRector extends AbstractRector
             return false;
         }
 
-        /** @var MethodCall $node */
         if (count($node->args) !== 1) {
             return false;
         }

--- a/src/Rector/Contrib/Nette/Utils/MagicMethodRector.php
+++ b/src/Rector/Contrib/Nette/Utils/MagicMethodRector.php
@@ -2,7 +2,6 @@
 
 namespace Rector\Rector\Contrib\Nette\Utils;
 
-use PhpParser\Comment\Doc;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use Rector\BetterReflection\Reflector\SmartClassReflector;
@@ -75,13 +74,11 @@ final class MagicMethodRector extends AbstractRector
             return false;
         }
 
-        /** @var Doc[]|null $docComments */
         $docComments = $node->getAttribute('comments');
         if ($docComments === null) {
             return false;
         }
 
-        /** @var string $className */
         $className = $node->getAttribute(Attribute::CLASS_NAME);
 
         $classReflection = $this->smartClassReflector->reflect($className);

--- a/src/Rector/Contrib/Nette/Utils/NetteObjectToSmartTraitRector.php
+++ b/src/Rector/Contrib/Nette/Utils/NetteObjectToSmartTraitRector.php
@@ -3,7 +3,6 @@
 namespace Rector\Rector\Contrib\Nette\Utils;
 
 use PhpParser\Node;
-use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Class_;
 use Rector\Builder\StatementGlue;
 use Rector\Node\Attribute;
@@ -47,7 +46,6 @@ final class NetteObjectToSmartTraitRector extends AbstractRector
             return false;
         }
 
-        /** @var FullyQualified $fullyQualifiedName */
         $fullyQualifiedName = $node->extends->getAttribute(Attribute::RESOLVED_NAME);
 
         return $fullyQualifiedName->toString() === self::PARENT_CLASS;

--- a/src/Rector/Contrib/PHPUnit/DelegateExceptionArgumentsRector.php
+++ b/src/Rector/Contrib/PHPUnit/DelegateExceptionArgumentsRector.php
@@ -5,6 +5,7 @@ namespace Rector\Rector\Contrib\PHPUnit;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
 use Rector\Node\MethodCallNodeFactory;
 use Rector\NodeAnalyzer\MethodCallAnalyzer;
 use Rector\Rector\AbstractRector;
@@ -54,7 +55,6 @@ final class DelegateExceptionArgumentsRector extends AbstractRector
             return false;
         }
 
-        /** @var MethodCall $node */
         return isset($node->args[1]);
     }
 
@@ -63,7 +63,7 @@ final class DelegateExceptionArgumentsRector extends AbstractRector
      */
     public function refactor(Node $methodCallNode): ?Node
     {
-        /** @var Node\Identifier $identifierNode */
+        /** @var Identifier $identifierNode */
         $identifierNode = $methodCallNode->name;
         $oldMethodName = $identifierNode->name;
 

--- a/src/Rector/Contrib/PHPUnit/GetMockRector.php
+++ b/src/Rector/Contrib/PHPUnit/GetMockRector.php
@@ -49,7 +49,6 @@ final class GetMockRector extends AbstractRector
             return false;
         }
 
-        /** @var MethodCall $node */
         return count($node->args) === 1;
     }
 

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertCompareToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertCompareToSpecificMethodRector.php
@@ -6,7 +6,6 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Identifier;
 use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Scalar\String_;
 use Rector\NodeAnalyzer\MethodCallAnalyzer;
@@ -69,7 +68,6 @@ final class AssertCompareToSpecificMethodRector extends AbstractRector
             return false;
         }
 
-        /** @var MethodCall $methodCallNode */
         $methodCallNode = $node;
 
         $firstArgumentValue = $methodCallNode->args[0]->value;
@@ -109,7 +107,6 @@ final class AssertCompareToSpecificMethodRector extends AbstractRector
 
     private function renameMethod(MethodCall $methodCallNode): void
     {
-        /** @var Identifier $identifierNode */
         $identifierNode = $methodCallNode->name;
         $oldMethodName = $identifierNode->toString();
 

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertComparisonToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertComparisonToSpecificMethodRector.php
@@ -5,7 +5,6 @@ namespace Rector\Rector\Contrib\PHPUnit\SpecificMethod;
 use PhpParser\Node;
 use PhpParser\Node\Expr\BinaryOp;
 use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Identifier;
 use Rector\NodeAnalyzer\MethodCallAnalyzer;
 use Rector\NodeChanger\IdentifierRenamer;
 use Rector\Rector\AbstractRector;
@@ -67,7 +66,6 @@ final class AssertComparisonToSpecificMethodRector extends AbstractRector
             return false;
         }
 
-        /** @var MethodCall $methodCallNode */
         $methodCallNode = $node;
 
         $firstArgumentValue = $methodCallNode->args[0]->value;
@@ -115,7 +113,6 @@ final class AssertComparisonToSpecificMethodRector extends AbstractRector
 
     private function renameMethod(MethodCall $methodCallNode): void
     {
-        /** @var Identifier $identifierNode */
         $identifierNode = $methodCallNode->name;
         $oldMethodName = $identifierNode->toString();
 

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertSameBoolNullToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertSameBoolNullToSpecificMethodRector.php
@@ -5,7 +5,6 @@ namespace Rector\Rector\Contrib\PHPUnit\SpecificMethod;
 use PhpParser\Node;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Identifier;
 use Rector\NodeAnalyzer\MethodCallAnalyzer;
 use Rector\NodeChanger\IdentifierRenamer;
 use Rector\Rector\AbstractRector;
@@ -61,7 +60,6 @@ final class AssertSameBoolNullToSpecificMethodRector extends AbstractRector
             return false;
         }
 
-        /** @var MethodCall $methodCallNode */
         $methodCallNode = $node;
 
         $firstArgumentValue = $methodCallNode->args[0]->value;
@@ -87,7 +85,6 @@ final class AssertSameBoolNullToSpecificMethodRector extends AbstractRector
 
     private function renameMethod(MethodCall $methodCallNode): void
     {
-        /** @var Identifier $identifierNode */
         $identifierNode = $methodCallNode->name;
         $oldMethodName = $identifierNode->toString();
 

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertTrueFalseInternalTypeToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertTrueFalseInternalTypeToSpecificMethodRector.php
@@ -75,7 +75,6 @@ final class AssertTrueFalseInternalTypeToSpecificMethodRector extends AbstractRe
             return false;
         }
 
-        /** @var MethodCall $methodCallNode */
         $methodCallNode = $node;
 
         $firstArgumentValue = $methodCallNode->args[0]->value;

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertTrueFalseToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertTrueFalseToSpecificMethodRector.php
@@ -7,8 +7,6 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\Empty_;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Identifier;
-use PhpParser\Node\Name;
 use Rector\NodeAnalyzer\MethodCallAnalyzer;
 use Rector\NodeChanger\IdentifierRenamer;
 use Rector\Rector\AbstractRector;
@@ -82,7 +80,6 @@ final class AssertTrueFalseToSpecificMethodRector extends AbstractRector
             return false;
         }
 
-        /** @var MethodCall $node */
         if (! isset($node->args[0])) {
             return false;
         }
@@ -116,7 +113,6 @@ final class AssertTrueFalseToSpecificMethodRector extends AbstractRector
 
     private function renameMethod(MethodCall $methodCallNode): void
     {
-        /** @var Identifier $identifierNode */
         $identifierNode = $methodCallNode->name;
         $oldMethodName = $identifierNode->toString();
 
@@ -155,7 +151,6 @@ final class AssertTrueFalseToSpecificMethodRector extends AbstractRector
     private function resolveFunctionName(Node $node): ?string
     {
         if ($node instanceof FuncCall) {
-            /** @var Name $nameNode */
             $nameNode = $node->name;
 
             return $nameNode->toString();

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertTrueIssetToObjectHasAttributeRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertTrueIssetToObjectHasAttributeRector.php
@@ -57,7 +57,6 @@ final class AssertTrueIssetToObjectHasAttributeRector extends AbstractRector
             return false;
         }
 
-        /** @var MethodCall $methodCallNode */
         $methodCallNode = $node;
 
         $firstArgumentValue = $methodCallNode->args[0]->value;
@@ -67,7 +66,6 @@ final class AssertTrueIssetToObjectHasAttributeRector extends AbstractRector
             return false;
         }
 
-        /** @var Isset_ $issetNode */
         $issetNode = $firstArgumentValue;
 
         return $issetNode->vars[0] instanceof PropertyFetch;
@@ -81,7 +79,6 @@ final class AssertTrueIssetToObjectHasAttributeRector extends AbstractRector
         // rename method
         $this->identifierRenamer->renameNodeWithMap($methodCallNode, $this->renameMethodsMap);
 
-        // move isset to property and object
         /** @var Isset_ $issetNode */
         $issetNode = $methodCallNode->args[0]->value;
 

--- a/src/Rector/Contrib/PhpParser/IdentifierRector.php
+++ b/src/Rector/Contrib/PhpParser/IdentifierRector.php
@@ -5,7 +5,6 @@ namespace Rector\Rector\Contrib\PhpParser;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
-use PhpParser\Node\Expr\Variable;
 use Rector\Node\Attribute;
 use Rector\Node\MethodCallNodeFactory;
 use Rector\NodeAnalyzer\PropertyFetchAnalyzer;
@@ -74,10 +73,8 @@ final class IdentifierRector extends AbstractRector
             return false;
         }
 
-        /** @var PropertyFetch $node */
         $variableNode = $node->var;
 
-        /** @var Variable $variableNode */
         $nodeTypes = $this->nodeTypeResolver->resolve($variableNode);
 
         $properties = $this->matchTypeToProperties($nodeTypes);

--- a/src/Rector/Contrib/Symfony/DependencyInjection/CompilerAddPassPriorityRector.php
+++ b/src/Rector/Contrib/Symfony/DependencyInjection/CompilerAddPassPriorityRector.php
@@ -47,7 +47,6 @@ final class CompilerAddPassPriorityRector extends AbstractRector
             return false;
         }
 
-        /** @var MethodCall $node */
         $args = $node->args;
 
         // has 3 arguments, all is done

--- a/src/Rector/Contrib/Symfony/DependencyInjection/ContainerBuilderCompileEnvArgumentRector.php
+++ b/src/Rector/Contrib/Symfony/DependencyInjection/ContainerBuilderCompileEnvArgumentRector.php
@@ -37,7 +37,6 @@ final class ContainerBuilderCompileEnvArgumentRector extends AbstractRector
             return false;
         }
 
-        /** @var Node\Expr\MethodCall $node */
         $arguments = $node->args;
 
         // already has an argument

--- a/src/Rector/Contrib/Symfony/Form/OptionNameRector.php
+++ b/src/Rector/Contrib/Symfony/Form/OptionNameRector.php
@@ -4,7 +4,6 @@ namespace Rector\Rector\Contrib\Symfony\Form;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\ArrayItem;
-use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Scalar\String_;
 use Rector\Node\Attribute;
 use Rector\Rector\AbstractRector;
@@ -44,7 +43,6 @@ final class OptionNameRector extends AbstractRector
         $arrayParentNode = $arrayItemParentNode->getAttribute(Attribute::PARENT_NODE);
         $argParentNode = $arrayParentNode->getAttribute(Attribute::PARENT_NODE);
 
-        /** @var MethodCall $argParentNode */
         $methodCallNode = $argParentNode->getAttribute(Attribute::PARENT_NODE);
 
         return $methodCallNode->name->toString() === 'add';

--- a/src/Rector/Contrib/Symfony/HttpKernel/GetterToPropertyRector.php
+++ b/src/Rector/Contrib/Symfony/HttpKernel/GetterToPropertyRector.php
@@ -4,6 +4,7 @@ namespace Rector\Rector\Contrib\Symfony\HttpKernel;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Scalar\String_;
 use Rector\Builder\Class_\ClassPropertyCollector;
 use Rector\Contract\Bridge\ServiceTypeForNameProviderInterface;
 use Rector\Naming\PropertyNaming;
@@ -74,7 +75,7 @@ final class GetterToPropertyRector extends AbstractRector
      */
     public function refactor(Node $methodCallNode): ?Node
     {
-        /** @var Node\Scalar\String_ $stringArgument */
+        /** @var String_ $stringArgument */
         $stringArgument = $methodCallNode->args[0]->value;
 
         $serviceName = $stringArgument->value;

--- a/src/Rector/Contrib/Symfony/VarDumper/VarDumperTestTraitMethodArgsRector.php
+++ b/src/Rector/Contrib/Symfony/VarDumper/VarDumperTestTraitMethodArgsRector.php
@@ -53,7 +53,6 @@ final class VarDumperTestTraitMethodArgsRector extends AbstractRector
             return false;
         }
 
-        /** @var StaticCall $node */
         if (count($node->args) <= 2 || $node->args[2]->value instanceof ConstFetch) {
             return false;
         }

--- a/src/Rector/Dynamic/ArgumentReplacerRector.php
+++ b/src/Rector/Dynamic/ArgumentReplacerRector.php
@@ -7,7 +7,6 @@ use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
-use PhpParser\Node\Identifier;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\NodeAnalyzer\ClassMethodAnalyzer;
@@ -93,7 +92,6 @@ final class ArgumentReplacerRector extends AbstractRector
                 // replace old value with new one
                 $argumentOrParameter = $argumentsOrParameters[$position];
 
-                /** @var Arg $argumentOrParameter */
                 $resolvedValue = $this->nodeValueResolver->resolve($argumentOrParameter->value);
 
                 if ($resolvedValue === $key) {
@@ -119,7 +117,6 @@ final class ArgumentReplacerRector extends AbstractRector
         foreach ($this->argumentChangesMethodAndClass as $type => $argumentChangesByMethod) {
             $methods = array_keys($argumentChangesByMethod);
             if ($this->isTypeAndMethods($node, $type, $methods)) {
-                /** @var Identifier $identifierNode */
                 $identifierNode = $node->name;
 
                 return $argumentChangesByMethod[$identifierNode->toString()];

--- a/src/Rector/Dynamic/MethodNameReplacerRector.php
+++ b/src/Rector/Dynamic/MethodNameReplacerRector.php
@@ -114,7 +114,6 @@ final class MethodNameReplacerRector extends AbstractRector
 
         $oldToNewMethods = $this->matchOldToNewMethods();
 
-        /** @var Identifier $identifierNode */
         $identifierNode = $node->name;
 
         $methodName = $identifierNode->toString();
@@ -172,10 +171,8 @@ final class MethodNameReplacerRector extends AbstractRector
             return false;
         }
 
-        /** @var Identifier $node */
         $parentClassName = $node->getAttribute(Attribute::PARENT_CLASS_NAME);
 
-        /** @var Identifier $node */
         if (! isset($this->perClassOldToNewMethods[$parentClassName][$node->toString()])) {
             return false;
         }

--- a/src/Rector/Dynamic/NamespaceReplacerRector.php
+++ b/src/Rector/Dynamic/NamespaceReplacerRector.php
@@ -96,7 +96,6 @@ final class NamespaceReplacerRector extends AbstractRector
         }
 
         if ($node instanceof Name) {
-            /** @var FullyQualified|null $resolveName */
             $resolveName = $node->getAttribute(Attribute::RESOLVED_NAME);
             if ($resolveName) {
                 return $resolveName->toString();
@@ -186,7 +185,6 @@ final class NamespaceReplacerRector extends AbstractRector
 
     private function resolvePartialNewName(Name $nameNode): string
     {
-        /** @var FullyQualified $resolvedName */
         $resolvedName = $nameNode->getAttribute(Attribute::RESOLVED_NAME);
         $completeNewName = $this->resolveNewNameFromNode($resolvedName);
 

--- a/src/Rector/Dynamic/ParentTypehintedArgumentRector.php
+++ b/src/Rector/Dynamic/ParentTypehintedArgumentRector.php
@@ -4,12 +4,9 @@ namespace Rector\Rector\Dynamic;
 
 use PhpParser\BuilderHelpers;
 use PhpParser\Node;
-use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Param;
-use PhpParser\Node\Stmt\Class_;
-use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\BetterReflection\Reflection\TypeAnalyzer;
 use Rector\Node\Attribute;
@@ -70,7 +67,6 @@ final class ParentTypehintedArgumentRector extends AbstractRector
             return false;
         }
 
-        /** @var ClassLike $classNode */
         $classNode = $node->getAttribute(Attribute::CLASS_NODE);
         $classNodeTypes = $this->nodeTypeResolver->resolve($classNode);
         if (! $classNodeTypes) {
@@ -85,7 +81,6 @@ final class ParentTypehintedArgumentRector extends AbstractRector
      */
     public function refactor(Node $classMethodNode): ?Node
     {
-        /** @var Class_ $classMethodNode */
         $classNode = $classMethodNode->getAttribute(Attribute::CLASS_NODE);
         $classNodeTypes = $this->nodeTypeResolver->resolve($classNode);
 
@@ -141,9 +136,7 @@ final class ParentTypehintedArgumentRector extends AbstractRector
         ClassMethod $classMethodNode,
         array $parametersToTypehints
     ): ClassMethod {
-        /** @var Param $param */
         foreach ($classMethodNode->params as $param) {
-            /** @var Variable $variableNode */
             $variableNode = $param->var;
 
             $parameterName = (string) $variableNode->name;

--- a/src/Rector/Dynamic/PropertyNameReplacerRector.php
+++ b/src/Rector/Dynamic/PropertyNameReplacerRector.php
@@ -4,7 +4,6 @@ namespace Rector\Rector\Dynamic;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\PropertyFetch;
-use PhpParser\Node\Identifier;
 use Rector\NodeAnalyzer\PropertyFetchAnalyzer;
 use Rector\NodeChanger\IdentifierRenamer;
 use Rector\Rector\AbstractRector;
@@ -69,7 +68,6 @@ final class PropertyNameReplacerRector extends AbstractRector
     {
         $oldToNewProperties = $this->matchOldToNewProperties();
 
-        /** @var Identifier $identifierNode */
         $identifierNode = $propertyFetchNode->name;
 
         $propertyName = $identifierNode->toString();

--- a/src/Rector/Dynamic/PropertyToMethodRector.php
+++ b/src/Rector/Dynamic/PropertyToMethodRector.php
@@ -7,7 +7,6 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
-use PhpParser\Node\Identifier;
 use Rector\NodeAnalyzer\PropertyFetchAnalyzer;
 use Rector\Rector\AbstractRector;
 
@@ -94,7 +93,6 @@ final class PropertyToMethodRector extends AbstractRector
         foreach ($this->perClassPropertyToMethods as $class => $propertyToMethods) {
             $properties = array_keys($propertyToMethods);
             if ($this->propertyFetchAnalyzer->isTypeAndProperties($propertyFetchNode, $class, $properties)) {
-                /** @var Identifier $identifierNode */
                 $identifierNode = $propertyFetchNode->name;
 
                 $this->activeMethod = $propertyToMethods[$identifierNode->toString()][$type];

--- a/src/Rector/MagicDisclosure/GetAndSetToMethodCallRector.php
+++ b/src/Rector/MagicDisclosure/GetAndSetToMethodCallRector.php
@@ -7,7 +7,6 @@ use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\Expression;
 use Rector\Node\MethodCallNodeFactory;
 use Rector\NodeAnalyzer\ExpressionAnalyzer;
@@ -98,7 +97,6 @@ final class GetAndSetToMethodCallRector extends AbstractRector
         $assignNode = $expressionNode->expr;
 
         if ($assignNode->expr instanceof PropertyFetch) {
-            /** @var PropertyFetch $propertyFetchNode */
             $propertyFetchNode = $assignNode->expr;
             $method = $this->activeTransformation['get'];
             $assignNode->expr = $this->createMethodCallNodeFromPropertyFetchNode($propertyFetchNode, $method);
@@ -118,7 +116,6 @@ final class GetAndSetToMethodCallRector extends AbstractRector
         PropertyFetch $propertyFetchNode,
         string $method
     ): MethodCall {
-        /** @var Identifier $identifierNode */
         $identifierNode = $propertyFetchNode->name;
 
         $value = $identifierNode->toString();
@@ -138,7 +135,6 @@ final class GetAndSetToMethodCallRector extends AbstractRector
         /** @var PropertyFetch $propertyFetchNode */
         $propertyFetchNode = $assignNode->var;
 
-        /** @var Identifier $identifierNode */
         $identifierNode = $propertyFetchNode->name;
 
         $key = $identifierNode->toString();


### PR DESCRIPTION
From what I've studied, `PHPStan` errors can be fixed with `Strong Type-Hinting` via comments. But, actually, getting into `Rector`'s source code, I could remove several of them, as well some namespaces that were only used by this comments. Even rules in `phpstan.neon` I could remove.

@TomasVotruba Is this a valid refactor, or should we keep them?