### PR TITLE
[ProcessCommand] Fix --dry-run option

### DIFF
--- a/src/Console/Output/ProcessCommandReporter.php
+++ b/src/Console/Output/ProcessCommandReporter.php
@@ -53,6 +53,23 @@ final class ProcessCommandReporter
     }
 
     /**
+     * @param string[][] $diffFiles
+     */
+    public function reportDiffFiles(array $diffFiles): void
+    {
+        $this->consoleStyle->title(sprintf(
+            '%d file%s with changes',
+            count($diffFiles),
+            count($diffFiles) === 1 ? '' : 's'
+        ));
+
+        foreach ($diffFiles as $diffFile) {
+            $this->consoleStyle->writeln($diffFile['file']);
+            $this->consoleStyle->writeln($diffFile['diff']);
+        }
+    }
+
+    /**
      * @param object[] $objects
      * @return object[]
      */


### PR DESCRIPTION
As [foreseen](https://github.com/rectorphp/rector/pull/246#issuecomment-354471135) by @TomasVotruba in #246, the `--dry-run` option should also follow the process of collecting the changes, and them render.
Before:
![captura de tela de 2018-01-02 04-03-55](https://user-images.githubusercontent.com/16328050/34475473-92bd6274-ef73-11e7-9e57-468edd50ecbb.png)
After:
![captura de tela de 2018-01-02 04-12-00](https://user-images.githubusercontent.com/16328050/34475474-98166144-ef73-11e7-9b0d-1ab9c2db61e9.png)

I've also added a title before the diffs: `X files with changes` :man_technologist: 