### PR TITLE
[ProcessCommand] Improvement by reporting changed files

### DIFF
--- a/src/Application/FileProcessor.php
+++ b/src/Application/FileProcessor.php
@@ -44,11 +44,14 @@ final class FileProcessor
         return $this->processFileToString($file);
     }
 
-    public function processFile(SplFileInfo $fileInfo): void
+    /**
+     * @return mixed
+     */
+    public function processFile(SplFileInfo $fileInfo)
     {
         [$newStmts, $oldStmts, $oldTokens] = $this->nodeTraverserQueue->processFileInfo($fileInfo);
 
-        $this->formatPerservingPrinter->printToFile($fileInfo, $newStmts, $oldStmts, $oldTokens);
+        return $this->formatPerservingPrinter->printToFile($fileInfo, $newStmts, $oldStmts, $oldTokens);
     }
 
     /**

--- a/src/Application/FileProcessor.php
+++ b/src/Application/FileProcessor.php
@@ -45,7 +45,7 @@ final class FileProcessor
     }
 
     /**
-     * @return mixed
+     * @return int|bool
      */
     public function processFile(SplFileInfo $fileInfo)
     {

--- a/src/Application/FileProcessor.php
+++ b/src/Application/FileProcessor.php
@@ -44,10 +44,7 @@ final class FileProcessor
         return $this->processFileToString($file);
     }
 
