### PR TITLE
[PHPUnit] Expand Rectors to support more methods

### DIFF
--- a/packages/BetterReflection/src/Reflector/SmartClassReflector.php
+++ b/packages/BetterReflection/src/Reflector/SmartClassReflector.php
@@ -2,6 +2,7 @@
 
 namespace Rector\BetterReflection\Reflector;
 
+use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Interface_;
@@ -105,12 +106,9 @@ final class SmartClassReflector
         }
 
         if ($classLikeNode instanceof Interface_) {
-            $types = [];
-            foreach ($classLikeNode->extends as $interface) {
-                $types[] = $interface->toString();
-            }
-
-            return $types;
+            return array_map(function (Name $interface): string {
+                return $interface->toString();
+            }, $classLikeNode->extends);
         }
     }
 

--- a/src/NodeAnalyzer/ClassLikeAnalyzer.php
+++ b/src/NodeAnalyzer/ClassLikeAnalyzer.php
@@ -106,14 +106,9 @@ final class ClassLikeAnalyzer
      */
     private function resolveImplementsTypes(Class_ $classNode): array
     {
-        $types = [];
-
-        $interfaces = $classNode->implements;
-        foreach ($interfaces as $interface) {
+        return array_map(function (Name $interface): string {
             /** @var FullyQualified $interface */
-            $types[] = $interface->toString();
-        }
-
-        return $types;
+            return $interface->toString();
+        }, $classNode->implements);
     }
 }

--- a/src/Rector/Contrib/PHPUnit/ExceptionAnnotationRector.php
+++ b/src/Rector/Contrib/PHPUnit/ExceptionAnnotationRector.php
@@ -77,11 +77,9 @@ final class ExceptionAnnotationRector extends AbstractRector
             /** @var Generic[] $tags */
             $tags = $this->docBlockAnalyzer->getTagsByName($classMethodNode, $annotation);
 
