### PR TITLE
AnnotatedPropertyInjectToConstructorInjectionRector issues

### DIFF
--- a/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/AnnotatedPropertyInjectToConstructorInjectionRectorTest.php
+++ b/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/AnnotatedPropertyInjectToConstructorInjectionRectorTest.php
@@ -21,6 +21,11 @@ final class AnnotatedPropertyInjectToConstructorInjectionRectorTest extends Abst
     public function provideWrongToFixedFiles(): Iterator
     {
         yield [__DIR__ . '/Wrong/wrong.php.inc', __DIR__ . '/Correct/correct.php.inc'];
+        yield [__DIR__ . '/Wrong/wrong2.php.inc', __DIR__ . '/Correct/correct2.php.inc'];
+        yield [__DIR__ . '/Wrong/wrong3.php.inc', __DIR__ . '/Correct/correct3.php.inc'];
+        yield [__DIR__ . '/Wrong/wrong4.php.inc', __DIR__ . '/Correct/correct4.php.inc'];
+        yield [__DIR__ . '/Wrong/wrong5.php.inc', __DIR__ . '/Correct/correct5.php.inc'];
+        yield [__DIR__ . '/Wrong/wrong6.php.inc', __DIR__ . '/Correct/correct6.php.inc'];
     }
 
     protected function provideConfig(): string

--- a/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/Correct/correct2.php.inc
+++ b/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/Correct/correct2.php.inc
@@ -1,19 +1,19 @@
 <?php declare (strict_types=1);
 
-class ClassWithInjects
+class ClassWithInjects2
 {
     /**
      * @var stdClass
+     * @autowired
      */
-    private $property;
+    public $property;
 
     /**
      * @var DateTimeInterface
-     * @inject
      */
-    public $otherProperty;
-    public function __construct(\stdClass $property)
+    private $otherProperty;
+    public function __construct(\DateTimeInterface $otherProperty)
     {
-        $this->property = $property;
+        $this->otherProperty = $otherProperty;
     }
 }

--- a/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/Correct/correct3.php.inc
+++ b/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/Correct/correct3.php.inc
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+use Rector\Tests\Rector\Architecture\DependencyInjection\AnnotatedPropertyInjectToConstructorInjectionRector\Source\SomeProduct;
+
+class ClassWithInjects3
+{
+    /**
+     * @var SomeProduct
+     */
+    private $property;
+
+    public function __construct(SomeProduct $property)
+    {
+        $this->property = $property;
+    }
+}

--- a/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/Correct/correct4.php.inc
+++ b/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/Correct/correct4.php.inc
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+use Rector\Tests\Rector\Architecture\DependencyInjection\AnnotatedPropertyInjectToConstructorInjectionRector\Source\SomeProductWithInterface;
+
+class ClassWithInjects4
+{
+    /**
+     * @var SomeProductWithInterface
+     */
+    private $property;
+
+    public function __construct(SomeProductWithInterface $property)
+    {
+        $this->property = $property;
+    }
+}

--- a/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/Correct/correct5.php.inc
+++ b/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/Correct/correct5.php.inc
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+use Rector\Tests\Rector\Architecture\DependencyInjection\AnnotatedPropertyInjectToConstructorInjectionRector\Source\SomeProductWithTrait;
+
+class ClassWithInjects5
+{
+    /**
+     * @var SomeProductWithTrait
+     */
+    private $property;
+
+    public function __construct(SomeProductWithTrait $property)
+    {
+        $this->property = $property;
+    }
+}

--- a/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/Correct/correct6.php.inc
+++ b/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/Correct/correct6.php.inc
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+use Rector\Tests\Rector\Architecture\DependencyInjection\AnnotatedPropertyInjectToConstructorInjectionRector\Source\SomeProductWithParent;
+
+class ClassWithInjects6
+{
+    /**
+     * @var SomeProductWithParent
+     */
+    private $property;
+
+    public function __construct(SomeProductWithParent $property)
+    {
+        $this->property = $property;
+    }
+}

--- a/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/Source/SomeInterface.php
+++ b/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/Source/SomeInterface.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Tests\Rector\Architecture\DependencyInjection\AnnotatedPropertyInjectToConstructorInjectionRector\Source;
+
+interface SomeInterface
+{
+}

--- a/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/Source/SomeParent.php
+++ b/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/Source/SomeParent.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Tests\Rector\Architecture\DependencyInjection\AnnotatedPropertyInjectToConstructorInjectionRector\Source;
+
+class SomeParent
+{
+
+}

