### PR TITLE
[DocBlockAnalyzer] Fix tests

### DIFF
--- a/packages/ReflectionDocBlock/src/NodeAnalyzer/DocBlockAnalyzer.php
+++ b/packages/ReflectionDocBlock/src/NodeAnalyzer/DocBlockAnalyzer.php
@@ -102,18 +102,13 @@ final class DocBlockAnalyzer
     }
 
     /**
-     * @return Tag[]|null
+     * @return Tag[]|string[]
      */
-    public function getTagsByName(Node $node, string $name): ?array
+    public function getTagsByName(Node $node, string $name): array
     {
         $docBlock = $this->docBlockFactory->createFromNode($node);
 
-        $tags = $docBlock->getTagsByName($name);
-        if (count($tags) === 0) {
-            return null;
-        }
-
-        return $tags;
+        return $docBlock->getTagsByName($name);
     }
 
     public function replaceVarType(Node $node, string $to): void


### PR DESCRIPTION
In DocBlockAnalyzer line 88 we `count` the return of `getTagsByName`. [In PHP 7.2](https://travis-ci.org/rectorphp/rector/jobs/326743440#L607), if we try to count `null`, an error arises: 
```
count(): Parameter must be an array or an object that implements Countable
```
So, instead of null, just return an empty array.