### PR TITLE
Rename composer all to composer complete-check

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ Just follow 3 rules:
 - Tests, coding standard and PHPStan **checks must pass**
 
     ```bash
-    composer all
+    composer complete-check
     ```
 
     Don you need to fix coding standards? Run:

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         }
     },
     "scripts": {
-        "all": ["@check-cs", "phpunit", "@phpstan"],
+        "complete-check": ["@check-cs", "phpunit", "@phpstan"],
         "check-cs": "vendor/bin/ecs check bin packages src tests",
         "fix-cs": "vendor/bin/ecs check bin packages src tests --fix",
         "phpstan": "vendor/bin/phpstan.phar analyse packages src tests --level max --configuration phpstan.neon"


### PR DESCRIPTION
I've renamed the `composer all` command to `composer complete-check`. As we have in [`Symplify`](https://github.com/Symplify/Symplify/blob/master/composer.json#L74), I guess suggests a better name for what this command does.