### PR TITLE
[Tests] Skip tests that require PHP 7.1 or lower

### DIFF
--- a/tests/Rector/Contrib/Nette/Utils/MagicMethodRector/MagicMethodRectorTest.php
+++ b/tests/Rector/Contrib/Nette/Utils/MagicMethodRector/MagicMethodRectorTest.php
@@ -14,6 +14,10 @@ final class MagicMethodRectorTest extends AbstractRectorTestCase
      */
     public function test(string $wrong, string $fixed): void
     {
+        if (PHP_VERSION > '7.2.0') {
+            $this->markTestSkipped('This test needs PHP 7.1 or lower.');
+        }
+
         $this->doTestFileMatchesExpectedContent($wrong, $fixed);
     }
 

--- a/tests/Rector/Contrib/Nette/Utils/NetteObjectToSmartTraitRector/NetteObjectToSmartTraitRectorTest.php
+++ b/tests/Rector/Contrib/Nette/Utils/NetteObjectToSmartTraitRector/NetteObjectToSmartTraitRectorTest.php
@@ -14,6 +14,10 @@ final class NetteObjectToSmartTraitRectorTest extends AbstractRectorTestCase
      */
     public function test(string $wrong, string $fixed): void
     {
+        if (PHP_VERSION > '7.2.0') {
+            $this->markTestSkipped('This test needs PHP 7.1 or lower.');
+        }
+
         $this->doTestFileMatchesExpectedContent($wrong, $fixed);
     }
 


### PR DESCRIPTION
This fixes #393 