### PR TITLE
Remove minimum stability "beta" as Symplify 4 was realeased

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,5 @@
     ],
     "config": {
         "sort-packages": true
-    },
-    "minimum-stability": "beta",
-    "prefer-stable": true
+    }    
 }


### PR DESCRIPTION
As well this was causing a lot of messages like `"but these conflict with your requirements or minimum-stability"` :)