### PR TITLE
[CodeQuality] Create UnnecessaryTernaryExpressionRector

### DIFF
--- a/docs/AllRectorsOverview.md
+++ b/docs/AllRectorsOverview.md
@@ -179,6 +179,15 @@ Simplify `in_array` and `array_keys` functions combination into `array_key_exist
 +array_key_exists("key", $array);
 ```
 
+## Rector\Rector\Contrib\CodeQuality\UnnecessaryTernaryExpressionRector
+
+Remove unnecessary ternary expressions.
+
+```diff
+-$foo === $bar ? true : false;
++$foo === $bar;
+```
+
 ## Rector\Rector\Dynamic\ParentTypehintedArgumentRector
 
 [Dynamic] Changes defined parent class typehints.

--- a/src/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector.php
+++ b/src/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector.php
@@ -95,20 +95,18 @@ final class UnnecessaryTernaryExpressionRector extends AbstractRector
 
     private function fixBinaryOperation(BinaryOp $operation): BinaryOp
     {
-        $operandsMap = [
-            '===' => NotIdentical::class,
-            '!==' => Identical::class,
-            '==' => NotEqual::class,
-            '!=' => Equal::class,
-            '<>' => Equal::class,
-            '>' => Smaller::class,
-            '<' => Greater::class,
-            '>=' => SmallerOrEqual::class,
-            '<=' => GreaterOrEqual::class,
+        $inverseOperandMap = [
+            Identical::class => NotIdentical::class,
+            NotIdentical::class => Identical::class,
+            Equal::class => NotEqual::class,
+            NotEqual::class => Equal::class,
+            Greater::class => Smaller::class,
+            Smaller::class => Greater::class,
+            GreaterOrEqual::class => SmallerOrEqual::class,
+            SmallerOrEqual::class => GreaterOrEqual::class,
         ];
 
-        $operand = $operation->getOperatorSigil();
-        $binaryOpClassName = $operandsMap[$operand];
+        $binaryOpClassName = $inverseOperandMap[get_class($operation)];
 
         return new $binaryOpClassName($operation->left, $operation->right);
     }

--- a/src/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector.php
+++ b/src/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector.php
@@ -76,9 +76,7 @@ final class UnnecessaryTernaryExpressionRector extends AbstractRector
         $ifExpression = $ternaryExpression->if;
         $elseExpression = $ternaryExpression->else;
 
-        if (! $ifExpression instanceof ConstFetch
-            || ! $elseExpression instanceof ConstFetch
-        ) {
+        if (! $ifExpression instanceof ConstFetch || ! $elseExpression instanceof ConstFetch) {
             return false;
         }
 

--- a/src/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector.php
+++ b/src/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector.php
@@ -83,17 +83,17 @@ final class UnnecessaryTernaryExpressionRector extends AbstractRector
      */
     public function refactor(Node $ternaryNode): ?Node
     {
-        /** @var BinaryOp $binaryOpOperation */
-        $binaryOpOperation = $ternaryNode->cond;
+        /** @var BinaryOp $binaryOperation */
+        $binaryOperation = $ternaryNode->cond;
 
         if ($this->ifValue === 'true' && $this->elseValue === 'false') {
-            return $binaryOpOperation;
+            return $binaryOperation;
         }
 
-        return $this->fixBinaryOperation($binaryOpOperation);
+        return $this->inverseBinaryOperation($binaryOperation);
     }
 
-    private function fixBinaryOperation(BinaryOp $operation): BinaryOp
+    private function inverseBinaryOperation(BinaryOp $operation): BinaryOp
     {
         $inverseOperandMap = [
             Identical::class => NotIdentical::class,

--- a/src/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector.php
+++ b/src/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector.php
@@ -23,6 +23,20 @@ use Rector\RectorDefinition\RectorDefinition;
 final class UnnecessaryTernaryExpressionRector extends AbstractRector
 {
     /**
+     * @var string[]
+     */
+    private $inverseOperandMap = [
+        Identical::class => NotIdentical::class,
+        NotIdentical::class => Identical::class,
+        Equal::class => NotEqual::class,
+        NotEqual::class => Equal::class,
+        Greater::class => Smaller::class,
+        Smaller::class => Greater::class,
+        GreaterOrEqual::class => SmallerOrEqual::class,
+        SmallerOrEqual::class => GreaterOrEqual::class,
+    ];
+
+    /**
      * @var string
      */
     private $ifValue;
@@ -95,18 +109,7 @@ final class UnnecessaryTernaryExpressionRector extends AbstractRector
 
     private function inverseBinaryOperation(BinaryOp $operation): BinaryOp
     {
-        $inverseOperandMap = [
-            Identical::class => NotIdentical::class,
-            NotIdentical::class => Identical::class,
-            Equal::class => NotEqual::class,
-            NotEqual::class => Equal::class,
-            Greater::class => Smaller::class,
-            Smaller::class => Greater::class,
-            GreaterOrEqual::class => SmallerOrEqual::class,
-            SmallerOrEqual::class => GreaterOrEqual::class,
-        ];
-
-        $binaryOpClassName = $inverseOperandMap[get_class($operation)];
+        $binaryOpClassName = $this->inverseOperandMap[get_class($operation)];
 
         return new $binaryOpClassName($operation->left, $operation->right);
     }

--- a/src/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector.php
+++ b/src/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector.php
@@ -54,8 +54,13 @@ final class UnnecessaryTernaryExpressionRector extends AbstractRector
         return ! in_array('null', [$ifConstFetch, $elseConstFetch], true);
     }
 
-    public function refactor(Node $node): ?Node
+    /**
+     * @param Ternary $ternaryExpression
+     */
+    public function refactor(Node $ternaryExpression): ?Node
     {
-        return $node;
+        $ternaryExpression = $ternaryExpression->cond;
+
+        return $ternaryExpression;
     }
 }

--- a/src/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector.php
+++ b/src/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector.php
@@ -53,7 +53,7 @@ final class UnnecessaryTernaryExpressionRector extends AbstractRector
         $elseExpression = $ternaryExpression->else;
 
         if (! $ifExpression instanceof ConstFetch
-            && ! $elseExpression instanceof ConstFetch
+            || ! $elseExpression instanceof ConstFetch
         ) {
             return false;
         }

--- a/src/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector.php
+++ b/src/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector.php
@@ -5,6 +5,14 @@ namespace Rector\Rector\Contrib\CodeQuality;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp;
+use PhpParser\Node\Expr\BinaryOp\Equal;
+use PhpParser\Node\Expr\BinaryOp\Greater;
+use PhpParser\Node\Expr\BinaryOp\GreaterOrEqual;
+use PhpParser\Node\Expr\BinaryOp\Identical;
+use PhpParser\Node\Expr\BinaryOp\NotEqual;
+use PhpParser\Node\Expr\BinaryOp\NotIdentical;
+use PhpParser\Node\Expr\BinaryOp\Smaller;
+use PhpParser\Node\Expr\BinaryOp\SmallerOrEqual;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\Ternary;
 use PhpParser\Node\Identifier;
@@ -71,38 +79,38 @@ final class UnnecessaryTernaryExpressionRector extends AbstractRector
     }
 
     /**
-     * @param Ternary $ternaryExpression
+     * @param Ternary $ternaryNode
      */
-    public function refactor(Node $ternaryExpression): ?Node
+    public function refactor(Node $ternaryNode): ?Node
     {
         /** @var BinaryOp */
-        $binaryOpOperation = $ternaryExpression->cond;
+        $binaryOpOperation = $ternaryNode->cond;
 
         if ($this->ifValue === 'true' && $this->elseValue === 'false') {
-            $ternaryExpression = $binaryOpOperation;
+            $ternaryNode = $binaryOpOperation;
         } else {
-            $ternaryExpression = $this->fixBinaryOperation($binaryOpOperation);
+            $ternaryNode = $this->fixBinaryOperation($binaryOpOperation);
         }
 
-        return $ternaryExpression;
+        return $ternaryNode;
     }
 
     private function fixBinaryOperation(BinaryOp $operation): BinaryOp
     {
         $operandsMap = [
-            '===' => 'NotIdentical',
-            '!==' => 'Identical',
-            '==' => 'NotEqual',
-            '!=' => 'Equal',
-            '<>' => 'Equal',
-            '>' => 'Smaller',
-            '<' => 'Greater',
-            '>=' => 'SmallerOrEqual',
-            '<=' => 'GreaterOrEqual',
+            '===' => NotIdentical::class,
+            '!==' => Identical::class,
+            '==' => NotEqual::class,
+            '!=' => Equal::class,
+            '<>' => Equal::class,
+            '>' => Smaller::class,
+            '<' => Greater::class,
+            '>=' => SmallerOrEqual::class,
+            '<=' => GreaterOrEqual::class,
         ];
 
         $operand = $operation->getOperatorSigil();
-        $binaryOpClassName = 'PhpParser\\Node\\Expr\\BinaryOp\\' . $operandsMap[$operand];
+        $binaryOpClassName = $operandsMap[$operand];
 
         return new $binaryOpClassName($operation->left, $operation->right);
     }

--- a/src/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector.php
+++ b/src/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector.php
@@ -16,6 +16,7 @@ use PhpParser\Node\Expr\BinaryOp\SmallerOrEqual;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\Ternary;
 use PhpParser\Node\Identifier;
+use Rector\Exception\NotImplementedException;
 use Rector\Rector\AbstractRector;
 use Rector\RectorDefinition\CodeSample;
 use Rector\RectorDefinition\RectorDefinition;
@@ -109,8 +110,22 @@ final class UnnecessaryTernaryExpressionRector extends AbstractRector
 
     private function inverseBinaryOperation(BinaryOp $operation): BinaryOp
     {
-        $binaryOpClassName = $this->inverseOperandMap[get_class($operation)];
+        $this->ensureBinaryOperationIsSupported($operation);
 
+        $binaryOpClassName = $this->inverseOperandMap[get_class($operation)];
         return new $binaryOpClassName($operation->left, $operation->right);
+    }
+
+    private function ensureBinaryOperationIsSupported(BinaryOp $operation): void
+    {
+        if (isset($this->inverseOperandMap[get_class($operation)])) {
+            return;
+        }
+
+        throw new NotImplementedException(sprintf(
+            '"%s" type is not implemented yet. Add it in %s',
+            get_class($operation),
+            __METHOD__
+        ));
     }
 }

--- a/src/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector.php
+++ b/src/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Rector\Contrib\CodeQuality;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use Rector\Rector\AbstractRector;
+use Rector\RectorDefinition\CodeSample;
+use Rector\RectorDefinition\RectorDefinition;
+
+final class UnnecessaryTernaryExpressionRector extends AbstractRector
+{
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition(
+            'Remove unnecessary ternary expressions.',
+            [new CodeSample('$foo === $bar ? true : false;', '$foo === $bar;')]
+        );
+    }
+
+    public function isCandidate(Node $node): bool
+    {
+        return true;
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        return $node;
+    }
+}

