### PR TITLE
Add vendor-bin to $possibleAutoloadPaths

### DIFF
--- a/bin/rector_bootstrap.php
+++ b/bin/rector_bootstrap.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types=1);
 
 $possibleAutoloadPaths = [
+    // load from vendor-bin
+    getcwd() . '/vendor-bin/rector/vendor/autoload.php',
     // load from nearest vendor
     getcwd() . '/vendor/autoload.php',
     // repository


### PR DESCRIPTION
I was able to install Rector in my Composer fork with [the solution in `README.md`](https://github.com/rectorphp/rector#do-you-have-conflicts), but a Fatal Error arrises:
```
PHP Fatal error:  Uncaught Error: Class 'Symplify\PackageBuilder\Console\Style\SymfonyStyleFactory' not found in /var/www/composer/vendor-bin/rector/vendor/rector/rector/bin/rector:47
Stack trace:
#0 {main}
  thrown in /var/www/composer/vendor-bin/rector/vendor/rector/rector/bin/rector on line 47
```
After add `vendor-bin` as the first option in the `$possibleAutoloadPaths` array at `bin/rector_bootstrap.php`, Rector ran perfectly.