### PR TITLE
[AssertCompareToSpecificMethodRector] Fix bug with ArrayDimFetch Nodes

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -38,6 +38,7 @@ parameters:
         # known value of Name of MethodCall
         - '#Call to an undefined method PhpParser\\Node\\Expr\|PhpParser\\Node\\Name::toString\(\)#'
         - '#Cannot call method toString\(\) on PhpParser\\Node\\Expr\|string#'
+        - '#Access to an undefined property PhpParser\\Node\\Expr::\$name#'
 
         # buggy
         - '#Parameter \#1 \$classLikeNode of method Rector\\NodeAnalyzer\\ClassLikeAnalyzer::resolveExtendsTypes\(\) expects PhpParser\\Node\\Stmt\\Class_\|PhpParser\\Node\\Stmt\\Interface_, PhpParser\\Node\\Stmt\\ClassLike given#'
@@ -51,7 +52,6 @@ parameters:
         - '#Call to an undefined method PhpParser\\PrettyPrinter\\Standard::printFormatPreserving\(\)#'
         - '#Array \(array<Rector\\BetterReflection\\Reflection\\ReflectionClass>\) does not accept Rector\\BetterReflection\\Reflection\\Reflection#'
 
-        - '#Access to an undefined property PhpParser\\Node\\Expr::\$name#'
     excludes_analyse:
         # test files
         - '*tests/Rector/Dynamic/MethodNameReplacerRector/wrong/*'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -51,6 +51,7 @@ parameters:
         - '#Call to an undefined method PhpParser\\PrettyPrinter\\Standard::printFormatPreserving\(\)#'
         - '#Array \(array<Rector\\BetterReflection\\Reflection\\ReflectionClass>\) does not accept Rector\\BetterReflection\\Reflection\\Reflection#'
 
+        - '#Access to an undefined property PhpParser\\Node\\Expr::\$name#'
     excludes_analyse:
         # test files
         - '*tests/Rector/Dynamic/MethodNameReplacerRector/wrong/*'

--- a/src/FileSystem/PhpFilesFinder.php
+++ b/src/FileSystem/PhpFilesFinder.php
@@ -46,6 +46,7 @@ final class PhpFilesFinder
             ->in($directories)
             ->exclude('examples')
             ->exclude('stubs')
+            ->exclude('fixtures')
             // very rare and specific code
             ->exclude('polyfill')
             ->notName('*polyfill*')

--- a/src/FileSystem/PhpFilesFinder.php
+++ b/src/FileSystem/PhpFilesFinder.php
@@ -44,11 +44,16 @@ final class PhpFilesFinder
             ->files()
             ->name('*.php')
             ->in($directories)
-            ->exclude('examples')
-            ->exclude('stubs')
-            ->exclude('fixtures')
-            // very rare and specific code
-            ->exclude('polyfill')
+            ->exclude([
+                'examples',
+                'Examples',
+                'stubs',
+                'Stubs',
+                'fixtures',
+                'Fixtures',
+                'polyfill',
+                'Polyfill',
+            ])
             ->notName('*polyfill*')
             ->sortByName();
 

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertCompareToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertCompareToSpecificMethodRector.php
@@ -3,6 +3,7 @@
 namespace Rector\Rector\Contrib\PHPUnit\SpecificMethod;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
@@ -81,13 +82,14 @@ final class AssertCompareToSpecificMethodRector extends AbstractRector
             return false;
         }
 
-        $secondArgumentValue = $methodCallNode->args[1]->value->name;
+        /** @var Expr $secondArgumentValue */
+        $secondArgumentValue = $methodCallNode->args[1]->value;
 
