### PR TITLE
FilesFinder - allow searching in asterisk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 composer.lock
 
 /demo
+rector-symfony.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,4 +42,4 @@ cache:
     - $HOME/.composer/cache
 
 notifications:
-  email: never
+  email: false

--- a/README.md
+++ b/README.md
@@ -107,7 +107,13 @@ Do you need to upgrade to **Symfony 4.0**, for example?
     vendor/bin/rector process src --level symfony33 --dry-run
     ```
 
-3. What levels are on the board?
+3. To process just specific subdirectories, you can use [fnmatch](http://php.net/manual/en/function.fnmatch.php) pattern with `*`:
+
+   ```bash
+   vendor/bin/rector process "src/Symfony/Component/*/Tests" --level phpunit60 --dry-run
+   ```
+
+4. What levels are on the board?
 
     ```bash
     vendor/bin/rector levels

--- a/bin/container.php
+++ b/bin/container.php
@@ -5,19 +5,22 @@ use Symfony\Component\Console\Input\ArgvInput;
 use Symplify\PackageBuilder\Configuration\ConfigFileFinder;
 use Symplify\PackageBuilder\Configuration\LevelFileFinder;
 
-// 1. Detect configuration from --level
-$configFile = (new LevelFileFinder())->detectFromInputAndDirectory(new ArgvInput(), __DIR__ . '/../config/level');
+$configFiles = [];
 
-// 2. Or from --config
-if ($configFile === null) {
-    ConfigFileFinder::detectFromInput('rector', new ArgvInput());
-    $configFile = ConfigFileFinder::provide('rector', ['rector.yml', 'rector.yaml']);
-}
+// Detect configuration from --level
+$configFiles[] = (new LevelFileFinder())->detectFromInputAndDirectory(new ArgvInput(), __DIR__ . '/../config/level');
+
+// And from --config or default one
+ConfigFileFinder::detectFromInput('rector', new ArgvInput());
+$configFiles[] = ConfigFileFinder::provide('rector', ['rector.yml', 'rector.yaml']);
+
+// remove empty values
+$configFiles = array_filter($configFiles);
 
 // 3. Build DI container
 $containerFactory = new ContainerFactory();