--- a/src/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector.php
+++ b/src/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector.php
@@ -83,16 +83,14 @@ final class UnnecessaryTernaryExpressionRector extends AbstractRector
      */
     public function refactor(Node $ternaryNode): ?Node
     {
-        /** @var BinaryOp */
+        /** @var BinaryOp $binaryOpOperation */
         $binaryOpOperation = $ternaryNode->cond;
 
         if ($this->ifValue === 'true' && $this->elseValue === 'false') {
-            $ternaryNode = $binaryOpOperation;
-        } else {
-            $ternaryNode = $this->fixBinaryOperation($binaryOpOperation);
+            return $binaryOpOperation;
         }
 
-        return $ternaryNode;
+        return $this->fixBinaryOperation($binaryOpOperation);
     }
 
     private function fixBinaryOperation(BinaryOp $operation): BinaryOp

--- a/src/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector.php
+++ b/src/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\Ternary;
+use PhpParser\Node\Identifier;
 use Rector\Rector\AbstractRector;
 use Rector\RectorDefinition\CodeSample;
 use Rector\RectorDefinition\RectorDefinition;
@@ -58,8 +59,13 @@ final class UnnecessaryTernaryExpressionRector extends AbstractRector
             return false;
         }
 
-        $this->ifValue = $ifExpression->name->toLowerString();
-        $this->elseValue = $elseExpression->name->toLowerString();
+        /** @var Identifier $ifExpressionName */
+        $ifExpressionName = $ifExpression->name;
+        /** @var Identifier $elseExpressionName */
+        $elseExpressionName = $elseExpression->name;
+
+        $this->ifValue = $ifExpressionName->toLowerString();
+        $this->elseValue = $elseExpressionName->toLowerString();
 
         return ! in_array('null', [$this->ifValue, $this->elseValue], true);
     }

