### PR TITLE
Improve Test Performance

### DIFF
--- a/packages/Sensio/tests/Rector/FrameworkExtraBundle/TemplateAnnotationRector/TemplateAnnotationVersion3RectorTest.php
+++ b/packages/Sensio/tests/Rector/FrameworkExtraBundle/TemplateAnnotationRector/TemplateAnnotationVersion3RectorTest.php
@@ -10,6 +10,13 @@ use Rector\Testing\PHPUnit\AbstractRectorTestCase;
  */
 final class TemplateAnnotationVersion3RectorTest extends AbstractRectorTestCase
 {
+    protected function setUp(): void
+    {
+        $this->rebuildFreshContainer = true;
+
+        parent::setUp();
+    }
+
     /**
      * @dataProvider provideWrongToFixedFiles()
      */

--- a/packages/Sensio/tests/Rector/FrameworkExtraBundle/TemplateAnnotationRector/TemplateAnnotationVersion5RectorTest.php
+++ b/packages/Sensio/tests/Rector/FrameworkExtraBundle/TemplateAnnotationRector/TemplateAnnotationVersion5RectorTest.php
@@ -10,6 +10,13 @@ use Rector\Testing\PHPUnit\AbstractRectorTestCase;
  */
 final class TemplateAnnotationVersion5RectorTest extends AbstractRectorTestCase
 {
+    protected function setUp(): void
+    {
+        $this->rebuildFreshContainer = true;
+
+        parent::setUp();
+    }
+
     /**
      * @dataProvider provideWrongToFixedFiles()
      */

--- a/packages/Symfony/tests/Rector/FrameworkBundle/GetToConstructorInjectionRector/GetToConstructorInjectionRectorTest.php
+++ b/packages/Symfony/tests/Rector/FrameworkBundle/GetToConstructorInjectionRector/GetToConstructorInjectionRectorTest.php
@@ -10,6 +10,13 @@ use Rector\Testing\PHPUnit\AbstractRectorTestCase;
  */
 final class GetToConstructorInjectionRectorTest extends AbstractRectorTestCase
 {
+    protected function setUp(): void
+    {
+        $this->rebuildFreshContainer = true;
+
+        parent::setUp();
+    }
+
     /**
      * @dataProvider provideWrongToFixedFiles()
      */

--- a/src/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/src/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -28,6 +28,11 @@ abstract class AbstractRectorTestCase extends TestCase
     protected $parameterProvider;
 
     /**
+     * @var bool
+     */
+    protected $rebuildFreshContainer = false;
+
+    /**
      * @var FileGuard
      */
     private $fileGuard;
@@ -36,11 +41,6 @@ abstract class AbstractRectorTestCase extends TestCase
      * @var ContainerInterface[]
      */
     private static $containersPerConfig = [];
-
-    /**
-     * @var bool
-     */
-    protected $rebuildFreshContainer = false;
 
     protected function setUp(): void
     {

--- a/src/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/src/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -37,6 +37,11 @@ abstract class AbstractRectorTestCase extends TestCase
      */
     private static $containersPerConfig = [];
 
+    /**
+     * @var bool
+     */
+    protected $rebuildFreshContainer = false;
+
     protected function setUp(): void
     {
         $config = $this->provideConfig();
@@ -45,7 +50,7 @@ abstract class AbstractRectorTestCase extends TestCase
 
         $key = md5_file($config);
 
-        if (isset(self::$containersPerConfig[$key])) {
+        if (isset(self::$containersPerConfig[$key]) && $this->rebuildFreshContainer === false) {
             $this->container = self::$containersPerConfig[$key];
         } else {
             self::$containersPerConfig[$key] = $this->container = (new ContainerFactory())->createWithConfig($config);

--- a/src/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/src/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -32,13 +32,25 @@ abstract class AbstractRectorTestCase extends TestCase
      */
     private $fileGuard;
 
+    /**
+     * @var ContainerInterface[]
+     */
+    private static $containersPerConfig = [];
+
     protected function setUp(): void
     {
         $config = $this->provideConfig();
         $this->fileGuard = new FileGuard();
         $this->fileGuard->ensureFileExists($config, get_called_class());
 
-        $this->container = (new ContainerFactory())->createWithConfig($config);
+        $key = md5_file($config);
+
+        if (isset(self::$containersPerConfig[$key])) {
+            $this->container = self::$containersPerConfig[$key];
+        } else {
+            self::$containersPerConfig[$key] = $this->container = (new ContainerFactory())->createWithConfig($config);
+        }
+
         $this->fileProcessor = $this->container->get(FileProcessor::class);
         $this->parameterProvider = $this->container->get(ParameterProvider::class);
     }


### PR DESCRIPTION
In total 98 containers are created during tests.

50 of them are dulicated - a nw containe is created, even if it was already created before with the same config.

**This reduces the number of created containers from 98 to 50.**