### PR TITLE
[Fix] Object of class PhpParser\Node\{} could not be converted to string

### DIFF
--- a/packages/NodeTypeResolver/src/PerNodeTypeResolver/MethodCallTypeResolver.php
+++ b/packages/NodeTypeResolver/src/PerNodeTypeResolver/MethodCallTypeResolver.php
@@ -70,11 +70,11 @@ final class MethodCallTypeResolver implements PerNodeTypeResolverInterface, Node
     {
         $parentCallerTypes = $this->resolveMethodCallVarTypes($methodCallNode);
 
-        if ($methodCallNode->name instanceof Identifier) {
-            $methodName = $methodCallNode->name->toString();
-        } else {
-            $methodName = (string) $methodCallNode->name;
+        if (! $methodCallNode->name instanceof Identifier) {
+            return [];
         }
+
+        $methodName = $methodCallNode->name->toString();
 
         if (! $parentCallerTypes || ! $methodName) {
             return [];

--- a/packages/NodeTypeResolver/src/PerNodeTypeResolver/MethodCallTypeResolver.php
+++ b/packages/NodeTypeResolver/src/PerNodeTypeResolver/MethodCallTypeResolver.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
 use Rector\BetterReflection\Reflector\MethodReflector;
 use Rector\Node\Attribute;
 use Rector\NodeTypeResolver\Contract\NodeTypeResolverAwareInterface;
@@ -68,7 +69,12 @@ final class MethodCallTypeResolver implements PerNodeTypeResolverInterface, Node
     public function resolve(Node $methodCallNode): array
     {
         $parentCallerTypes = $this->resolveMethodCallVarTypes($methodCallNode);
-        $methodName = (string) $methodCallNode->name;
+
+        if ($methodCallNode->name instanceof Identifier) {
+            $methodName = $methodCallNode->name->toString();
+        } else {
+            $methodName = (string) $methodCallNode->name;
+        }
 
         if (! $parentCallerTypes || ! $methodName) {
             return [];

--- a/packages/NodeTypeResolver/tests/PerNodeTypeResolver/MethodCallTypeResolver/MethodCallSource/OnMagicClassCall.php.inc
+++ b/packages/NodeTypeResolver/tests/PerNodeTypeResolver/MethodCallTypeResolver/MethodCallSource/OnMagicClassCall.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+use Nette\Config\Configurator;
+
+$configurator = new Configurator;
+
+$configurator->{__CLASS__}();

--- a/packages/NodeTypeResolver/tests/PerNodeTypeResolver/MethodCallTypeResolver/MethodCallTypeResolverTest.php
+++ b/packages/NodeTypeResolver/tests/PerNodeTypeResolver/MethodCallTypeResolver/MethodCallTypeResolverTest.php
@@ -52,6 +52,11 @@ final class MethodCallTypeResolverTest extends AbstractNodeTypeResolverTest
                 'Nette\Config\Configurator',
                 'Nette\Object',
             ]],
+            # on magic class call
+            [__DIR__ . '/MethodCallSource/OnMagicClassCall.php.inc', 0, [
+                'Nette\Config\Configurator',
+                'Nette\Object',
+            ]],
         ];
     }
 }


### PR DESCRIPTION
[As predicted](https://github.com/rectorphp/rector/pull/274#discussion_r160067629) in #274