### PR TITLE
Fix #387

### DIFF
--- a/packages/NodeTypeResolver/src/PerNodeTypeResolver/VariableTypeResolver.php
+++ b/packages/NodeTypeResolver/src/PerNodeTypeResolver/VariableTypeResolver.php
@@ -51,13 +51,13 @@ final class VariableTypeResolver implements PerNodeTypeResolverInterface, NodeTy
             return $this->nodeTypeResolver->resolve($classNode);
         }
 
+        if ($variableNode->name instanceof Variable) {
+            return $this->nodeTypeResolver->resolve($variableNode->name);
+        }
+
         $variableTypes = $this->typeContext->getTypesForVariable((string) $variableNode->name);
         if ($variableTypes) {
             return $variableTypes;
-        }
-
-        if ($variableNode->name instanceof Variable) {
-            return $this->nodeTypeResolver->resolve($variableNode->name);
         }
 
         return [];


### PR DESCRIPTION
This PR is a fixes #387. Unfortanly I couldn't find the code that was breaking, only the file: `tests/Loader/LoaderIntegrationTest.php` :disappointed: 

I just invert the logic to first check for a `Variable`, as the error was:
```
PHP Recoverable fatal error:  Object of class PhpParser\Node\Expr\Variable could not be converted to string in /home/carusogabriel/.composer/vendor/rector/rector/packages/NodeTypeResolver/src/PerNodeTypeResolver/VariableTypeResolver.php on line 54
```