-            $methodCallExpressions = [];
-
-            foreach ($tags as $tag) {
-                $methodCallExpressions[] = $this->createMethodCallExpressionFromTag($tag, $method);
-            }
+            $methodCallExpressions = array_map(function (Generic $tag) use ($method): Expression {
+                return $this->createMethodCallExpressionFromTag($tag, $method);
+            }, $tags);
 
             $classMethodNode->stmts = array_merge($methodCallExpressions, $classMethodNode->stmts);
 

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertFalseStrposToContainsRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertFalseStrposToContainsRector.php
@@ -13,7 +13,7 @@ use Rector\Rector\AbstractRector;
 /**
  * Before:
  * - $this->assertFalse(strpos($anything, 'foo'), 'message');
- * - $this->assertNotFalse(strpos($anything, 'foo'), 'message');
+ * - $this->assertNotFalse(stripos($anything, 'foo'), 'message');
  *
  * After:
  * - $this->assertNotContains('foo', $anything, 'message');
@@ -55,7 +55,7 @@ final class AssertFalseStrposToContainsRector extends AbstractRector
 
         $strposNode = $firstArgumentValue->name->toString();
 
-        return $strposNode === 'strpos';
+        return in_array($strposNode, ['strpos', 'stripos'], true);
     }
 
     /**

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertInstanceOfComparisonRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertInstanceOfComparisonRector.php
@@ -1,0 +1,108 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Rector\Contrib\PHPUnit\SpecificMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Instanceof_;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use Rector\Node\NodeFactory;
+use Rector\NodeAnalyzer\MethodCallAnalyzer;
+use Rector\NodeChanger\IdentifierRenamer;
+use Rector\Rector\AbstractRector;
+
+/**
+ * - Before:
+ * - $this->assertTrue($foo instanceof Foo, 'message');
+ * - $this->assertFalse($foo instanceof Foo, 'message');
+ *
+ * - After:
+ * - $this->assertInstanceOf(Foo::class, $foo, 'message');
+ * - $this->assertNotInstanceOf(Foo::class, $foo, 'message');
+ */
+final class AssertInstanceOfComparisonRector extends AbstractRector
+{
+    /**
+     * @var MethodCallAnalyzer
+     */
+    private $methodCallAnalyzer;
+
+    /**
+     * @var IdentifierRenamer
+     */
+    private $identifierRenamer;
+
+    /**
+     * @var NodeFactory
+     */
+    private $nodeFactory;
+
+    public function __construct(
+        MethodCallAnalyzer $methodCallAnalyzer,
+        IdentifierRenamer $identifierRenamer,
+        NodeFactory $nodeFactory
+    ) {
+        $this->methodCallAnalyzer = $methodCallAnalyzer;
+        $this->identifierRenamer = $identifierRenamer;
+        $this->nodeFactory = $nodeFactory;
+    }
+
+    public function isCandidate(Node $node): bool
+    {
+        if (! $this->methodCallAnalyzer->isTypesAndMethods(
+            $node,
+            ['PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase'],
+            ['assertTrue', 'assertFalse']
+        )) {
+            return false;
+        }
+
+        /** @var MethodCall $methodCallNode */
+        $methodCallNode = $node;
+
+        $firstArgumentValue = $methodCallNode->args[0]->value;
+
+        return $firstArgumentValue instanceof Instanceof_;
+    }
+
+    /**
+     * @param MethodCall $methodCallNode
+     */
+    public function refactor(Node $methodCallNode): ?Node
+    {
+        $this->renameMethod($methodCallNode);
+        $this->changeOrderArguments($methodCallNode);
+
+        return $methodCallNode;
+    }
+
+    public function changeOrderArguments(MethodCall $methodCallNode): void
+    {
+        $oldArguments = $methodCallNode->args;
+        /** @var Instanceof_ $comparison */
+        $comparison = $oldArguments[0]->value;
+
+        $className = $comparison->class->toString();
+        $argument = $comparison->expr;
+
+        unset($oldArguments[0]);
+
+        $methodCallNode->args = array_merge([
+            $this->nodeFactory->createString($className),
+            $argument,
+        ], $oldArguments);
+    }
+
+    private function renameMethod(MethodCall $methodCallNode): void
+    {
+        /** @var Identifier $identifierNode */
+        $identifierNode = $methodCallNode->name;
+        $oldMethodName = $identifierNode->toString();
+
+        if ($oldMethodName === 'assertTrue') {
+            $this->identifierRenamer->renameNode($methodCallNode, 'assertInstanceOf');
+        } else {
+            $this->identifierRenamer->renameNode($methodCallNode, 'assertNotInstanceOf');
+        }
+    }
+}

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertTrueFalseToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertTrueFalseToSpecificMethodRector.php
@@ -37,6 +37,7 @@ final class AssertTrueFalseToSpecificMethodRector extends AbstractRector
         'is_null' => ['assertNull', 'assertNotNull'],
         'is_writable' => ['assertIsWritable', 'assertNotIsWritable'],
         'is_nan' => ['assertNan', false],
