### PR TITLE
[PHPUnit] Safe way to check if a class is a Test class

### DIFF
--- a/easy-coding-standard.neon
+++ b/easy-coding-standard.neon
@@ -46,6 +46,7 @@ parameters:
             - */packages/NodeTypeResolver/**/PerNodeTypeResolver/**TypeResolver.php
             - */packages/NodeTypeResolver/**/PerNodeTypeResolver/**TypeResolver/*Test.php
             - packages/BetterReflection/src/Reflector/SmartClassReflector.php
+            - src/Rector/AbstractPHPUnitRector.php
 
     skip_codes:
         # empty arguments passing

--- a/src/NodeValueResolver/ConstExprEvaluatorFactory.php
+++ b/src/NodeValueResolver/ConstExprEvaluatorFactory.php
@@ -23,8 +23,7 @@ final class ConstExprEvaluatorFactory
 
     private function resolveClassConstFetch(ClassConstFetch $classConstFetchNode): string
     {
-        $class = $classConstFetchNode->class->getAttribute(Attribute::RESOLVED_NAME)
-            ->toString();
+        $class = $classConstFetchNode->class->getAttribute(Attribute::RESOLVED_NAME)->toString();
 
         /** @var Identifier $identifierNode */
         $identifierNode = $classConstFetchNode->name;

--- a/src/Rector/AbstractPHPUnitRector.php
+++ b/src/Rector/AbstractPHPUnitRector.php
@@ -3,7 +3,6 @@
 namespace Rector\Rector;
 
 use PhpParser\Node;
-use PHPUnit\Framework\TestCase;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 
 abstract class AbstractPHPUnitRector extends AbstractRector
@@ -27,6 +26,6 @@ abstract class AbstractPHPUnitRector extends AbstractRector
     {
         $nodeResolved = $this->nodeTypeResolver->resolve($node);
 
-        return ! array_intersect([TestCase::class, 'PHPUnit_Framework_TestCase'], $nodeResolved);
+        return ! array_intersect(['PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase'], $nodeResolved);
     }
 }

--- a/src/Rector/AbstractPHPUnitRector.php
+++ b/src/Rector/AbstractPHPUnitRector.php
@@ -8,12 +8,25 @@ use Rector\NodeTypeResolver\NodeTypeResolver;
 
 abstract class AbstractPHPUnitRector extends AbstractRector
 {
+    /**
+     * @var NodeTypeResolver
+     */
+    private $nodeTypeResolver;
+
+    /**
+     * Nasty magic, unable to do that in config autowire _instanceof calls.
+     *
+     * @required
+     */
+    public function setNodeTypeResolver(NodeTypeResolver $nodeTypeResolver): void
+    {
+        $this->nodeTypeResolver = $nodeTypeResolver;
+    }
+
     protected function isInTestClass(Node $node): bool
     {
-        $nodeTypeResolver = new NodeTypeResolver();
+        $nodeResolved = $this->nodeTypeResolver->resolve($node);
 
-        $nodeResolved = $nodeTypeResolver->resolve($node);
-
-        return (bool) ! array_intersect([TestCase::class, 'PHPUnit_Framework_TestCase'], $nodeResolved);
+        return ! array_intersect([TestCase::class, 'PHPUnit_Framework_TestCase'], $nodeResolved);
     }
 }

--- a/src/Rector/AbstractPHPUnitRector.php
+++ b/src/Rector/AbstractPHPUnitRector.php
@@ -4,14 +4,16 @@ namespace Rector\Rector;
 
 use PhpParser\Node;
 use PHPUnit\Framework\TestCase;
-use Rector\Node\Attribute;
+use Rector\NodeTypeResolver\NodeTypeResolver;
 
 abstract class AbstractPHPUnitRector extends AbstractRector
 {
     protected function isInTestClass(Node $node): bool
     {
-        $parentClassName = (string) $node->getAttribute(Attribute::PARENT_CLASS_NAME);
+        $nodeTypeResolver = new NodeTypeResolver();
 
-        return in_array($parentClassName, [TestCase::class, 'PHPUnit_Framework_TestCase'], true);
+        $nodeResolved = $nodeTypeResolver->resolve($node);
+
+        return (bool) ! array_intersect([TestCase::class, 'PHPUnit_Framework_TestCase'], $nodeResolved);
     }
 }

--- a/src/Rector/AbstractPHPUnitRector.php
+++ b/src/Rector/AbstractPHPUnitRector.php
@@ -2,21 +2,16 @@
 
 namespace Rector\Rector;
 
-use Nette\Utils\Strings;
 use PhpParser\Node;
+use PHPUnit\Framework\TestCase;
 use Rector\Node\Attribute;
 
 abstract class AbstractPHPUnitRector extends AbstractRector
 {
-    /**
-     * Check if the file is a PHPUnit TestCase. By default, it should end with "Test", as it is the standard.
-     *
-     * @see https://phpunit.de/getting-started-with-phpunit.html
-     */
     protected function isInTestClass(Node $node): bool
     {
-        $className = (string) $node->getAttribute(Attribute::CLASS_NAME);
+        $parentClassName = (string) $node->getAttribute(Attribute::PARENT_CLASS_NAME);
 
-        return Strings::endsWith($className, 'Test');
+        return in_array($parentClassName, [TestCase::class, 'PHPUnit_Framework_TestCase'], true);
     }
 }

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertTrueFalseToSpecificMethodRector/Correct/correct.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertTrueFalseToSpecificMethodRector/Correct/correct.php.inc
@@ -1,6 +1,10 @@
 <?php declare(strict_types=1);
 
-final class MyTest extends \PHPUnit\Framework\TestCase
+abstract class Testing extends \PHPUnit\Framework\TestCase
+{
+}
+
+final class MyTest extends Testing
 {
     public function test()
     {

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertTrueFalseToSpecificMethodRector/Wrong/wrong.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertTrueFalseToSpecificMethodRector/Wrong/wrong.php.inc
@@ -1,6 +1,10 @@
 <?php declare(strict_types=1);
 
-final class MyTest extends \PHPUnit\Framework\TestCase
+abstract class Testing extends \PHPUnit\Framework\TestCase
+{
+}
+
+final class MyTest extends Testing
 {
     public function test()
     {


### PR DESCRIPTION
The current logic checks if the TestCase ends with `Test`, but this isn't the safest way to do it. For example:
```php
<?php
class TestingCase extends \PHPUnit\Framework\TestCase {}

class MyTestCase extends TestingCase {}
```