--- a/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/Source/SomeProduct.php
+++ b/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/Source/SomeProduct.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Tests\Rector\Architecture\DependencyInjection\AnnotatedPropertyInjectToConstructorInjectionRector\Source;
+
+final class SomeProduct
+{
+
+}

--- a/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/Source/SomeProductWithInterface.php
+++ b/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/Source/SomeProductWithInterface.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Tests\Rector\Architecture\DependencyInjection\AnnotatedPropertyInjectToConstructorInjectionRector\Source;
+
+final class SomeProductWithInterface implements SomeInterface
+{
+
+}

--- a/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/Source/SomeProductWithParent.php
+++ b/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/Source/SomeProductWithParent.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Tests\Rector\Architecture\DependencyInjection\AnnotatedPropertyInjectToConstructorInjectionRector\Source;
+
+final class SomeProductWithParent extends SomeParent
+{
+
+}

--- a/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/Source/SomeProductWithTrait.php
+++ b/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/Source/SomeProductWithTrait.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Tests\Rector\Architecture\DependencyInjection\AnnotatedPropertyInjectToConstructorInjectionRector\Source;
+
+final class SomeProductWithTrait
+{
+    use SomeTrait;
+}

--- a/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/Source/SomeTrait.php
+++ b/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/Source/SomeTrait.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Tests\Rector\Architecture\DependencyInjection\AnnotatedPropertyInjectToConstructorInjectionRector\Source;
+
+trait SomeTrait
+{
+}

--- a/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/Wrong/wrong2.php.inc
+++ b/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/Wrong/wrong2.php.inc
@@ -1,16 +1,16 @@
 <?php declare (strict_types=1);
 
-class ClassWithInjects
+class ClassWithInjects2
 {
     /**
      * @var stdClass
      * @autowired
      */
-    protected $property;
+    public $property;
 
     /**
      * @var DateTimeInterface
      * @inject
      */
-    public $otherProperty;
+    protected $otherProperty;
 }

--- a/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/Wrong/wrong3.php.inc
+++ b/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/Wrong/wrong3.php.inc
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+use Rector\Tests\Rector\Architecture\DependencyInjection\AnnotatedPropertyInjectToConstructorInjectionRector\Source\SomeProduct;
+
+class ClassWithInjects3
+{
+    /**
+     * @var SomeProduct
+     * @inject
+     */
+    protected $property;
+}

--- a/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/Wrong/wrong4.php.inc
+++ b/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/Wrong/wrong4.php.inc
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+use Rector\Tests\Rector\Architecture\DependencyInjection\AnnotatedPropertyInjectToConstructorInjectionRector\Source\SomeProductWithInterface;
+
+class ClassWithInjects4
+{
+    /**
+     * @var SomeProductWithInterface
+     * @inject
+     */
+    protected $property;
+}

--- a/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/Wrong/wrong5.php.inc
+++ b/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/Wrong/wrong5.php.inc
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+use Rector\Tests\Rector\Architecture\DependencyInjection\AnnotatedPropertyInjectToConstructorInjectionRector\Source\SomeProductWithTrait;
+
+class ClassWithInjects5
+{
+    /**
+     * @var SomeProductWithTrait
+     * @inject
+     */
+    protected $property;
+}

--- a/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/Wrong/wrong6.php.inc
+++ b/tests/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector/Wrong/wrong6.php.inc
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+use Rector\Tests\Rector\Architecture\DependencyInjection\AnnotatedPropertyInjectToConstructorInjectionRector\Source\SomeProductWithParent;
+
+class ClassWithInjects6
+{
+    /**
+     * @var SomeProductWithParent
+     * @inject
+     */
+    protected $property;
+}


### PR DESCRIPTION
Hey there,

First of all, thanks for the amazing project! It's been such a timesaver in upgrading some legacy code which doing manually would have been soul destroying.

I've been trying to use `AnnotatedPropertyInjectToConstructorInjectionRector` to clean up some uses of JMS DI in one of our projects. 
I've encountered a few issues which require manual cleanup after rector has run.
Hopefully these tests highlight the issues I'm facing, but if not, just shout.

I've not had time to look to see if I can fix these myself yet, but I'd imagine I wouldn't be able to do so quickly, so I just thought i get the ball rolling with some 'failing' tests.

Cheers!