### PR TITLE
Generalize AssertComparisonToSpecificMethodRector definition

### DIFF
--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertComparisonToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertComparisonToSpecificMethodRector.php
@@ -52,13 +52,19 @@ final class AssertComparisonToSpecificMethodRector extends AbstractPHPUnitRector
 
     public function getDefinition(): RectorDefinition
     {
-        return new RectorDefinition('Turns comparisons to their method name alternatives in PHPUnit TestCase', [
-            new CodeSample('$this->assertTrue($foo === $bar, "message");', '$this->assertSame($bar, $foo, "message");'),
-            new CodeSample(
-                '$this->assertFalse($foo >= $bar, "message");',
-                '$this->assertLessThanOrEqual($bar, $foo, "message");'
-            ),
-        ]);
+        return new RectorDefinition(
+            'Turns comparison operations to their method name alternatives in PHPUnit TestCase',
+            [
+                new CodeSample(
+                    '$this->assertTrue($foo === $bar, "message");',
+                    '$this->assertSame($bar, $foo, "message");'
+                ),
+                new CodeSample(
+                    '$this->assertFalse($foo >= $bar, "message");',
+                    '$this->assertLessThanOrEqual($bar, $foo, "message");'
+                ),
+            ]
+        );
     }
 
     public function isCandidate(Node $node): bool

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertComparisonToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertComparisonToSpecificMethodRector.php
@@ -52,7 +52,7 @@ final class AssertComparisonToSpecificMethodRector extends AbstractPHPUnitRector
 
     public function getDefinition(): RectorDefinition
     {
-        return new RectorDefinition('Turns === comparisons to their method name alternatives in PHPUnit TestCase', [
+        return new RectorDefinition('Turns comparisons to their method name alternatives in PHPUnit TestCase', [
             new CodeSample('$this->assertTrue($foo === $bar, "message");', '$this->assertSame($bar, $foo, "message");'),
             new CodeSample(
                 '$this->assertFalse($foo >= $bar, "message");',


### PR DESCRIPTION
Remove the `===`, as `AssertComparisonToSpecificMethodRector` have many comparions