### PR TITLE
show Rector class on caused error

### DIFF
--- a/ecs.yml
+++ b/ecs.yml
@@ -101,6 +101,7 @@ parameters:
             - '*Command.php'
             - '*NodeVisitor.php'
             - '*CompilerPass.php'
+            - 'src/Rector/AbstractRector.php'
             - 'packages/Php/src/Rector/Unset_/UnsetCastRector.php'
             - 'packages/Php/src/Rector/ConstFetch/BarewordStringRector.php'
             # array type check

--- a/packages/CodeQuality/src/Rector/Identical/SimplifyConditionsRector.php
+++ b/packages/CodeQuality/src/Rector/Identical/SimplifyConditionsRector.php
@@ -99,9 +99,13 @@ final class SimplifyConditionsRector extends AbstractRector
         return $binaryOpNode->right instanceof BinaryOp;
     }
 
-    private function createInversedBooleanOp(BinaryOp $binaryOpNode): BinaryOp
+    private function createInversedBooleanOp(BinaryOp $binaryOpNode): ?BinaryOp
     {
         $inversedBinaryClass = $this->assignAndBinaryMap->getInversed($binaryOpNode);
+        if ($inversedBinaryClass === null) {
+            return null;
+        }
+
         return new $inversedBinaryClass($binaryOpNode->left, $binaryOpNode->right);
     }
 }

--- a/packages/CodeQuality/src/Rector/If_/SimplifyIfReturnBoolRector.php
+++ b/packages/CodeQuality/src/Rector/If_/SimplifyIfReturnBoolRector.php
@@ -29,9 +29,7 @@ if (strpos($docToken->getContent(), "\n") === false) {
 return false;
 CODE_SAMPLE
                 ,
-                <<<'CODE_SAMPLE'
-return strpos($docToken->getContent(), "\n") === false;
-CODE_SAMPLE
+                'return strpos($docToken->getContent(), "\n") === false;'
             ),
         ]);
     }

--- a/packages/CodeQuality/tests/Rector/If_/SimplifyIfReturnBoolRector/Correct/correct7.php.inc
+++ b/packages/CodeQuality/tests/Rector/If_/SimplifyIfReturnBoolRector/Correct/correct7.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\CodeQuality\Tests\Rector\If_\SimplifyIfReturnBoolRetor\Wrong;
+
+trait ValidatesAttributes
+{
+    public function validateDimensions()
+    {
+        return !(true || true);
+    }
+
+    public function function2($value, $secondValue)
+    {
+        return !(($value === true) || ($secondValue === true));
+    }
+
+    public function function3($attribute, $value, $parameters)
+    {
+        return !($this->failsBasicDimensionChecks($parameters, $width, $height) ||
+            $this->failsRatioCheck($parameters, $width, $height));
+    }
+}

--- a/packages/CodeQuality/tests/Rector/If_/SimplifyIfReturnBoolRector/SimplifyIfReturnBoolRectorTest.php
+++ b/packages/CodeQuality/tests/Rector/If_/SimplifyIfReturnBoolRector/SimplifyIfReturnBoolRectorTest.php
@@ -26,6 +26,7 @@ final class SimplifyIfReturnBoolRectorTest extends AbstractRectorTestCase
         yield [__DIR__ . '/Wrong/wrong4.php.inc', __DIR__ . '/Correct/correct4.php.inc'];
         yield [__DIR__ . '/Wrong/wrong5.php.inc', __DIR__ . '/Correct/correct5.php.inc'];
         yield [__DIR__ . '/Wrong/wrong6.php.inc', __DIR__ . '/Correct/correct6.php.inc'];
+        yield [__DIR__ . '/Wrong/wrong7.php.inc', __DIR__ . '/Correct/correct7.php.inc'];
     }
 
     protected function provideConfig(): string