-    /**
-     * @return int|bool
-     */
-    public function processFile(SplFileInfo $fileInfo)
+    public function processFile(SplFileInfo $fileInfo): bool
     {
         [$newStmts, $oldStmts, $oldTokens] = $this->nodeTraverserQueue->processFileInfo($fileInfo);
 

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -151,7 +151,7 @@ final class ProcessCommand extends Command
     private function processFiles(array $fileInfos): void
     {
         $totalFiles = count($fileInfos);
-        $this->symfonyStyle->title(sprintf('Processing %s Files', $totalFiles));
+        $this->symfonyStyle->title(sprintf('Processing %s File%s', $totalFiles, $totalFiles === 1 ? '' : 's'));
         $this->symfonyStyle->progressStart($totalFiles);
 
         $i = 1;

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -151,7 +151,7 @@ final class ProcessCommand extends Command
     private function processFiles(array $fileInfos): void
     {
         $totalFiles = count($fileInfos);
-        $this->consoleStyle->title(sprintf('Processing %s File%s', $totalFiles, $totalFiles === 1 ? '' : 's'));
+        $this->consoleStyle->title(sprintf('Processing %d file%s', $totalFiles, $totalFiles === 1 ? '' : 's'));
         $this->consoleStyle->progressStart($totalFiles);
 
         $i = 1;

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -185,7 +185,7 @@ final class ProcessCommand extends Command
             }
         } else {
             $newContent = $this->fileProcessor->processFile($fileInfo);
-            if ($newContent !== false) {
+            if ($newContent) {
                 $this->changedFiles[] = $fileInfo->getPathname();
             }
         }

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -3,6 +3,7 @@
 namespace Rector\Console\Command;
 
 use Rector\Application\FileProcessor;
+use Rector\Console\ConsoleStyle;
 use Rector\Console\Output\ProcessCommandReporter;
 use Rector\ConsoleDiffer\DifferAndFormatter;
 use Rector\Exception\Command\FileProcessingException;
@@ -15,7 +16,6 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Finder\SplFileInfo;
 use Symplify\PackageBuilder\Parameter\ParameterProvider;
 use Throwable;
@@ -43,9 +43,9 @@ final class ProcessCommand extends Command
     private $rectorCollector;
 
     /**
-     * @var SymfonyStyle
+     * @var ConsoleStyle
      */
-    private $symfonyStyle;
+    private $consoleStyle;
 
     /**
      * @var PhpFilesFinder
@@ -75,7 +75,7 @@ final class ProcessCommand extends Command
     public function __construct(
         FileProcessor $fileProcessor,
         RectorCollector $rectorCollector,
-        SymfonyStyle $symfonyStyle,
+        ConsoleStyle $consoleStyle,
         PhpFilesFinder $phpFilesFinder,
         ProcessCommandReporter $processCommandReporter,
         ParameterProvider $parameterProvider,
@@ -85,7 +85,7 @@ final class ProcessCommand extends Command
 
         $this->fileProcessor = $fileProcessor;
         $this->rectorCollector = $rectorCollector;
-        $this->symfonyStyle = $symfonyStyle;
+        $this->consoleStyle = $consoleStyle;
         $this->phpFilesFinder = $phpFilesFinder;
         $this->processCommandReporter = $processCommandReporter;
         $this->parameterProvider = $parameterProvider;
@@ -111,7 +111,7 @@ final class ProcessCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->symfonyStyle->setVerbosity($output->getVerbosity());
+        $this->consoleStyle->setVerbosity($output->getVerbosity());
 
         $this->ensureSomeRectorsAreRegistered();
 
@@ -128,7 +128,7 @@ final class ProcessCommand extends Command
             $this->processCommandReporter->reportChangedFiles($this->changedFiles);
         }
 
-        $this->symfonyStyle->success('Rector is done!');
+        $this->consoleStyle->success('Rector is done!');
 
         return 0;
     }
@@ -151,8 +151,8 @@ final class ProcessCommand extends Command
     private function processFiles(array $fileInfos): void
     {
         $totalFiles = count($fileInfos);
-        $this->symfonyStyle->title(sprintf('Processing %s File%s', $totalFiles, $totalFiles === 1 ? '' : 's'));
-        $this->symfonyStyle->progressStart($totalFiles);
+        $this->consoleStyle->title(sprintf('Processing %s File%s', $totalFiles, $totalFiles === 1 ? '' : 's'));
+        $this->consoleStyle->progressStart($totalFiles);
 
         $i = 1;
         foreach ($fileInfos as $fileInfo) {
@@ -166,10 +166,10 @@ final class ProcessCommand extends Command
                 );
             }
 
-            $this->symfonyStyle->progressAdvance();
+            $this->consoleStyle->progressAdvance();
         }
 
-        $this->symfonyStyle->newLine(2);
+        $this->consoleStyle->newLine(2);
     }
 
     private function processFile(SplFileInfo $fileInfo, int &$i): void
@@ -179,8 +179,8 @@ final class ProcessCommand extends Command
             $newContent = $this->fileProcessor->processFileToString($fileInfo);
 
             if ($newContent !== $oldContent) {
-                $this->symfonyStyle->writeln(sprintf('<options=bold>%d) %s</>', $i, $fileInfo->getPathname()));
-                $this->symfonyStyle->writeln($this->differAndFormatter->diffAndFormat($oldContent, $newContent));
+                $this->consoleStyle->writeln(sprintf('<options=bold>%d) %s</>', $i, $fileInfo->getPathname()));
+                $this->consoleStyle->writeln($this->differAndFormatter->diffAndFormat($oldContent, $newContent));
                 ++$i;
             }
         } else {

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -174,9 +174,8 @@ final class ProcessCommand extends Command
 
     private function processFile(SplFileInfo $fileInfo, int &$i): void
     {
-        $oldContent = $fileInfo->getContents();
-
         if ($this->parameterProvider->provideParameter(self::OPTION_DRY_RUN)) {
+            $oldContent = $fileInfo->getContents();
             $newContent = $this->fileProcessor->processFileToString($fileInfo);
 
             if ($newContent !== $oldContent) {
@@ -186,8 +185,7 @@ final class ProcessCommand extends Command
             }
         } else {
             $newContent = $this->fileProcessor->processFile($fileInfo);
-
-            if ($newContent !== $oldContent) {
+            if ($newContent !== false) {
                 $this->changedFiles[] = $fileInfo->getPathname();
             }
         }

--- a/src/Console/ConsoleStyle.php
+++ b/src/Console/ConsoleStyle.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Console;
+
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+final class ConsoleStyle extends SymfonyStyle
+{
+    /**
+     * @param string[] $elements
+     */
+    public function listing(array $elements): void
+    {
+        $elements = array_map(function ($element) {
+            return sprintf(' - %s', $element);
+        }, $elements);
+        $this->writeln($elements);
+        $this->newLine();
+    }
+}

--- a/src/Console/Output/ProcessCommandReporter.php
+++ b/src/Console/Output/ProcessCommandReporter.php
@@ -28,7 +28,7 @@ final class ProcessCommandReporter
         $this->symfonyStyle->title(sprintf(
             '%d Loaded Rector%s',
             $this->rectorCollector->getRectorCount(),
-            $this->rectorCollector->getRectorCount() === 1 ?: 's'
+            $this->rectorCollector->getRectorCount() === 1 ? '' : 's'
         ));
 
         $rectorList = $this->sortByClassName($this->rectorCollector->getRectors());
@@ -43,7 +43,11 @@ final class ProcessCommandReporter
      */
     public function reportChangedFiles(array $changedFiles): void
     {
-        $this->symfonyStyle->title(sprintf('%s Changed Files', count($changedFiles)));
+        $this->symfonyStyle->title(sprintf(
+            '%s Changed File%s',
+            count($changedFiles),
+            count($changedFiles) === 1 ? '' : 's'
+        ));
         $this->symfonyStyle->listing($changedFiles);
     }
 

--- a/src/Console/Output/ProcessCommandReporter.php
+++ b/src/Console/Output/ProcessCommandReporter.php
@@ -2,8 +2,8 @@
 
 namespace Rector\Console\Output;
 
+use Rector\Console\ConsoleStyle;
 use Rector\Rector\RectorCollector;
-use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class ProcessCommandReporter
 {
@@ -13,19 +13,19 @@ final class ProcessCommandReporter
     private $rectorCollector;
 
     /**
-     * @var SymfonyStyle
+     * @var ConsoleStyle
      */
-    private $symfonyStyle;
+    private $consoleStyle;
 
-    public function __construct(RectorCollector $rectorCollector, SymfonyStyle $symfonyStyle)
+    public function __construct(RectorCollector $rectorCollector, ConsoleStyle $consoleStyle)
     {
         $this->rectorCollector = $rectorCollector;
-        $this->symfonyStyle = $symfonyStyle;
+        $this->consoleStyle = $consoleStyle;
     }
 
     public function reportLoadedRectors(): void
     {
-        $this->symfonyStyle->title(sprintf(
+        $this->consoleStyle->title(sprintf(
             '%d Loaded Rector%s',
             $this->rectorCollector->getRectorCount(),
             $this->rectorCollector->getRectorCount() === 1 ? '' : 's'
@@ -33,7 +33,7 @@ final class ProcessCommandReporter
 
         $rectorList = $this->sortByClassName($this->rectorCollector->getRectors());
 
-        $this->symfonyStyle->listing(array_map(function ($rector): string {
+        $this->consoleStyle->listing(array_map(function ($rector): string {
             return get_class($rector);
         }, $rectorList));
     }
@@ -43,12 +43,12 @@ final class ProcessCommandReporter
      */
     public function reportChangedFiles(array $changedFiles): void
     {
-        $this->symfonyStyle->title(sprintf(
+        $this->consoleStyle->title(sprintf(
             '%s Changed File%s',
             count($changedFiles),
             count($changedFiles) === 1 ? '' : 's'
         ));
-        $this->symfonyStyle->listing($changedFiles);
+        $this->consoleStyle->listing($changedFiles);
     }
 
     /**

--- a/src/Console/Output/ProcessCommandReporter.php
+++ b/src/Console/Output/ProcessCommandReporter.php
@@ -28,18 +28,23 @@ final class ProcessCommandReporter
         $this->symfonyStyle->title(sprintf(
             '%d Loaded Rector%s',
             $this->rectorCollector->getRectorCount(),
-            $this->rectorCollector->getRectorCount() === 1 ? '' : 's'
+            $this->rectorCollector->getRectorCount() === 1 ?: 's'
         ));
 
         $rectorList = $this->sortByClassName($this->rectorCollector->getRectors());
-        foreach ($rectorList as $rector) {
-            $this->symfonyStyle->writeln(sprintf(
-                ' - %s',
-                get_class($rector)
-            ));
-        }
 
-        $this->symfonyStyle->newLine();
+        $this->symfonyStyle->listing(array_map(function ($rector): string {
+            return get_class($rector);
+        }, $rectorList));
+    }
+
+    /**
+     * @param string[] $changedFiles
+     */
+    public function reportChangedFiles(array $changedFiles): void
+    {
+        $this->symfonyStyle->title(sprintf('%s Changed Files', count($changedFiles)));
+        $this->symfonyStyle->listing($changedFiles);
     }
 
     /**

--- a/src/Console/Output/ProcessCommandReporter.php
+++ b/src/Console/Output/ProcessCommandReporter.php
@@ -44,7 +44,7 @@ final class ProcessCommandReporter
     public function reportChangedFiles(array $changedFiles): void
     {
         $this->consoleStyle->title(sprintf(
-            '%s Changed File%s',
+            '%d Changed file%s',
             count($changedFiles),
             count($changedFiles) === 1 ? '' : 's'
         ));

--- a/src/Console/Output/ProcessCommandReporter.php
+++ b/src/Console/Output/ProcessCommandReporter.php
@@ -3,6 +3,7 @@
 namespace Rector\Console\Output;
 
 use Rector\Console\ConsoleStyle;
+use Rector\Contract\Rector\RectorInterface;
 use Rector\Rector\RectorCollector;
 
 final class ProcessCommandReporter
@@ -33,7 +34,7 @@ final class ProcessCommandReporter
 
         $rectorList = $this->sortByClassName($this->rectorCollector->getRectors());
 
-        $this->consoleStyle->listing(array_map(function ($rector): string {
+        $this->consoleStyle->listing(array_map(function (RectorInterface $rector): string {
             return get_class($rector);
         }, $rectorList));
     }

--- a/src/Printer/FormatPerservingPrinter.php
+++ b/src/Printer/FormatPerservingPrinter.php
@@ -22,9 +22,8 @@ final class FormatPerservingPrinter
      * @param Node[] $newStmts
      * @param Node[] $oldStmts
      * @param Node[] $oldTokens
-     * @return int|bool
      */
-    public function printToFile(SplFileInfo $fileInfo, array $newStmts, array $oldStmts, array $oldTokens)
+    public function printToFile(SplFileInfo $fileInfo, array $newStmts, array $oldStmts, array $oldTokens): bool
     {
         $oldContent = file_get_contents($fileInfo->getRealPath());
         $newContent = $this->printToString($newStmts, $oldStmts, $oldTokens);

--- a/src/Printer/FormatPerservingPrinter.php
+++ b/src/Printer/FormatPerservingPrinter.php
@@ -22,17 +22,18 @@ final class FormatPerservingPrinter
      * @param Node[] $newStmts
      * @param Node[] $oldStmts
      * @param Node[] $oldTokens
+     * @return mixed
      */
-    public function printToFile(SplFileInfo $fileInfo, array $newStmts, array $oldStmts, array $oldTokens): void
+    public function printToFile(SplFileInfo $fileInfo, array $newStmts, array $oldStmts, array $oldTokens)
     {
         $oldContent = file_get_contents($fileInfo->getRealPath());
         $newContent = $this->printToString($newStmts, $oldStmts, $oldTokens);
 
         if ($oldContent === $newContent) {
-            return;
+            return false;
         }
 
-        file_put_contents($fileInfo->getRealPath(), $newContent);
+        return file_put_contents($fileInfo->getRealPath(), $newContent);
     }
 
     /**

--- a/src/Printer/FormatPerservingPrinter.php
+++ b/src/Printer/FormatPerservingPrinter.php
@@ -22,7 +22,7 @@ final class FormatPerservingPrinter
      * @param Node[] $newStmts
      * @param Node[] $oldStmts
      * @param Node[] $oldTokens
-     * @return mixed
+     * @return int|bool
      */
     public function printToFile(SplFileInfo $fileInfo, array $newStmts, array $oldStmts, array $oldTokens)
     {


### PR DESCRIPTION
I've made a little improvement to our `ProcessCommand`: report _how many_, and **what files**, were changed :tada:

### Changes:
- Now the `printToFile` and `processFile` methods in `FormatPerservingPrinter` and `FileProcessor` return the result of `file_put_contents`, and as this function [returns `false` in cause of failure](http://php.net/manual/en/function.file-put-contents.php#refsect1-function.file-put-contents-returnvalues), I've also added `return false` in case the file didn't get changed, so we can check it;
- I've used the [`listing` method](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Console/Style/SymfonyStyle.php#L102-L111) from `SymfonyStyle`, to avoid `for` loops in our code. As suggested by @javiereguiluz in [`symfony/symfony#25616`](https://github.com/symfony/symfony/pull/25616#issuecomment-354243140), I've created `ConsoleStyle`, extending from `SymfonyStyle`, so we can continue to get the dashes `-` while listing, instead of stars `*`;
- The `newLine` method, also from `SymfonyStyle`, allows us to pass the number of new lines we want, so we can avoid repeating that command.

### Screenshots:
Before:
![before](https://user-images.githubusercontent.com/16328050/34400531-784e4b86-eb79-11e7-8950-8da438f08212.png)
After:
![after](https://user-images.githubusercontent.com/16328050/34404429-a1019dc4-eb94-11e7-9d44-38eab1cc8ac6.png)