### PR TITLE
Fix guzzle50.yml syntax error

### DIFF
--- a/config/level/guzzle/guzzle50.yml
+++ b/config/level/guzzle/guzzle50.yml
@@ -14,7 +14,7 @@ services:
 
     Rector\Rector\Function_\FunctionToMethodCallRector:
         'GuzzleHttp\json_decode': ['GuzzleHttp\Utils', 'jsonDecode']
-        'GuzzleHttp\get_path': ['GuzzleHttp\Utils': 'getPath']
+        'GuzzleHttp\get_path': ['GuzzleHttp\Utils', 'getPath']
     Rector\Rector\StaticCall\StaticCallToFunctionRector:
         'GuzzleHttp\Utils::setPath': 'GuzzleHttp\set_path'
         'GuzzleHttp\Pool::batch': 'GuzzleHttp\Pool\batch'


### PR DESCRIPTION
Unexpected characters (: 'getPath']) at line 18 (near "'GuzzleHttp\\get_path': ['GuzzleHttp\\Utils': 'getPath']").