### PR TITLE
Add vendor-bin to $possibleAutoloadPaths

### DIFF
--- a/bin/rector_bootstrap.php
+++ b/bin/rector_bootstrap.php
@@ -1,12 +1,12 @@
 <?php declare(strict_types=1);
 
 $possibleAutoloadPaths = [
-    // load from nearest vendor
-    getcwd() . '/vendor/autoload.php',
     // repository
     __DIR__ . '/../vendor/autoload.php',
     // composer require
     __DIR__ . '/../../../../vendor/autoload.php',
+    // load from nearest vendor
+    getcwd() . '/vendor/autoload.php',
 ];
 
 foreach ($possibleAutoloadPaths as $possibleAutoloadPath) {


### PR DESCRIPTION
This suppress #280, with a branch on Rector allowing local tests.

@TomasVotruba I'll test and see with position `vendor-bin` is better.