+        'is_a' => ['assertInstanceOf', 'assertNotInstanceOf'],
     ];
 
     /**
@@ -147,9 +148,19 @@ final class AssertTrueFalseToSpecificMethodRector extends AbstractRector
     {
         $funcCallOrEmptyNode = $methodCallNode->args[0]->value;
         if ($funcCallOrEmptyNode instanceof FuncCall) {
+            $funcCallOrEmptyNodeName = $funcCallOrEmptyNode->name->toString();
+            $funcCallOrEmptyNodeArgs = $funcCallOrEmptyNode->args;
             $oldArguments = $methodCallNode->args;
             unset($oldArguments[0]);
-            $newArguments = array_merge($funcCallOrEmptyNode->args, $oldArguments);
+
+            if ($funcCallOrEmptyNodeName === 'is_a') {
+                $newArguments = array_merge(
+                    array_reverse($funcCallOrEmptyNodeArgs),
+                    $oldArguments
+                );
+            } else {
+                $newArguments = array_merge($funcCallOrEmptyNodeArgs, $oldArguments);
+            }
 
             $methodCallNode->args = $newArguments;
         }

--- a/src/config/level/phpunit/phpunit-specific-method.yml
+++ b/src/config/level/phpunit/phpunit-specific-method.yml
@@ -6,3 +6,4 @@ rectors:
     Rector\Rector\Contrib\PHPUnit\SpecificMethod\AssertTrueFalseInternalTypeToSpecificMethodRector: ~
     Rector\Rector\Contrib\PHPUnit\SpecificMethod\AssertCompareToSpecificMethodRector: ~
     Rector\Rector\Contrib\PHPUnit\SpecificMethod\AssertTrueIssetToObjectHasAttributeRector: ~
+    Rector\Rector\Contrib\PHPUnit\SpecificMethod\AssertInstanceOfComparisonRector: ~

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertFalseStrposToContainsRector/Wrong/wrong.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertFalseStrposToContainsRector/Wrong/wrong.php.inc
@@ -5,6 +5,6 @@ final class MyTest extends \PHPUnit\Framework\TestCase
     public function test()
     {
         $this->assertNotFalse(strpos($node, 'foo'));
-        $this->assertFalse(strpos($node, 'foo'), 'message');
+        $this->assertFalse(stripos($node, 'foo'), 'message');
     }
 }

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertInstanceOfComparisonRector/AssertInstanceOfComparisonRectorTest.php
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertInstanceOfComparisonRector/AssertInstanceOfComparisonRectorTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Tests\Rector\Contrib\PHPUnit\SpecificMethod\AssertInstanceOfComparisonRector;
+
+use Rector\Rector\Contrib\PHPUnit\SpecificMethod\AssertInstanceOfComparisonRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AssertInstanceOfComparisonRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideWrongToFixedFiles()
+     */
+    public function test(string $wrong, string $fixed): void
+    {
+        $this->doTestFileMatchesExpectedContent($wrong, $fixed);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function provideWrongToFixedFiles(): array
+    {
+        return [
+            [__DIR__ . '/Wrong/wrong.php.inc', __DIR__ . '/Correct/correct.php.inc'],
+        ];
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getRectorClasses(): array
+    {
+        return [AssertInstanceOfComparisonRector::class];
+    }
+}

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertInstanceOfComparisonRector/Correct/correct.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertInstanceOfComparisonRector/Correct/correct.php.inc
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+final class MyTest extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $this->assertInstanceOf('Foo', $something);
+        $this->assertNotInstanceOf('Foo', $something);
+    }
+}

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertInstanceOfComparisonRector/Wrong/wrong.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertInstanceOfComparisonRector/Wrong/wrong.php.inc
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+final class MyTest extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $this->assertTrue($something instanceof Foo);
+        $this->assertFalse($something instanceof Foo);
+    }
+}

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertTrueFalseToSpecificMethodRector/Correct/correct.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertTrueFalseToSpecificMethodRector/Correct/correct.php.inc
@@ -15,5 +15,6 @@ final class MyTest extends \PHPUnit\Framework\TestCase
         $this->assertNotNull('...');
         $this->assertIsWritable('...');
         $this->assertNotContains('...', ['...'], 'argument');
+        $this->assertInstanceOf('Foo', $anything, 'argument');
     }
 }

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertTrueFalseToSpecificMethodRector/Wrong/wrong.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertTrueFalseToSpecificMethodRector/Wrong/wrong.php.inc
@@ -15,5 +15,6 @@ final class MyTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse(is_null('...'));
         $this->assertTrue(is_writable('...'));
         $this->assertFalse(array_search('...', ['...']), 'argument');
+        $this->assertTrue(is_a($anything, 'Foo'), 'argument');
     }
 }


### PR DESCRIPTION
I've expanded our PHPUnit `Rector`s to support more methods to refactory:
- `AssertFalseStrposToContainsRector` also converts `stripos` to `assertContains`;
- `AssertTrueFalseToSpecificMethodRector` supports `is_a` to `assertInstanceOf`;
- `AssertInstanceOfComparisonRector` is a new one to handle `instanceof` comparison to `assertInstanceOf` assertion.

Bonus: I use `array_map` in some places to clean up some code :man_technologist: 