-if ($configFile) {
-    return $containerFactory->createWithConfig($configFile);
+if ($configFiles) {
+    return $containerFactory->createWithConfigFiles($configFiles);
 }
 
 return $containerFactory->create();

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "humbug/php-scoper": "^0.9.1",
-        "phpunit/phpunit": "^7.1",
+        "phpunit/phpunit": "^7.3",
         "slam/php-cs-fixer-extensions": "^1.15",
         "symplify/easy-coding-standard": "^4.6.1",
         "tracy/tracy": "^2.5"

--- a/packages/NodeTypeResolver/.travis.yml
+++ b/packages/NodeTypeResolver/.travis.yml
@@ -2,11 +2,11 @@ language: php
 
 matrix:
     include:
-    - php: 7.1
-      env: PHPUNIT_FLAGS="--coverage-clover coverage.xml"
-    - php: 7.1
-      env: COMPOSER_FLAGS="--prefer-lowest"
-    - php: 7.2
+        - php: 7.1
+          env: PHPUNIT_FLAGS="--coverage-clover coverage.xml"
+        - php: 7.1
+          env: COMPOSER_FLAGS="--prefer-lowest"
+        - php: 7.2
 
 install:
     - composer update $COMPOSER_FLAGS
@@ -23,4 +23,4 @@ after_script:
         fi
 
 notifications:
-    email: never
+    email: false

--- a/packages/NodeTypeResolver/composer.json
+++ b/packages/NodeTypeResolver/composer.json
@@ -12,10 +12,11 @@
         "symfony/dependency-injection": "^3.4|^4.0",
         "symfony/finder": "^3.4|^4.0",
         "symplify/better-phpdoc-parser": "^4.7",
+        "rector/utils": "dev-master",
         "symplify/package-builder": "^4.7"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.2"
+        "phpunit/phpunit": "^7.3"
     },
     "autoload": {
         "psr-4": {

--- a/packages/NodeTypeResolver/src/config/config.yml
+++ b/packages/NodeTypeResolver/src/config/config.yml
@@ -4,4 +4,7 @@ imports:
     # to cover installed as dependency
     - { resource: '../../../../../../symplify/better-phpdoc-parser/src/config/services.yml' , ignore_errors: true }
 
+    # rector/utils package
+    - { resource: '../../../Utils/src/config/services.yml' }
+
     - { resource: 'services.yml' }

--- a/packages/Silverstripe/src/Rector/DefineConstantToStaticCallRector.php
+++ b/packages/Silverstripe/src/Rector/DefineConstantToStaticCallRector.php
@@ -6,6 +6,7 @@ use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\String_;
 use Rector\Rector\AbstractRector;
@@ -35,6 +36,14 @@ final class DefineConstantToStaticCallRector extends AbstractRector
     public function refactor(Node $node): ?Node
     {
         if (count($node->args) !== 1) {
+            return null;
+        }
+
+        if (! $node->name instanceof Name) {
+            return null;
+        }
+
+        if ($node->name->toString() !== 'defined') {
             return null;
         }
 

--- a/packages/Symfony/src/Rector/Controller/AddFlashRector.php
+++ b/packages/Symfony/src/Rector/Controller/AddFlashRector.php
@@ -82,6 +82,7 @@ CODE_SAMPLE
         if ($parentClassName !== $this->controllerClass) {
             return null;
         }
+
         if (! $this->chainMethodCallAnalyzer->isTypeAndChainCalls(
             $node,
             'Symfony\Component\HttpFoundation\Request',

--- a/packages/Utils/src/FilesystemTweaker.php
+++ b/packages/Utils/src/FilesystemTweaker.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Utils;
+
+use Nette\Utils\Strings;
+use Rector\Exception\FileSystem\DirectoryNotFoundException;
+use Rector\Exception\FileSystem\FileNotFoundException;
+
+final class FilesystemTweaker
+{
+    /**
+     * @param string[] $source
+     * @return string[][]
+     */
+    public function splitSourceToDirectoriesAndFiles(array $source): array
+    {
+        $files = [];
+        $directories = [];
+
+        foreach ($source as $singleSource) {
+            if (is_file($singleSource)) {
+                $this->ensureFileExists($singleSource);
+                $files[] = $singleSource;
+            } else {
+                $directories[] = $singleSource;
+            }
+        }
+
+        return [$files, $directories];
+    }
+
+    /**
+     * This will turn paths like "src/Symfony/Component/*\/Tests" to existing directory paths
+     *
+     * @param string[] $directories
+     * @return string[]
+     */
+    public function resolveDirectoriesWithFnmatch(array $directories): array
+    {
+        $absoluteDirectories = [];
+        foreach ($directories as $directory) {
+            if (Strings::contains($directory, '*')) { // is fnmatch for directories
+                $absoluteDirectories = array_merge($absoluteDirectories, glob($directory, GLOB_ONLYDIR));
+            } else { // is classic directory
+                $this->ensureDirectoryExists($directory);
+                $absoluteDirectories[] = $directory;
+            }
+        }
+
+        return $absoluteDirectories;
+    }
+
+    private function ensureFileExists(string $file): void
+    {
+        if (file_exists($file)) {
+            return;
+        }
+
+        throw new FileNotFoundException(sprintf('File "%s" was not found.', $file));
+    }
+
+    private function ensureDirectoryExists(string $directory): void
+    {
+        if (file_exists($directory)) {
+            return;
+        }
+
+        throw new DirectoryNotFoundException(sprintf('Directory "%s" was not found.', $directory));
+    }
+}

--- a/packages/YamlRector/tests/AbstractYamlRectorTest.php
+++ b/packages/YamlRector/tests/AbstractYamlRectorTest.php
@@ -32,7 +32,7 @@ abstract class AbstractYamlRectorTest extends TestCase
         $this->fileGuard = new FileGuard();
         $this->fileGuard->ensureFileExists($config, get_called_class());
 
-        $this->container = (new ContainerFactory())->createWithConfig($config);
+        $this->container = (new ContainerFactory())->createWithConfigFiles([$config]);
 
         $this->yamlFileProcessor = $this->container->get(YamlFileProcessor::class);
     }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,6 +17,9 @@ parameters:
         - '#Cannot cast PhpParser\\Node\\Expr\|PhpParser\\Node\\Name to string#'
         - '#Array \(array<array<PhpParser\\Node\\Stmt>>\) does not accept array<PhpParser\\Node\\Stmt|null>#'
 
+        # array miss types
+        - '#Method Rector\\FileSystem\\FilesFinder::splitSourceToDirectoriesAndFiles\(\) should return array<array<string>\|Symfony\\Component\\Finder\\SplFileInfo> but returns array<int, array<int, string\|Symfony\\Component\\Finder\\SplFileInfo>>#'
+
         # already fixed, invalidated cache?
         - '#Access to an undefined property PhpParser\\Node\\Expr::\$args#'
 
@@ -44,6 +47,10 @@ parameters:
         - '#Parameter \#1 \$pattern of function fnmatch expects string, string\|false given#'
         - '#Parameter \#1 \$file of function file_put_contents expects string, string\|false given#'
         - '#Parameter \#1 \$filePath of method Rector\\Parser\\Parser::parseFile\(\) expects string, string\|false given#'
+        - '#Parameter \#2 \$filename of function fnmatch expects string, string\|false given#'
+
+        # getcwd false postive
+        - '#Parameter \#1 \$dirs of method Symfony\\Component\\Finder\\Finder::in\(\) expects array\|string, string\|false given#'
 
         # false positive, has annotation type above (@todo recheck for possible ignored positives)
         - '#Access to an undefined property PhpParser\\Node::\$name#' # 11

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,9 +17,6 @@ parameters:
         - '#Cannot cast PhpParser\\Node\\Expr\|PhpParser\\Node\\Name to string#'
         - '#Array \(array<array<PhpParser\\Node\\Stmt>>\) does not accept array<PhpParser\\Node\\Stmt|null>#'
 
-        # array miss types
-        - '#Method Rector\\FileSystem\\FilesFinder::splitSourceToDirectoriesAndFiles\(\) should return array<array<string>\|Symfony\\Component\\Finder\\SplFileInfo> but returns array<int, array<int, string\|Symfony\\Component\\Finder\\SplFileInfo>>#'
-
         # already fixed, invalidated cache?
         - '#Access to an undefined property PhpParser\\Node\\Expr::\$args#'
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -47,10 +47,6 @@ parameters:
         - '#Parameter \#1 \$pattern of function fnmatch expects string, string\|false given#'
         - '#Parameter \#1 \$file of function file_put_contents expects string, string\|false given#'
         - '#Parameter \#1 \$filePath of method Rector\\Parser\\Parser::parseFile\(\) expects string, string\|false given#'
-        - '#Parameter \#2 \$filename of function fnmatch expects string, string\|false given#'
-
-        # getcwd false postive
-        - '#Parameter \#1 \$dirs of method Symfony\\Component\\Finder\\Finder::in\(\) expects array\|string, string\|false given#'
 
         # false positive, has annotation type above (@todo recheck for possible ignored positives)
         - '#Access to an undefined property PhpParser\\Node::\$name#' # 11

--- a/src/Autoloading/AdditionalAutoloader.php
+++ b/src/Autoloading/AdditionalAutoloader.php
@@ -49,19 +49,14 @@ final class AdditionalAutoloader
         $this->filesystemTweaker = $filesystemTweaker;
     }
 
-    public function autoloadWithInput(InputInterface $input): void
-    {
-        $this->autoloadFileFromInput($input);
-        $this->autoloadDirectories($this->autoloadDirectories);
-        $this->autoloadFiles($this->autoloadFiles);
-    }
-
     /**
      * @param string[] $source
      */
     public function autoloadWithInputAndSource(InputInterface $input, array $source): void
     {
-        $this->autoloadWithInput($input);
+        $this->autoloadFileFromInput($input);
+        $this->autoloadDirectories($this->autoloadDirectories);
+        $this->autoloadFiles($this->autoloadFiles);
 
         [$files, $directories] = $this->filesystemTweaker->splitSourceToDirectoriesAndFiles($source);
         $this->autoloadFiles($files);

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -138,8 +138,6 @@ final class ProcessCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->additionalAutoloader->autoloadWithInput($input);
-
         $this->rectorGuard->ensureSomeRectorsAreRegistered();
 
         $source = $input->getArgument(Option::SOURCE);
@@ -149,6 +147,8 @@ final class ProcessCommand extends Command
         $phpFileInfos = $this->filesFinder->findInDirectoriesAndFiles($source, ['php']);
         $yamlFileInfos = $this->filesFinder->findInDirectoriesAndFiles($source, ['yml', 'yaml']);
         $allFileInfos = $phpFileInfos + $yamlFileInfos;
+
+        $this->additionalAutoloader->autoloadWithInputAndSource($input, $source);
 
         $this->processCommandReporter->reportLoadedRectors();
 

--- a/src/DependencyInjection/ContainerFactory.php
+++ b/src/DependencyInjection/ContainerFactory.php
@@ -16,9 +16,12 @@ final class ContainerFactory
         return $appKernel->getContainer();
     }
 
-    public function createWithConfig(string $config): ContainerInterface
+    /**
+     * @param string[] $configFiles
+     */
+    public function createWithConfigFiles(array $configFiles): ContainerInterface
     {
-        $appKernel = new RectorKernel($config);
+        $appKernel = new RectorKernel($configFiles);
         $appKernel->boot();
         // this is require to keep CLI verbosity independent on AppKernel dev/prod mode
         putenv('SHELL_VERBOSITY=0');

--- a/src/DependencyInjection/RectorKernel.php
+++ b/src/DependencyInjection/RectorKernel.php
@@ -24,26 +24,29 @@ use Symplify\PackageBuilder\Yaml\FileLoader\ParameterImportsYamlFileLoader;
 final class RectorKernel extends Kernel
 {
     /**
-     * @var string
+     * @var string[]
      */
-    private $configFile;
+    private $extraConfigFiles = [];
 
-    public function __construct(?string $configFile = '')
+    /**
+     * @param string[] $configFiles
+     */
+    public function __construct(array $configFiles = [])
     {
-        if ($configFile) {
-            $this->configFile = $configFile;
-        }
+        $this->extraConfigFiles = $configFiles;
 
-        // debug: true is require to invalidate container on service files change
-        parent::__construct('cli' . sha1((string) $configFile), true);
+        $configFilesHash = md5(serialize($configFiles));
+
+        // debug: require to invalidate container on service files change
+        parent::__construct('cli_' . $configFilesHash, true);
     }
 
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(__DIR__ . '/../config/config.yml');
 
-        if ($this->configFile) {
-            $loader->load($this->configFile);
+        foreach ($this->extraConfigFiles as $extraConfigFile) {
+            $loader->load($extraConfigFile);
         }
     }
 

--- a/src/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/src/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -44,16 +44,18 @@ abstract class AbstractRectorTestCase extends TestCase
 
     protected function setUp(): void
     {
-        $config = $this->provideConfig();
+        $configFile = $this->provideConfig();
         $this->fileGuard = new FileGuard();
-        $this->fileGuard->ensureFileExists($config, get_called_class());
+        $this->fileGuard->ensureFileExists($configFile, get_called_class());
 
-        $key = md5_file($config);
+        $key = md5_file($configFile);
 
         if (isset(self::$containersPerConfig[$key]) && $this->rebuildFreshContainer === false) {
             $this->container = self::$containersPerConfig[$key];
         } else {
-            self::$containersPerConfig[$key] = $this->container = (new ContainerFactory())->createWithConfig($config);
+            self::$containersPerConfig[$key] = $this->container = (new ContainerFactory())->createWithConfigFiles(
+                [$configFile]
+            );
         }
 
         $this->fileProcessor = $this->container->get(FileProcessor::class);

--- a/tests/AbstractConfigurableContainerAwareTestCase.php
+++ b/tests/AbstractConfigurableContainerAwareTestCase.php
@@ -20,7 +20,7 @@ abstract class AbstractConfigurableContainerAwareTestCase extends TestCase
      */
     public function __construct(?string $name = null, array $data = [], string $dataName = '')
     {
-        $this->container = (new ContainerFactory())->createWithConfig($this->provideConfig());
+        $this->container = (new ContainerFactory())->createWithConfigFiles([$this->provideConfig()]);
 
         parent::__construct($name, $data, $dataName);
     }


### PR DESCRIPTION
Related #609 

Closes #613 


This allows to use fnmatch `*` for directories in path to process:

```
bin/rector process "src/Symfony/Component/*/Tests" --level symfony40 --dry-run
```
