### PR TITLE
[Symfony] AddFlashRector

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -43,6 +43,7 @@ parameters:
         - '#Call to an undefined method PhpParser\\PrettyPrinter\\Standard::printFormatPreserving\(\)#' # 1
         - '#Array \(array<Rector\\BetterReflection\\Reflection\\ReflectionClass>\) does not accept Rector\\BetterReflection\\Reflection\\Reflection#' # 1
         - '#Method Rector\\Rector\\AbstractRector::leaveNode\(\) should return int\|PhpParser\\Node but returns bool#'
+        - '#Access to an undefined property PhpParser\\Node\\Expr::\$(name|var)#'
 
     excludes_analyse:
         # test files

--- a/src/NodeAnalyzer/ChainMethodCallAnalyzer.php
+++ b/src/NodeAnalyzer/ChainMethodCallAnalyzer.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+
+namespace Rector\NodeAnalyzer;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use Rector\NodeTypeResolver\NodeTypeResolver;
+
+final class ChainMethodCallAnalyzer
+{
+    /**
+     * @var NodeTypeResolver
+     */
+    private $nodeTypeResolver;
+
+    public function __construct(NodeTypeResolver $nodeTypeResolver)
+    {
+        $this->nodeTypeResolver = $nodeTypeResolver;
+    }
+
+    /**
+     * Checks "$this->someMethod()->anotherMethod()"
+     *
+     * @param string[] $methods
+     */
+    public function isTypeAndChainCalls(Node $node, string $type, array $methods): bool
+    {
+        if (! $node instanceof MethodCall) {
+            return false;
+        }
+
+        // node chaining is in reverse order than code
+        $methods = array_reverse($methods);
+
+        $currentMethodCall = $node;
+
+        foreach ($methods as $method) {
+            if ((string) $currentMethodCall->name !== $method) {
+                return false;
+            }
+
+            $currentMethodCall = $currentMethodCall->var;
+            if ($currentMethodCall instanceof MethodCall) {
+                continue;
+            }
+        }
+
+        $variableTypes = $this->nodeTypeResolver->resolve($currentMethodCall);
+
+        return in_array($type, $variableTypes, true);
+    }
+}

--- a/src/Rector/Contrib/Symfony/Controller/AddFlashRector.php
+++ b/src/Rector/Contrib/Symfony/Controller/AddFlashRector.php
@@ -59,7 +59,7 @@ final class AddFlashRector extends AbstractRector
         return $this->methodCallNodeFactory->createWithVariableNameMethodNameAndArguments(
             'this',
             'addFlash',
-            [] // todo arguments of last method
+            $node->args
         );
     }
 }

--- a/src/Rector/Contrib/Symfony/Controller/AddFlashRector.php
+++ b/src/Rector/Contrib/Symfony/Controller/AddFlashRector.php
@@ -12,7 +12,7 @@ use Rector\Rector\AbstractRector;
  * Before:
  * $request->getSession()->getFlashBag()->add('success', 'something');
  * After:
- * $this->>addflash('success', 'something');
+ * $this->addflash('success', 'something');
  */
 final class AddFlashRector extends AbstractRector
 {

--- a/src/Rector/Contrib/Symfony/Controller/AddFlashRector.php
+++ b/src/Rector/Contrib/Symfony/Controller/AddFlashRector.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Rector\Contrib\Symfony\Controller;
+
+use PhpParser\Node;
+use Rector\Node\Attribute;
+use Rector\Node\MethodCallNodeFactory;
+use Rector\NodeAnalyzer\MethodCallAnalyzer;
+use Rector\Rector\AbstractRector;
+
+/**
+ * Before:
+ * $request->getSession()->getFlashBag()->add('success', 'something');
+ * After:
+ * $this->>addflash('success', 'something');
+ */
+final class AddFlashRector extends AbstractRector
+{
+    /**
+     * @var MethodCallAnalyzer
+     */
+    private $methodCallAnalyzer;
+
+    /**
+     * @var MethodCallNodeFactory
+     */
+    private $methodCallNodeFactory;
+
+    public function __construct(
+        MethodCallAnalyzer $methodCallAnalyzer,
+        MethodCallNodeFactory $methodCallNodeFactory
+    ) {
+        $this->methodCallAnalyzer = $methodCallAnalyzer;
+        $this->methodCallNodeFactory = $methodCallNodeFactory;
+    }
+
+    public function isCandidate(Node $node): bool
+    {
+        $parentClassName = $node->getAttribute(Attribute::PARENT_CLASS_NAME);
+        if ($parentClassName !== 'Symfony\Bundle\FrameworkBundle\Controller\Controller') {
+            return false;
+        }
+
+        if (! $this->methodCallAnalyzer->isTypeAndMethod(
+            $node,
+            'Symfony\Component\HttpFoundation\Request',
+            'getSession'
+        )) {
+            return false;
+        }
+
+        if ($node->getAttribute(Attribute::NEXT_NODE)->name !== 'getFlashBag') {
+            return false;
+        }
+
+        // add check for add method
+        return true;
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        return $this->methodCallNodeFactory->createWithVariableNameMethodNameAndArguments(
+            'this',
+            'addFlash',
+            [] // todo arguments of last method
+        );
+    }
+}

--- a/src/config/level/symfony/symfony26.yml
+++ b/src/config/level/symfony/symfony26.yml
@@ -1,2 +1,3 @@
 rectors:
     Rector\Rector\Contrib\Symfony\Controller\RedirectToRouteRector: ~
+    Rector\Rector\Contrib\Symfony\Controller\AddFlashRector: ~

--- a/tests/Rector/Contrib/Symfony/Controller/AddFlashRector/AddFlashRectorTest.php
+++ b/tests/Rector/Contrib/Symfony/Controller/AddFlashRector/AddFlashRectorTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Tests\Rector\Contrib\Symfony\Controller\RedirectToRouteRector;
+
+use Rector\Rector\Contrib\Symfony\Controller\AddFlashRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AddFlashRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideWrongToFixedFiles()
+     */
+    public function test(string $wrong, string $fixed): void
+    {
+        $this->doTestFileMatchesExpectedContent($wrong, $fixed);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function provideWrongToFixedFiles(): array
+    {
+        return [
+            [__DIR__ . '/Wrong/wrong.php.inc', __DIR__ . '/Correct/correct.php.inc'],
+            [__DIR__ . '/Wrong/wrong2.php.inc', __DIR__ . '/Correct/correct2.php.inc'],
+        ];
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getRectorClasses(): array
+    {
+        return [AddFlashRector::class];
+    }
+}

--- a/tests/Rector/Contrib/Symfony/Controller/AddFlashRector/AddFlashRectorTest.php
+++ b/tests/Rector/Contrib/Symfony/Controller/AddFlashRector/AddFlashRectorTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Rector\Tests\Rector\Contrib\Symfony\Controller\RedirectToRouteRector;
+namespace Rector\Tests\Rector\Contrib\Symfony\Controller\AddFlashRector;
 
 use Rector\Rector\Contrib\Symfony\Controller\AddFlashRector;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;

--- a/tests/Rector/Contrib/Symfony/Controller/AddFlashRector/Correct/correct.php.inc
+++ b/tests/Rector/Contrib/Symfony/Controller/AddFlashRector/Correct/correct.php.inc
@@ -1,0 +1,12 @@
+<?php declare (strict_types=1);
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+
+class AppController extends Controller
+{
+    public function someAction(Request $request)
+    {
+        $this->addFlash('success', 'message');
+    }
+}

--- a/tests/Rector/Contrib/Symfony/Controller/AddFlashRector/Correct/correct2.php.inc
+++ b/tests/Rector/Contrib/Symfony/Controller/AddFlashRector/Correct/correct2.php.inc
@@ -1,0 +1,11 @@
+<?php declare (strict_types=1);
+
+use Symfony\Component\HttpFoundation\Request;
+
+class AnyClass
+{
+    public function someAction(Request $request)
+    {
+        $request->getSession()->getFlashBag()->add('success', 'message');
+    }
+}

--- a/tests/Rector/Contrib/Symfony/Controller/AddFlashRector/Wrong/wrong.php.inc
+++ b/tests/Rector/Contrib/Symfony/Controller/AddFlashRector/Wrong/wrong.php.inc
@@ -1,0 +1,12 @@
+<?php declare (strict_types=1);
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+
+class AppController extends Controller
+{
+    public function someAction(Request $request)
+    {
+        $request->getSession()->getFlashBag()->add('success', 'message');
+    }
+}

--- a/tests/Rector/Contrib/Symfony/Controller/AddFlashRector/Wrong/wrong2.php.inc
+++ b/tests/Rector/Contrib/Symfony/Controller/AddFlashRector/Wrong/wrong2.php.inc
@@ -1,0 +1,11 @@
+<?php declare (strict_types=1);
+
+use Symfony\Component\HttpFoundation\Request;
+
+class AnyClass
+{
+    public function someAction(Request $request)
+    {
+        $request->getSession()->getFlashBag()->add('success', 'message');
+    }
+}


### PR DESCRIPTION
Hey added rector simplifying adding flash messages. Helper method addFlash was introduced in SF 2.6.

```php
/**
 * Before:
 * $request->getSession()->getFlashBag()->add('success', 'something');
 * After:
 * $this->addflash('success', 'something');
 */
```
It is not finished, if you could help me out, It will be great. I added tests, config and I need help with finishing rector as i'm stuck with it now. Thx.