--- a/tests/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector/Correct/correct.php.inc
+++ b/tests/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector/Correct/correct.php.inc
@@ -32,4 +32,9 @@ final class MyClass
     {
         return $foo ?: $bar;
     }
+
+    public function falsePositiveTernaryExpression(): string
+    {
+        return $foo === '' ? null : $foo;
+    }
 }

--- a/tests/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector/Correct/correct.php.inc
+++ b/tests/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector/Correct/correct.php.inc
@@ -6,4 +6,11 @@ final class MyClass
     {
         return $foo === $bar;
     }
+
+    public function unecessaryTernaryExpression(): bool
+    {
+        $return =  $foo === $bar;
+
+        return $return;
+    }
 }

--- a/tests/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector/Correct/correct.php.inc
+++ b/tests/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector/Correct/correct.php.inc
@@ -2,15 +2,34 @@
 
 final class MyClass
 {
-    public function unecessaryTernary(): bool
+    public function unnecessaryTernary(): bool
     {
         return $foo === $bar;
     }
 
-    public function unecessaryTernaryExpression(): bool
+    public function unnecessaryTernaryExpression(): bool
     {
         $return =  $foo === $bar;
 
         return $return;
+    }
+
+    public function unnecessaryTernaryExpressionInverted(): bool
+    {
+        return $foo <= $bar;
+    }
+
+    public function ternaryExpressionInsideClosure(): bool
+    {
+        $result = function (): bool {
+            return $foo === 2;
+        };
+
+        return $result;
+    }
+
+    public function necessaryTernaryExpression(): bool
+    {
+        return $foo ?: $bar;
     }
 }

