### PR TITLE
[PHPUnit] Fix AssertCompareToSpecificMethodRector false positives

### DIFF
--- a/packages/PHPUnit/src/Rector/SpecificMethod/AssertCompareToSpecificMethodRector.php
+++ b/packages/PHPUnit/src/Rector/SpecificMethod/AssertCompareToSpecificMethodRector.php
@@ -85,8 +85,10 @@ final class AssertCompareToSpecificMethodRector extends AbstractPHPUnitRector
             return null;
         }
 
-        /** @var FuncCall $secondArgumentValue */
         $secondArgumentValue = $node->args[1]->value;
+        if (! $secondArgumentValue instanceof FuncCall) {
+            return null;
+        }
 
         $resolvedFuncCallName = $this->getName($secondArgumentValue);
         if ($resolvedFuncCallName === null) {

--- a/packages/PHPUnit/tests/Rector/SpecificMethod/AssertCompareToSpecificMethodRector/Correct/correct.php.inc
+++ b/packages/PHPUnit/tests/Rector/SpecificMethod/AssertCompareToSpecificMethodRector/Correct/correct.php.inc
@@ -9,5 +9,8 @@ final class MyTest extends \PHPUnit\Framework\TestCase
         $this->assertInternalType('string', $something);
         $this->assertEquals('string', $something['property']());
         $this->assertNotCount($foo[1]->result, $this->results);
+        $this->assertSame(1, $count);
+        $this->assertNotSame(2, $foo->count());
+        $this->assertEquals($count, $foo->sizeof);
     }
 }

--- a/packages/PHPUnit/tests/Rector/SpecificMethod/AssertCompareToSpecificMethodRector/Wrong/wrong.php.inc
+++ b/packages/PHPUnit/tests/Rector/SpecificMethod/AssertCompareToSpecificMethodRector/Wrong/wrong.php.inc
@@ -9,5 +9,8 @@ final class MyTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('string', gettype($something));
         $this->assertEquals('string', $something['property']());
         $this->assertNotSame($foo[1]->result, count($this->results));
+        $this->assertSame(1, $count);
+        $this->assertNotSame(2, $foo->count());
+        $this->assertEquals($count, $foo->sizeof);
     }
 }


### PR DESCRIPTION
When a property, method or variable has one of the names to be
refactored, e.g. `count`, it gets wrong refactored