-        if (! $secondArgumentValue instanceof Name) {
+        if (! $this->isNamedFunction($secondArgumentValue)) {
             return false;
         }
 
-        $methodName = $secondArgumentValue->getFirst();
+        $methodName = $secondArgumentValue->name->getFirst();
         if (! isset($this->defaultOldToNewMethods[$methodName])) {
             return false;
         }
@@ -131,5 +133,19 @@ final class AssertCompareToSpecificMethodRector extends AbstractRector
         /** @var FuncCall $secondArgument */
         $secondArgument = $methodCallNode->args[1]->value;
         $methodCallNode->args[1] = $secondArgument->args[0];
+    }
+
+    private function isNamedFunction(Expr $node): bool
+    {
+        if (! $node instanceof FuncCall) {
+            return false;
+        }
+
+        $functionName = $node->name;
+        if (! $functionName instanceof Name) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertCompareToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertCompareToSpecificMethodRector.php
@@ -89,7 +89,7 @@ final class AssertCompareToSpecificMethodRector extends AbstractRector
             return false;
         }
 
-        $methodName = $secondArgumentValue->name->getFirst();
+        $methodName = $secondArgumentValue->name->toString();
         if (! isset($this->defaultOldToNewMethods[$methodName])) {
             return false;
         }

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertCompareToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertCompareToSpecificMethodRector.php
@@ -5,8 +5,10 @@ namespace Rector\Rector\Contrib\PHPUnit\SpecificMethod;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Scalar\String_;
 use Rector\NodeAnalyzer\MethodCallAnalyzer;
@@ -80,18 +82,18 @@ final class AssertCompareToSpecificMethodRector extends AbstractRector
             return false;
         }
 
-        $secondArgumentValue = $methodCallNode->args[1]->value;
+        $secondArgumentValue = $methodCallNode->args[1]->value->name;
 
-        if (! $secondArgumentValue instanceof FuncCall) {
+        if (! $secondArgumentValue instanceof Name) {
             return false;
         }
 
-        $funcCallName = $secondArgumentValue->name->toString();
-        if (! isset($this->defaultOldToNewMethods[$funcCallName])) {
+        $name = $secondArgumentValue->getFirst();
+        if (! isset($this->defaultOldToNewMethods[$name])) {
             return false;
         }
 
-        $this->activeFuncCallName = $funcCallName;
+        $this->activeFuncCallName = $name;
 
         return true;
     }

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertCompareToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertCompareToSpecificMethodRector.php
@@ -5,7 +5,6 @@ namespace Rector\Rector\Contrib\PHPUnit\SpecificMethod;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
@@ -88,12 +87,12 @@ final class AssertCompareToSpecificMethodRector extends AbstractRector
             return false;
         }
 
-        $name = $secondArgumentValue->getFirst();
-        if (! isset($this->defaultOldToNewMethods[$name])) {
+        $methodName = $secondArgumentValue->getFirst();
+        if (! isset($this->defaultOldToNewMethods[$methodName])) {
             return false;
         }
 
-        $this->activeFuncCallName = $name;
+        $this->activeFuncCallName = $methodName;
 
         return true;
     }

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertCompareToSpecificMethodRector/Correct/correct.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertCompareToSpecificMethodRector/Correct/correct.php.inc
@@ -7,5 +7,6 @@ final class MyTest extends \PHPUnit\Framework\TestCase
         $this->assertCount(5, $something);
         $this->assertNotCount($count, $something, 'third argument');
         $this->assertInternalType('string', $something);
+        $this->assertEquals('string', $something['property']());
     }
 }

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertCompareToSpecificMethodRector/Wrong/wrong.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertCompareToSpecificMethodRector/Wrong/wrong.php.inc
@@ -7,5 +7,6 @@ final class MyTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(5, count($something));
         $this->assertNotEquals($count, sizeof($something), 'third argument');
         $this->assertEquals('string', gettype($something));
+        $this->assertEquals('string', $something['property']());
     }
 }


### PR DESCRIPTION
This fixes [#208](https://github.com/rectorphp/rector/issues/208#issuecomment-355059999) reported bug with complexes second arguments, such as `$something['property']()`.

I've tried to do not add a second if, to break function's cyclomatic allowed maximum of 5. So, an error must be added to `phpstan.neon`.

But, now we receive a PHP Notice during running Rector: `Undefined property: PhpParser\Node\Expr\ArrayDimFetch::$name`.

@TomasVotruba What should we do my friend?