### PR TITLE
Make AssertComparisonToSpecificMethodRector smarter

### DIFF
--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertComparisonToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertComparisonToSpecificMethodRector.php
@@ -116,10 +116,7 @@ final class AssertComparisonToSpecificMethodRector extends AbstractPHPUnitRector
         /** @var BinaryOp $expression */
         $expression = $oldArguments[0]->value;
 
-        if ($this->isConstantValue($expression->right)) {
-            $firstArgument = new Arg($expression->right);
-            $secondArgument = new Arg($expression->left);
-        } elseif ($this->isConstantValue($expression->left)) {
+        if ($this->isConstantValue($expression->left)) {
             $firstArgument = new Arg($expression->left);
             $secondArgument = new Arg($expression->right);
         } else {

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertComparisonToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertComparisonToSpecificMethodRector.php
@@ -116,17 +116,10 @@ final class AssertComparisonToSpecificMethodRector extends AbstractPHPUnitRector
         /** @var BinaryOp $expression */
         $expression = $oldArguments[0]->value;
 
-        if (in_array(get_class($expression->right), [LNumber::class, ConstFetch::class, String_::class], true)
-        ) {
+        if ($this->isConstantValue($expression->right)) {
             $firstArgument = new Arg($expression->right);
             $secondArgument = new Arg($expression->left);
-        } elseif (in_array(get_class($expression->left), [LNumber::class, ConstFetch::class, String_::class], true)) {
-            $firstArgument = new Arg($expression->left);
-            $secondArgument = new Arg($expression->right);
-        } elseif ($expression->right instanceof Variable && stripos($expression->right->name, 'exp') === 0) {
-            $firstArgument = new Arg($expression->right);
-            $secondArgument = new Arg($expression->left);
-        } elseif ($expression->left instanceof Variable && stripos($expression->left->name, 'exp') === 0) {
+        } elseif ($this->isConstantValue($expression->left)) {
             $firstArgument = new Arg($expression->left);
             $secondArgument = new Arg($expression->right);
         } else {
@@ -150,5 +143,11 @@ final class AssertComparisonToSpecificMethodRector extends AbstractPHPUnitRector
             'assertTrue' => $trueMethodName,
             'assertFalse' => $falseMethodName,
         ]);
+    }
+
+    private function isConstantValue(Node $node): bool
+    {
+        return in_array(get_class($node), [LNumber::class, ConstFetch::class, String_::class], true)
+                || $node instanceof Variable && stripos($node->name, 'exp') === 0;
     }
 }

--- a/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertComparisonToSpecificMethodRector.php
+++ b/src/Rector/Contrib/PHPUnit/SpecificMethod/AssertComparisonToSpecificMethodRector.php
@@ -4,12 +4,12 @@ namespace Rector\Rector\Contrib\PHPUnit\SpecificMethod;
 
 use PhpParser\Node;
 use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\BinaryOp;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Scalar\LNumber;
-use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Scalar;
 use Rector\NodeAnalyzer\MethodCallAnalyzer;
 use Rector\NodeChanger\IdentifierRenamer;
 use Rector\Rector\AbstractPHPUnitRector;
@@ -144,7 +144,8 @@ final class AssertComparisonToSpecificMethodRector extends AbstractPHPUnitRector
 
     private function isConstantValue(Node $node): bool
     {
-        return in_array(get_class($node), [LNumber::class, ConstFetch::class, String_::class], true)
-                || $node instanceof Variable && stripos($node->name, 'exp') === 0;
+        return in_array(get_class($node), [Array_::class, ConstFetch::class], true)
+              || is_subclass_of($node, Scalar::class)
+              || $node instanceof Variable && stripos($node->name, 'exp') === 0;
     }
 }

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertComparisonToSpecificMethodRector/Correct/correct.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertComparisonToSpecificMethodRector/Correct/correct.php.inc
@@ -4,8 +4,11 @@ final class MyTest extends \PHPUnit\Framework\TestCase
 {
     public function test()
     {
-        $this->assertNotSame($anything, $something);
+        $this->assertNotSame($expected, $anything);
         $this->assertGreaterThan(2, count($something));
         $this->assertLessThanOrEqual(5, count($something), 'message');
+        $this->assertSame(1, count($something));
+        $this->assertNotSame(true, in_array('foo', ['bar', 'baz'], true));
+        $this->assertNotEquals('string', gettype($foo));
     }
 }

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertComparisonToSpecificMethodRector/Correct/correct.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertComparisonToSpecificMethodRector/Correct/correct.php.inc
@@ -6,9 +6,10 @@ final class MyTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertNotSame($expected, $anything);
         $this->assertGreaterThan(2, count($something));
-        $this->assertLessThanOrEqual(5, count($something), 'message');
-        $this->assertSame(1, count($something));
+        $this->assertNotEquals(__DIR__, $something, 'message');
+        $this->assertSame(1.0, $something);
         $this->assertNotSame(true, in_array('foo', ['bar', 'baz'], true));
         $this->assertNotEquals('string', gettype($foo));
+        $this->assertEquals(['foo', 'bar'], $something);
     }
 }

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertComparisonToSpecificMethodRector/Wrong/wrong.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertComparisonToSpecificMethodRector/Wrong/wrong.php.inc
@@ -4,8 +4,11 @@ final class MyTest extends \PHPUnit\Framework\TestCase
 {
     public function test()
     {
-        $this->assertFalse($something === $anything);
+        $this->assertFalse($expected === $anything);
         $this->assertTrue(count($something) > 2);
         $this->assertFalse(count($something) >= 5, 'message');
+        $this->assertTrue(1 === count($something));
+        $this->assertFalse(true === in_array('foo', ['bar', 'baz'], true));
+        $this->assertTrue('string' != gettype($foo));
     }
 }

--- a/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertComparisonToSpecificMethodRector/Wrong/wrong.php.inc
+++ b/tests/Rector/Contrib/PHPUnit/SpecificMethod/AssertComparisonToSpecificMethodRector/Wrong/wrong.php.inc
@@ -6,9 +6,10 @@ final class MyTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertFalse($expected === $anything);
         $this->assertTrue(count($something) > 2);
-        $this->assertFalse(count($something) >= 5, 'message');
-        $this->assertTrue(1 === count($something));
+        $this->assertTrue(__DIR__ <> $something, 'message');
+        $this->assertTrue(1.0 === $something);
         $this->assertFalse(true === in_array('foo', ['bar', 'baz'], true));
         $this->assertTrue('string' != gettype($foo));
+        $this->assertTrue(['foo', 'bar'] == $something);
     }
 }


### PR DESCRIPTION
Inspired by https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3540

With this PR, I want to make `AssertComparisonToSpecificMethodRector` smarter, recognizing Yoda Comparisons and check what member has a `string`, number, const (`true`, `false` or `null`), as well variables starting with `exp` (from expected). This will result in more refactoring when passing to other Rectors :smile: 

TODO:
- [x] Recognize `array`
- [x] Recognize `float`