### PR TITLE
use correct rector name

### DIFF
--- a/config/level/php/php70.yml
+++ b/config/level/php/php70.yml
@@ -10,5 +10,5 @@ services:
     # be careful, run this just once, since it can keep swapping order back and forth
     Rector\Php\Rector\List_\ListSwapArrayOrderRector: ~
 
-    Rector\Php\Rector\FuncCall\CallUserFuncRector: ~
+    Rector\Php\Rector\FuncCall\CallUserMethodRector : ~
     Rector\Php\Rector\FuncCall\EregToPregMatchRector: ~


### PR DESCRIPTION
For issue #745 : 

The rector name is actually for a method, not a function.