### PR TITLE
[PHPUnit] Create AbstractPHPUnitRector

### DIFF
--- a/src/Rector/AbstractPHPUnitRector.php
+++ b/src/Rector/AbstractPHPUnitRector.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Rector;
+
+use Nette\Utils\Strings;
+use PhpParser\Node;
+use Rector\Node\Attribute;
+
+abstract class AbstractPHPUnitRector extends AbstractRector
+{
+    protected function isInTestClass(Node $node): bool
+    {
+        $className = $node->getAttribute(Attribute::CLASS_NAME);
+
+        return Strings::endsWith((string) $className, 'Test');
+    }
+}

--- a/src/Rector/AbstractPHPUnitRector.php
+++ b/src/Rector/AbstractPHPUnitRector.php
@@ -8,6 +8,11 @@ use Rector\Node\Attribute;
 
 abstract class AbstractPHPUnitRector extends AbstractRector
 {
+    /**
+     * Check if the file is a PHPUnit TestCase. By default, it should end with "Test", as it is the standard.
+     *
+     * @see https://phpunit.de/getting-started-with-phpunit.html
+     */
     protected function isInTestClass(Node $node): bool
     {
         $className = $node->getAttribute(Attribute::CLASS_NAME);

--- a/src/Rector/Contrib/PHPUnit/DelegateExceptionArgumentsRector.php
+++ b/src/Rector/Contrib/PHPUnit/DelegateExceptionArgumentsRector.php
@@ -51,10 +51,7 @@ final class DelegateExceptionArgumentsRector extends AbstractPHPUnitRector
             return false;
         }
 
-        if (! $this->methodCallAnalyzer->isMethods(
-            $node,
-            array_keys($this->oldToNewMethod)
-        )) {
+        if (! $this->methodCallAnalyzer->isMethods($node, array_keys($this->oldToNewMethod))) {
             return false;
         }
 

--- a/src/Rector/Contrib/PHPUnit/DelegateExceptionArgumentsRector.php
+++ b/src/Rector/Contrib/PHPUnit/DelegateExceptionArgumentsRector.php
@@ -8,7 +8,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Identifier;
 use Rector\Node\MethodCallNodeFactory;
 use Rector\NodeAnalyzer\MethodCallAnalyzer;
-use Rector\Rector\AbstractRector;
+use Rector\Rector\AbstractPHPUnitRector;
 
 /**
  * Before:
@@ -19,7 +19,7 @@ use Rector\Rector\AbstractRector;
  * - $this->expectExceptionMessage('Message');
  * - $this->expectExceptionCode('CODE');
  */
-final class DelegateExceptionArgumentsRector extends AbstractRector
+final class DelegateExceptionArgumentsRector extends AbstractPHPUnitRector
 {
     /**
      * @var string[]
@@ -27,16 +27,6 @@ final class DelegateExceptionArgumentsRector extends AbstractRector
     private $oldToNewMethod = [
         'setExpectedException' => 'expectExceptionMessage',
         'setExpectedExceptionRegExp' => 'expectExceptionMessageRegExp',
-    ];
-
-    /**
-     * @var string[]
-     */
-    private $phpUnitTestCaseClasses = [
-        // PHPUnit 5-
-        'PHPUnit_Framework_TestCase',
-        // PHPUnit 6+
-        'PHPUnit\Framework\TestCase',
     ];
 
     /**
@@ -57,9 +47,12 @@ final class DelegateExceptionArgumentsRector extends AbstractRector
 
     public function isCandidate(Node $node): bool
     {
-        if (! $this->methodCallAnalyzer->isTypesAndMethods(
+        if (! $this->isInTestClass($node)) {
+            return false;
+        }
+
+        if (! $this->methodCallAnalyzer->isMethods(
             $node,
-            $this->phpUnitTestCaseClasses,
             array_keys($this->oldToNewMethod)
         )) {
             return false;

--- a/src/Rector/Contrib/PHPUnit/ExceptionAnnotationRector.php
+++ b/src/Rector/Contrib/PHPUnit/ExceptionAnnotationRector.php
@@ -7,7 +7,7 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
 use Rector\Node\MethodCallNodeFactory;
-use Rector\Rector\AbstractRector;
+use Rector\Rector\AbstractPHPUnitRector;
 use Rector\ReflectionDocBlock\NodeAnalyzer\DocBlockAnalyzer;
 
 /**
@@ -19,7 +19,7 @@ use Rector\ReflectionDocBlock\NodeAnalyzer\DocBlockAnalyzer;
  * - $this->expectException('Exception');
  * - $this->expectExceptionMessage('Message');
  */
-final class ExceptionAnnotationRector extends AbstractRector
+final class ExceptionAnnotationRector extends AbstractPHPUnitRector
 {
     /**
      * In reversed order, which they should be called in code.
@@ -51,6 +51,10 @@ final class ExceptionAnnotationRector extends AbstractRector
 
     public function isCandidate(Node $node): bool
     {
+        if (! $this->isInTestClass($node)) {
+            return false;
+        }
+
         if (! $node instanceof ClassMethod) {
             return false;
         }

--- a/src/Rector/Contrib/PHPUnit/GetMockRector.php
+++ b/src/Rector/Contrib/PHPUnit/GetMockRector.php
@@ -2,13 +2,11 @@
 
 namespace Rector\Rector\Contrib\PHPUnit;
 
-use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
-use Rector\Node\Attribute;
 use Rector\NodeAnalyzer\MethodCallAnalyzer;
 use Rector\NodeChanger\IdentifierRenamer;
-use Rector\Rector\AbstractRector;
+use Rector\Rector\AbstractPHPUnitRector;
 
 /**
  * Before:
@@ -18,7 +16,7 @@ use Rector\Rector\AbstractRector;
  * After:
  * - $this->createMock('Class')
  */
-final class GetMockRector extends AbstractRector
+final class GetMockRector extends AbstractPHPUnitRector
 {
     /**
      * @var MethodCallAnalyzer
@@ -61,12 +59,5 @@ final class GetMockRector extends AbstractRector
         $this->identifierRenamer->renameNode($methodCallNode, 'createMock');
 
         return $methodCallNode;
-    }
-
-    private function isInTestClass(Node $node): bool
-    {
-        $className = $node->getAttribute(Attribute::CLASS_NAME);
-
-        return Strings::endsWith((string) $className, 'Test');
     }
 }

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertCompareToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertCompareToSpecificMethodRector.php
@@ -93,13 +93,9 @@ final class AssertCompareToSpecificMethodRector extends AbstractPHPUnitRector
         }
 
         $methodName = $secondArgumentValue->name->toString();
-        if (! isset($this->defaultOldToNewMethods[$methodName])) {
-            return false;
-        }
-
         $this->activeFuncCallName = $methodName;
 
-        return true;
+        return isset($this->defaultOldToNewMethods[$methodName]);
     }
 
     /**

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertCompareToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertCompareToSpecificMethodRector.php
@@ -13,7 +13,7 @@ use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Scalar\String_;
 use Rector\NodeAnalyzer\MethodCallAnalyzer;
 use Rector\NodeChanger\IdentifierRenamer;
-use Rector\Rector\AbstractRector;
+use Rector\Rector\AbstractPHPUnitRector;
 
 /**
  * Before:
@@ -28,7 +28,7 @@ use Rector\Rector\AbstractRector;
  * - $this->assert{function}($value, $anything, 'message');
  * - $this->assertNot{function}($value, $anything, 'message');
  */
-final class AssertCompareToSpecificMethodRector extends AbstractRector
+final class AssertCompareToSpecificMethodRector extends AbstractPHPUnitRector
 {
     /**
      * @var string[][]|false[][]
@@ -63,9 +63,12 @@ final class AssertCompareToSpecificMethodRector extends AbstractRector
 
     public function isCandidate(Node $node): bool
     {
-        if (! $this->methodCallAnalyzer->isTypesAndMethods(
+        if (! $this->isInTestClass($node)) {
+            return false;
+        }
+
+        if (! $this->methodCallAnalyzer->isMethods(
             $node,
-            ['PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase'],
             ['assertSame', 'assertNotSame', 'assertEquals', 'assertNotEquals']
         )) {
             return false;

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertComparisonToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertComparisonToSpecificMethodRector.php
@@ -64,10 +64,7 @@ final class AssertComparisonToSpecificMethodRector extends AbstractPHPUnitRector
             return false;
         }
 
-        if (! $this->methodCallAnalyzer->isMethods(
-            $node,
-            ['assertTrue', 'assertFalse']
-        )) {
+        if (! $this->methodCallAnalyzer->isMethods($node, ['assertTrue', 'assertFalse'])) {
             return false;
         }
 

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertComparisonToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertComparisonToSpecificMethodRector.php
@@ -9,7 +9,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Identifier;
 use Rector\NodeAnalyzer\MethodCallAnalyzer;
 use Rector\NodeChanger\IdentifierRenamer;
-use Rector\Rector\AbstractRector;
+use Rector\Rector\AbstractPHPUnitRector;
 
 /**
  * - Before:
@@ -20,7 +20,7 @@ use Rector\Rector\AbstractRector;
  * - $this->assertSame($bar, $foo, 'message');
  * - $this->assertLessThanOrEqual($bar, $foo, 'message');
  */
-final class AssertComparisonToSpecificMethodRector extends AbstractRector
+final class AssertComparisonToSpecificMethodRector extends AbstractPHPUnitRector
 {
     /**
      * @var string[][]|false[][]
@@ -60,9 +60,12 @@ final class AssertComparisonToSpecificMethodRector extends AbstractRector
 
     public function isCandidate(Node $node): bool
     {
-        if (! $this->methodCallAnalyzer->isTypesAndMethods(
+        if (! $this->isInTestClass($node)) {
+            return false;
+        }
+
+        if (! $this->methodCallAnalyzer->isMethods(
             $node,
-            ['PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase'],
             ['assertTrue', 'assertFalse']
         )) {
             return false;

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertFalseStrposToContainsRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertFalseStrposToContainsRector.php
@@ -3,9 +3,11 @@
 namespace Rector\Rector\Contrib\PHPUnit\SpecificMethod;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
 use Rector\NodeAnalyzer\MethodCallAnalyzer;
 use Rector\NodeChanger\IdentifierRenamer;
 use Rector\Rector\AbstractPHPUnitRector;
@@ -51,7 +53,7 @@ final class AssertFalseStrposToContainsRector extends AbstractPHPUnitRector
         }
 
         $firstArgumentValue = $node->args[0]->value;
-        if (! $firstArgumentValue instanceof FuncCall) {
+        if (! $this->isNamedFunction($firstArgumentValue)) {
             return false;
         }
 
@@ -96,5 +98,15 @@ final class AssertFalseStrposToContainsRector extends AbstractPHPUnitRector
         } else {
             $this->identifierRenamer->renameNode($methodCallNode, 'assertContains');
         }
+    }
+
+    private function isNamedFunction(Expr $node): bool
+    {
+        if (! $node instanceof FuncCall) {
+            return false;
+        }
+
+        $functionName = $node->name;
+        return $functionName instanceof Name;
     }
 }

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertFalseStrposToContainsRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertFalseStrposToContainsRector.php
@@ -8,7 +8,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Identifier;
 use Rector\NodeAnalyzer\MethodCallAnalyzer;
 use Rector\NodeChanger\IdentifierRenamer;
-use Rector\Rector\AbstractRector;
+use Rector\Rector\AbstractPHPUnitRector;
 
 /**
  * Before:
@@ -19,7 +19,7 @@ use Rector\Rector\AbstractRector;
  * - $this->assertNotContains('foo', $anything, 'message');
  * - $this->assertContains('foo', $anything, 'message');
  */
-final class AssertFalseStrposToContainsRector extends AbstractRector
+final class AssertFalseStrposToContainsRector extends AbstractPHPUnitRector
 {
     /**
      * @var MethodCallAnalyzer
@@ -39,9 +39,12 @@ final class AssertFalseStrposToContainsRector extends AbstractRector
 
     public function isCandidate(Node $node): bool
     {
-        if (! $this->methodCallAnalyzer->isTypesAndMethods(
+        if (! $this->isInTestClass($node)) {
+            return false;
+        }
+
+        if (! $this->methodCallAnalyzer->isMethods(
             $node,
-            ['PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase'],
             ['assertFalse', 'assertNotFalse']
         )) {
             return false;

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertFalseStrposToContainsRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertFalseStrposToContainsRector.php
@@ -45,10 +45,7 @@ final class AssertFalseStrposToContainsRector extends AbstractPHPUnitRector
             return false;
         }
 
-        if (! $this->methodCallAnalyzer->isMethods(
-            $node,
-            ['assertFalse', 'assertNotFalse']
-        )) {
+        if (! $this->methodCallAnalyzer->isMethods($node, ['assertFalse', 'assertNotFalse'])) {
             return false;
         }
 

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertInstanceOfComparisonRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertInstanceOfComparisonRector.php
@@ -53,10 +53,7 @@ final class AssertInstanceOfComparisonRector extends AbstractPHPUnitRector
             return false;
         }
 
-        if (! $this->methodCallAnalyzer->isMethods(
-            $node,
-            ['assertTrue', 'assertFalse']
-        )) {
+        if (! $this->methodCallAnalyzer->isMethods($node, ['assertTrue', 'assertFalse'])) {
             return false;
         }
 

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertInstanceOfComparisonRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertInstanceOfComparisonRector.php
@@ -9,7 +9,7 @@ use PhpParser\Node\Identifier;
 use Rector\Node\NodeFactory;
 use Rector\NodeAnalyzer\MethodCallAnalyzer;
 use Rector\NodeChanger\IdentifierRenamer;
-use Rector\Rector\AbstractRector;
+use Rector\Rector\AbstractPHPUnitRector;
 
 /**
  * - Before:
@@ -20,7 +20,7 @@ use Rector\Rector\AbstractRector;
  * - $this->assertInstanceOf(Foo::class, $foo, 'message');
  * - $this->assertNotInstanceOf(Foo::class, $foo, 'message');
  */
-final class AssertInstanceOfComparisonRector extends AbstractRector
+final class AssertInstanceOfComparisonRector extends AbstractPHPUnitRector
 {
     /**
      * @var MethodCallAnalyzer
@@ -49,9 +49,12 @@ final class AssertInstanceOfComparisonRector extends AbstractRector
 
     public function isCandidate(Node $node): bool
     {
-        if (! $this->methodCallAnalyzer->isTypesAndMethods(
+        if (! $this->isInTestClass($node)) {
+            return false;
+        }
+
+        if (! $this->methodCallAnalyzer->isMethods(
             $node,
-            ['PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase'],
             ['assertTrue', 'assertFalse']
         )) {
             return false;

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertIssetToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertIssetToSpecificMethodRector.php
@@ -54,10 +54,7 @@ final class AssertIssetToSpecificMethodRector extends AbstractPHPUnitRector
             return false;
         }
 
-        if (! $this->methodCallAnalyzer->isMethods(
-            $node,
-            ['assertTrue', 'assertFalse']
-        )) {
+        if (! $this->methodCallAnalyzer->isMethods($node, ['assertTrue', 'assertFalse'])) {
             return false;
         }
 

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertIssetToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertIssetToSpecificMethodRector.php
@@ -10,7 +10,7 @@ use PhpParser\Node\Expr\PropertyFetch;
 use Rector\Node\NodeFactory;
 use Rector\NodeAnalyzer\MethodCallAnalyzer;
 use Rector\NodeChanger\IdentifierRenamer;
-use Rector\Rector\AbstractRector;
+use Rector\Rector\AbstractPHPUnitRector;
 
 /**
  * Before:
@@ -21,7 +21,7 @@ use Rector\Rector\AbstractRector;
  * - $this->assertObjectHasAttribute('foo', $anything);
  * - $this->assertArrayNotHasKey('foo', $anything, 'message');
  */
-final class AssertIssetToSpecificMethodRector extends AbstractRector
+final class AssertIssetToSpecificMethodRector extends AbstractPHPUnitRector
 {
     /**
      * @var MethodCallAnalyzer
@@ -50,9 +50,12 @@ final class AssertIssetToSpecificMethodRector extends AbstractRector
 
     public function isCandidate(Node $node): bool
     {
-        if (! $this->methodCallAnalyzer->isTypesAndMethods(
+        if (! $this->isInTestClass($node)) {
+            return false;
+        }
+
+        if (! $this->methodCallAnalyzer->isMethods(
             $node,
-            ['PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase'],
             ['assertTrue', 'assertFalse']
         )) {
             return false;

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertSameBoolNullToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertSameBoolNullToSpecificMethodRector.php
@@ -8,7 +8,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Identifier;
 use Rector\NodeAnalyzer\MethodCallAnalyzer;
 use Rector\NodeChanger\IdentifierRenamer;
-use Rector\Rector\AbstractRector;
+use Rector\Rector\AbstractPHPUnitRector;
 
 /**
  * Before:
@@ -19,7 +19,7 @@ use Rector\Rector\AbstractRector;
  * - $this->assertNull($anything);
  * - $this->assertNotFalse($anything);
  */
-final class AssertSameBoolNullToSpecificMethodRector extends AbstractRector
+final class AssertSameBoolNullToSpecificMethodRector extends AbstractPHPUnitRector
 {
     /**
      * @var string[][]|false[][]
@@ -53,9 +53,12 @@ final class AssertSameBoolNullToSpecificMethodRector extends AbstractRector
 
     public function isCandidate(Node $node): bool
     {
-        if (! $this->methodCallAnalyzer->isTypesAndMethods(
+        if (! $this->isInTestClass($node)) {
+            return false;
+        }
+
+        if (! $this->methodCallAnalyzer->isMethods(
             $node,
-            ['PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase'],
             ['assertSame', 'assertNotSame']
         )) {
             return false;

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertSameBoolNullToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertSameBoolNullToSpecificMethodRector.php
@@ -57,10 +57,7 @@ final class AssertSameBoolNullToSpecificMethodRector extends AbstractPHPUnitRect
             return false;
         }
 
-        if (! $this->methodCallAnalyzer->isMethods(
-            $node,
-            ['assertSame', 'assertNotSame']
-        )) {
+        if (! $this->methodCallAnalyzer->isMethods($node, ['assertSame', 'assertNotSame'])) {
             return false;
         }
 

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertTrueFalseInternalTypeToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertTrueFalseInternalTypeToSpecificMethodRector.php
@@ -88,6 +88,7 @@ final class AssertTrueFalseInternalTypeToSpecificMethodRector extends AbstractPH
         /** @var MethodCall $methodCallNode */
         $methodCallNode = $node;
 
+        /** @var FuncCall $firstArgumentValue */
         $firstArgumentValue = $methodCallNode->args[0]->value;
         if (! $this->isNamedFunction($firstArgumentValue)) {
             return false;

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertTrueFalseInternalTypeToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertTrueFalseInternalTypeToSpecificMethodRector.php
@@ -3,8 +3,10 @@
 namespace Rector\Rector\Contrib\PHPUnit\SpecificMethod;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Name;
 use Rector\Node\NodeFactory;
 use Rector\NodeAnalyzer\MethodCallAnalyzer;
 use Rector\NodeChanger\IdentifierRenamer;
@@ -90,7 +92,7 @@ final class AssertTrueFalseInternalTypeToSpecificMethodRector extends AbstractPH
         $methodCallNode = $node;
 
         $firstArgumentValue = $methodCallNode->args[0]->value;
-        if (! $firstArgumentValue instanceof FuncCall) {
+        if (! $this->isNamedFunction($firstArgumentValue)) {
             return false;
         }
 
@@ -124,5 +126,15 @@ final class AssertTrueFalseInternalTypeToSpecificMethodRector extends AbstractPH
             $this->nodeFactory->createString($this->oldMethodsToTypes[$isFunctionName]),
             $argument,
         ], $oldArguments);
+    }
+
+    private function isNamedFunction(Expr $node): bool
+    {
+        if (! $node instanceof FuncCall) {
+            return false;
+        }
+
+        $functionName = $node->name;
+        return $functionName instanceof Name;
     }
 }

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertTrueFalseInternalTypeToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertTrueFalseInternalTypeToSpecificMethodRector.php
@@ -81,10 +81,7 @@ final class AssertTrueFalseInternalTypeToSpecificMethodRector extends AbstractPH
             return false;
         }
 
-        if (! $this->methodCallAnalyzer->isMethods(
-            $node,
-            array_keys($this->renameMethodsMap)
-        )) {
+        if (! $this->methodCallAnalyzer->isMethods($node, array_keys($this->renameMethodsMap))) {
             return false;
         }
 

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertTrueFalseInternalTypeToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertTrueFalseInternalTypeToSpecificMethodRector.php
@@ -8,7 +8,7 @@ use PhpParser\Node\Expr\MethodCall;
 use Rector\Node\NodeFactory;
 use Rector\NodeAnalyzer\MethodCallAnalyzer;
 use Rector\NodeChanger\IdentifierRenamer;
-use Rector\Rector\AbstractRector;
+use Rector\Rector\AbstractPHPUnitRector;
 
 /**
  * Before:
@@ -19,7 +19,7 @@ use Rector\Rector\AbstractRector;
  * - $this->assertInternalType({internal_type}, $anything, 'message');
  * - $this->assertNotInternalType({internal_type}, $anything, 'message');
  */
-final class AssertTrueFalseInternalTypeToSpecificMethodRector extends AbstractRector
+final class AssertTrueFalseInternalTypeToSpecificMethodRector extends AbstractPHPUnitRector
 {
     /**
      * @var string[]
@@ -75,9 +75,12 @@ final class AssertTrueFalseInternalTypeToSpecificMethodRector extends AbstractRe
 
     public function isCandidate(Node $node): bool
     {
-        if (! $this->methodCallAnalyzer->isTypesAndMethods(
+        if (! $this->isInTestClass($node)) {
+            return false;
+        }
+
+        if (! $this->methodCallAnalyzer->isMethods(
             $node,
-            ['PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase'],
             array_keys($this->renameMethodsMap)
         )) {
             return false;

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertTrueFalseToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertTrueFalseToSpecificMethodRector.php
@@ -171,7 +171,9 @@ final class AssertTrueFalseToSpecificMethodRector extends AbstractPHPUnitRector
 
     private function resolveFunctionName(Node $node): ?string
     {
-        if ($node instanceof FuncCall) {
+        if ($node instanceof FuncCall
+            && $node->name instanceof Name
+        ) {
             /** @var Name $nameNode */
             $nameNode = $node->name;
 

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertTrueFalseToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertTrueFalseToSpecificMethodRector.php
@@ -105,13 +105,9 @@ final class AssertTrueFalseToSpecificMethodRector extends AbstractPHPUnitRector
             return false;
         }
 
-        if (! isset($this->activeOldToNewMethods[$funcCallName])) {
-            return false;
-        }
-
         $this->activeFuncCallName = $funcCallName;
 
-        return true;
+        return isset($this->activeOldToNewMethods[$funcCallName]);
     }
 
     /**

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertTrueFalseToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertTrueFalseToSpecificMethodRector.php
@@ -11,7 +11,7 @@ use PhpParser\Node\Name;
 use Rector\Node\NodeFactory;
 use Rector\NodeAnalyzer\MethodCallAnalyzer;
 use Rector\NodeChanger\IdentifierRenamer;
-use Rector\Rector\AbstractRector;
+use Rector\Rector\AbstractPHPUnitRector;
 
 /**
  * Before:
@@ -20,7 +20,7 @@ use Rector\Rector\AbstractRector;
  * After:
  * - $this->assertIsReadable($readmeFile, 'message'));
  */
-final class AssertTrueFalseToSpecificMethodRector extends AbstractRector
+final class AssertTrueFalseToSpecificMethodRector extends AbstractPHPUnitRector
 {
     /**
      * @var string[][]|false[][]
@@ -82,9 +82,12 @@ final class AssertTrueFalseToSpecificMethodRector extends AbstractRector
 
     public function isCandidate(Node $node): bool
     {
-        if (! $this->methodCallAnalyzer->isTypesAndMethods(
+        if (! $this->isInTestClass($node)) {
+            return false;
+        }
+
+        if (! $this->methodCallAnalyzer->isMethods(
             $node,
-            ['PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase'],
             ['assertTrue', 'assertFalse']
         )) {
             return false;

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertTrueFalseToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertTrueFalseToSpecificMethodRector.php
@@ -86,10 +86,7 @@ final class AssertTrueFalseToSpecificMethodRector extends AbstractPHPUnitRector
             return false;
         }
 
-        if (! $this->methodCallAnalyzer->isMethods(
-            $node,
-            ['assertTrue', 'assertFalse']
-        )) {
+        if (! $this->methodCallAnalyzer->isMethods($node, ['assertTrue', 'assertFalse'])) {
             return false;
         }
 


### PR DESCRIPTION
This PR solves some problems with PHPUnit Rectors:
- Some assertions weren't being refactored if they extended a `BaseTestCase` class, not PHPUnit's;
- Unify how we candidate our classes to look up for assertions: end with `Test`, as it [is the standard in PHPUnit](https://phpunit.de/getting-started-with-phpunit.html). In the feature, we can remove this check, looking up just for the assertions, but only when improving the speed of Rector.

After that, a bug arises calling `toString` in FuncCall that are actually variables: `$method($argument)`, also fixed with this PR.