--- a/tests/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector/Correct/correct.php.inc
+++ b/tests/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector/Correct/correct.php.inc
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+final class MyClass
+{
+    public function unecessaryTernary(): bool
+    {
+        return $foo === $bar;
+    }
+}

--- a/tests/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector/UnnecessaryTernaryExpressionRectorTest.php
+++ b/tests/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector/UnnecessaryTernaryExpressionRectorTest.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Tests\Rector\Contrib\CodeQuality\UnnecessaryTernaryExpressionRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+/**
+ * @covers \Rector\Rector\Contrib\CodeQuality\UnnecessaryTernaryExpressionRector
+ */
+final class UnnecessaryTernaryExpressionRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideWrongToFixedFiles()
+     */
+    public function test(string $wrong, string $fixed): void
+    {
+        $this->doTestFileMatchesExpectedContent($wrong, $fixed);
+    }
+
+    public function provideWrongToFixedFiles(): Iterator
+    {
+        yield [__DIR__ . '/Wrong/wrong.php.inc', __DIR__ . '/Correct/correct.php.inc'];
+    }
+
+    protected function provideConfig(): string
+    {
+        return __DIR__ . '/config.yml';
+    }
+}

--- a/tests/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector/Wrong/wrong.php.inc
+++ b/tests/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector/Wrong/wrong.php.inc
@@ -6,4 +6,13 @@ final class MyClass
     {
         return $foo === $bar ? true : false;
     }
+
+    public function unecessaryTernaryExpression(): bool
+    {
+        $return =  $foo === $bar
+            ? true
+            : false;
+
+        return $return;
+    }
 }

--- a/tests/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector/Wrong/wrong.php.inc
+++ b/tests/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector/Wrong/wrong.php.inc
@@ -2,17 +2,36 @@
 
 final class MyClass
 {
-    public function unecessaryTernary(): bool
+    public function unnecessaryTernary(): bool
     {
         return $foo === $bar ? true : false;
     }
 
-    public function unecessaryTernaryExpression(): bool
+    public function unnecessaryTernaryExpression(): bool
     {
-        $return =  $foo === $bar
-            ? true
-            : false;
+        $return =  $foo !== $bar
+            ? false
+            : true;
 
         return $return;
+    }
+
+    public function unnecessaryTernaryExpressionInverted(): bool
+    {
+        return $foo >= $bar ? false : true;
+    }
+
+    public function ternaryExpressionInsideClosure(): bool
+    {
+        $result = function (): bool {
+            return $foo !== 2 ? false : true;
+        };
+
+        return $result;
+    }
+
+    public function necessaryTernaryExpression(): bool
+    {
+        return $foo ?: $bar;
     }
 }

--- a/tests/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector/Wrong/wrong.php.inc
+++ b/tests/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector/Wrong/wrong.php.inc
@@ -34,4 +34,9 @@ final class MyClass
     {
         return $foo ?: $bar;
     }
+
+    public function falsePositiveTernaryExpression(): string
+    {
+        return $foo === '' ? null : $foo;
+    }
 }

--- a/tests/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector/Wrong/wrong.php.inc
+++ b/tests/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector/Wrong/wrong.php.inc
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+final class MyClass
+{
+    public function unecessaryTernary(): bool
+    {
+        return $foo === $bar ? true : false;
+    }
+}

--- a/tests/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector/config.yml
+++ b/tests/Rector/Contrib/CodeQuality/UnnecessaryTernaryExpressionRector/config.yml
@@ -1,3 +1,2 @@
 services:
-    Rector\Rector\Contrib\CodeQuality\InArrayAndArrayKeysToArrayKeyExistsRector: ~
     Rector\Rector\Contrib\CodeQuality\UnnecessaryTernaryExpressionRector: ~


### PR DESCRIPTION
Implements https://github.com/rectorphp/rector/issues/424#issuecomment-383398012

Roadmap:
- [x] Identify ternary expression that can be remove
- [x] Remove unnecessary ternary expressions
- [x] Fix expressions. e.g.:
```diff
-$foo === $bar ? false : true;
+$foo !== $bar;
```