### PR TITLE
Support PHPUnit 7.1 iterable type in assertInternalType Rector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require-dev": {
         "symplify/easy-coding-standard": "^4.0",
         "phpstan/phpstan-shim": "^0.9",
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^7.1",
         "slam/php-cs-fixer-extensions": "^1.13",
         "tracy/tracy": "^2.4"
     },
@@ -70,5 +70,5 @@
     ],
     "config": {
         "sort-packages": true
-    }    
+    }
 }

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertTrueFalseInternalTypeToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertTrueFalseInternalTypeToSpecificMethodRector.php
@@ -34,6 +34,7 @@ final class AssertTrueFalseInternalTypeToSpecificMethodRector extends AbstractPH
         'is_float' => 'float',
         'is_int' => 'int',
         'is_integer' => 'integer',
+        'is_iterable' => 'iterable',
         'is_numeric' => 'numeric',
         'is_object' => 'object',
         'is_real' => 'real',


### PR DESCRIPTION
PHPUnit 7.1 [was released yesterday](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-7.1.md#710---2018-04-06) with support for the `iterable` type.