--- a/packages/CodeQuality/tests/Rector/If_/SimplifyIfReturnBoolRector/Wrong/wrong7.php.inc
+++ b/packages/CodeQuality/tests/Rector/If_/SimplifyIfReturnBoolRector/Wrong/wrong7.php.inc
@@ -1,0 +1,34 @@
+<?php
+
+namespace Rector\CodeQuality\Tests\Rector\If_\SimplifyIfReturnBoolRetor\Wrong;
+
+trait ValidatesAttributes
+{
+    public function validateDimensions()
+    {
+        if (true || true) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function function2($value, $secondValue)
+    {
+        if (($value === true) || ($secondValue === true)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function function3($attribute, $value, $parameters)
+    {
+        if ($this->failsBasicDimensionChecks($parameters, $width, $height) ||
+            $this->failsRatioCheck($parameters, $width, $height)) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/packages/Jms/src/Rector/Property/JmsInjectAnnotationRector.php
+++ b/packages/Jms/src/Rector/Property/JmsInjectAnnotationRector.php
@@ -135,7 +135,7 @@ CODE_SAMPLE
 
             // collect error
             $this->errorCollector->addErrorWithRectorMessage(
-                $this,
+                static::class,
                 sprintf('Service "%s" was not found in DI Container of your Symfony App.', $serviceName)
             );
         }

--- a/src/Application/AppliedRectorCollector.php
+++ b/src/Application/AppliedRectorCollector.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Application;
+
+final class AppliedRectorCollector
+{
+    /**
+     * @var string[]
+     */
+    private $rectorClasses = [];
+
+    public function addRectorClass(string $rectorClass): void
+    {
+        $this->rectorClasses[] = $rectorClass;
+    }
+
+    public function reset(): void
+    {
+        $this->rectorClasses = [];
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getRectorClasses(): array
+    {
+        return $this->rectorClasses;
+    }
+}

--- a/src/Application/Error.php
+++ b/src/Application/Error.php
@@ -2,7 +2,6 @@
 
 namespace Rector\Application;
 
-use Rector\Contract\Rector\RectorInterface;
 use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
 
 final class Error
@@ -23,20 +22,20 @@ final class Error
     private $fileInfo;
 
     /**
-     * @var RectorInterface|null
+     * @var string|null
      */
-    private $rector;
+    private $rectorClass;
 
     public function __construct(
         SmartFileInfo $smartFileInfo,
         string $message,
         ?int $line = null,
-        ?RectorInterface $rector = null
+        ?string $rectorClass = null
     ) {
         $this->fileInfo = $smartFileInfo;
         $this->message = $message;
         $this->line = $line;
-        $this->rector = $rector;
+        $this->rectorClass = $rectorClass;
     }
 
     public function getFileInfo(): SmartFileInfo
@@ -54,8 +53,8 @@ final class Error
         return $this->line;
     }
 
-    public function getRector(): ?RectorInterface
+    public function getRectorClass(): ?string
     {
-        return $this->rector;
+        return $this->rectorClass;
     }
 }

--- a/src/Application/ErrorCollector.php
+++ b/src/Application/ErrorCollector.php
@@ -2,7 +2,6 @@
 
 namespace Rector\Application;
 
-use Rector\Contract\Rector\RectorInterface;
 use Rector\NodeTypeResolver\FileSystem\CurrentFileInfoProvider;
 
 final class ErrorCollector
@@ -35,8 +34,8 @@ final class ErrorCollector
         return $this->errors;
     }
 
-    public function addErrorWithRectorMessage(RectorInterface $rector, string $message): void
+    public function addErrorWithRectorMessage(string $rectorClass, string $message): void
     {
-        $this->errors[] = new Error($this->currentFileInfoProvider->getSmartFileInfo(), $message, null, $rector);
+        $this->errors[] = new Error($this->currentFileInfoProvider->getSmartFileInfo(), $message, null, $rectorClass);
     }
 }

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -184,8 +184,6 @@ final class ProcessCommand extends Command
 
         $this->additionalAutoloader->autoloadWithInputAndSource($input, $source);
 
-        $this->processCommandReporter->reportLoadedRectors();
-
         $this->processFileInfos($allFileInfos, (bool) $input->getOption(Option::HIDE_AUTOLOAD_ERRORS));
 
         $this->processCommandReporter->reportFileDiffs($this->fileDiffs);

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -244,6 +244,10 @@ final class ProcessCommand extends Command
 
             $this->errorCollector->addError(new Error($fileInfo, $message));
         } catch (Throwable $throwable) {
+            if ($this->symfonyStyle->isVerbose()) {
+                throw $throwable;
+            }
+
             $rectorClass = $this->matchRectorClass($throwable);
             if ($rectorClass) {
                 $this->errorCollector->addErrorWithRectorMessage($rectorClass, $throwable->getMessage());

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -4,6 +4,7 @@ namespace Rector\Console\Command;
 
 use Nette\Utils\FileSystem;
 use PHPStan\AnalysedCodeException;
+use Rector\Application\AppliedRectorCollector;
 use Rector\Application\Error;
 use Rector\Application\ErrorCollector;
 use Rector\Application\FileProcessor;
@@ -103,6 +104,11 @@ final class ProcessCommand extends Command
      */
     private $afterRectorCodingStyle;
 
+    /**
+     * @var AppliedRectorCollector
+     */
+    private $appliedRectorCollector;
+
     public function __construct(
         FileProcessor $fileProcessor,
         SymfonyStyle $symfonyStyle,
@@ -115,7 +121,8 @@ final class ProcessCommand extends Command
         RectorGuard $rectorGuard,
         FileSystemFileProcessor $fileSystemFileProcessor,
         ErrorCollector $errorCollector,
-        AfterRectorCodingStyle $afterRectorCodingStyle
+        AfterRectorCodingStyle $afterRectorCodingStyle,
+        AppliedRectorCollector $appliedRectorCollector
     ) {
         parent::__construct();
 
@@ -131,6 +138,7 @@ final class ProcessCommand extends Command
         $this->fileSystemFileProcessor = $fileSystemFileProcessor;
         $this->errorCollector = $errorCollector;
         $this->afterRectorCodingStyle = $afterRectorCodingStyle;
+        $this->appliedRectorCollector = $appliedRectorCollector;
     }
 
     protected function configure(): void
@@ -264,7 +272,8 @@ final class ProcessCommand extends Command
             if ($newContent !== $oldContent) {
                 $this->fileDiffs[] = new FileDiff(
                     $fileInfo->getPathname(),
-                    $this->differAndFormatter->diffAndFormat($oldContent, $newContent)
+                    $this->differAndFormatter->diffAndFormat($oldContent, $newContent),
+                    $this->appliedRectorCollector->getRectorClasses()
                 );
             }
         } else {

--- a/src/Console/Output/ProcessCommandReporter.php
+++ b/src/Console/Output/ProcessCommandReporter.php
@@ -98,8 +98,9 @@ final class ProcessCommandReporter
     {
         foreach ($errors as $error) {
             $message = sprintf(
-                'Could not process "%s" file, due to: %s"%s".',
+                'Could not process "%s" file%s, due to: %s"%s".',
                 $error->getFileInfo()->getPathname(),
+                $error->getRectorClass() ? ' by "' . $error->getRectorClass() . '"' : '',
                 PHP_EOL,
                 $error->getMessage()
             );

--- a/src/Console/Output/ProcessCommandReporter.php
+++ b/src/Console/Output/ProcessCommandReporter.php
@@ -37,23 +37,6 @@ final class ProcessCommandReporter
         $this->yamlFileProcessor = $yamlFileProcessor;
     }
 
-    public function reportLoadedRectors(): void
-    {
-        $rectorCount = $this->rectorNodeTraverser->getRectorCount() + $this->yamlFileProcessor->getYamlRectorsCount();
-
-        $this->symfonyStyle->title(sprintf('%d Loaded Rector%s', $rectorCount, $rectorCount === 1 ? '' : 's'));
-
-        $allRectors = array_merge(
-            $this->rectorNodeTraverser->getRectors() + $this->yamlFileProcessor->getYamlRectors()
-        );
-
-        $rectorClasses = array_map(function (RectorInterface $rector): string {
-            return get_class($rector);
-        }, $allRectors);
-
-        $this->symfonyStyle->listing($rectorClasses);
-    }
-
     /**
      * @param string[] $changedFiles
      */

--- a/src/Console/Output/ProcessCommandReporter.php
+++ b/src/Console/Output/ProcessCommandReporter.php
@@ -3,10 +3,7 @@
 namespace Rector\Console\Output;
 
 use Rector\Application\Error;
-use Rector\Contract\Rector\RectorInterface;
-use Rector\PhpParser\NodeTraverser\RectorNodeTraverser;
 use Rector\Reporting\FileDiff;
-use Rector\YamlRector\YamlFileProcessor;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use function Safe\sprintf;
 
@@ -17,24 +14,9 @@ final class ProcessCommandReporter
      */
     private $symfonyStyle;
 
-    /**
-     * @var RectorNodeTraverser
-     */
-    private $rectorNodeTraverser;
-
-    /**
-     * @var YamlFileProcessor
-     */
-    private $yamlFileProcessor;
-
-    public function __construct(
-        RectorNodeTraverser $rectorNodeTraverser,
-        SymfonyStyle $symfonyStyle,
-        YamlFileProcessor $yamlFileProcessor
-    ) {
+    public function __construct(SymfonyStyle $symfonyStyle)
+    {
         $this->symfonyStyle = $symfonyStyle;
-        $this->rectorNodeTraverser = $rectorNodeTraverser;
-        $this->yamlFileProcessor = $yamlFileProcessor;
     }
 
     /**
@@ -71,6 +53,13 @@ final class ProcessCommandReporter
             $this->symfonyStyle->newLine();
             $this->symfonyStyle->writeln($fileDiff->getDiff());
             $this->symfonyStyle->newLine();
+
+            if ($fileDiff->getAppliedRectorClasses()) {
+                $this->symfonyStyle->writeln('Applied rectors:');
+                $this->symfonyStyle->newLine();
+                $this->symfonyStyle->listing($fileDiff->getAppliedRectorClasses());
+                $this->symfonyStyle->newLine();
+            }
         }
     }
 

--- a/src/PhpParser/Node/AssignAndBinaryMap.php
+++ b/src/PhpParser/Node/AssignAndBinaryMap.php
@@ -20,6 +20,8 @@ use PhpParser\Node\Expr\BinaryOp;
 use PhpParser\Node\Expr\BinaryOp\BitwiseAnd;
 use PhpParser\Node\Expr\BinaryOp\BitwiseOr;
 use PhpParser\Node\Expr\BinaryOp\BitwiseXor;
+use PhpParser\Node\Expr\BinaryOp\BooleanAnd;
+use PhpParser\Node\Expr\BinaryOp\BooleanOr;
 use PhpParser\Node\Expr\BinaryOp\Concat;
 use PhpParser\Node\Expr\BinaryOp\Div;
 use PhpParser\Node\Expr\BinaryOp\Equal;
@@ -44,6 +46,7 @@ final class AssignAndBinaryMap
      * @var string[]
      */
     private $binaryOpToInverseClasses = [
+        BooleanOr::class => BooleanAnd::class,
         Identical::class => NotIdentical::class,
         NotIdentical::class => Identical::class,
         Equal::class => NotEqual::class,

--- a/src/Reporting/FileDiff.php
+++ b/src/Reporting/FileDiff.php
@@ -14,10 +14,19 @@ final class FileDiff
      */
     private $file;
 
-    public function __construct(string $file, string $diff)
+    /**
+     * @var string[]
+     */
+    private $appliedRectorClasses = [];
+
+    /**
+     * @param string[] $appliedRectorClasses
+     */
+    public function __construct(string $file, string $diff, array $appliedRectorClasses = [])
     {
         $this->file = $file;
         $this->diff = $diff;
+        $this->appliedRectorClasses = array_unique($appliedRectorClasses);
     }
 
     public function getDiff(): string
@@ -28,5 +37,13 @@ final class FileDiff
     public function getFile(): string
     {
         return $this->file;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAppliedRectorClasses(): array
+    {
+        return $this->appliedRectorClasses;
     }
 }


### PR DESCRIPTION
### Before

```
[ERROR] Could not process "test.php" file, due to:   
         "Class name must be a valid object or a string".                                                               
```

### After

```
[ERROR] Could not process "test.php" file by "Rector\CodeQuality\Rector\Identical\SimplifyConditionsRector", due to:   
         "Class name must be a valid object or a string".                                                               
```


---

```
--debug / -vvv
```

### Before

```
[ERROR] Message
```

### After

Full stack trace

---

### Before

![image](https://user-images.githubusercontent.com/924196/47973124-d6ed4d80-e0a2-11e8-80cd-5d226bf8198d.png)


### After

![image](https://user-images.githubusercontent.com/924196/47973113-bcb36f80-e0a2-11e8-8e75-7cee29dca86c.png)
