### PR TITLE
[PHPUnit] Convert iterator_count into assertCount

### DIFF
--- a/packages/PHPUnit/src/Rector/SpecificMethod/AssertCompareToSpecificMethodRector.php
+++ b/packages/PHPUnit/src/Rector/SpecificMethod/AssertCompareToSpecificMethodRector.php
@@ -18,6 +18,7 @@ final class AssertCompareToSpecificMethodRector extends AbstractPHPUnitRector
     private $defaultOldToNewMethods = [
         'count' => ['assertCount', 'assertNotCount'],
         'sizeof' => ['assertCount', 'assertNotCount'],
+        'iterator_count' => ['assertCount', 'assertNotCount'],
         'gettype' => ['assertInternalType', 'assertNotInternalType'],
         'get_class' => ['assertInstanceOf', 'assertNotInstanceOf'],
     ];

--- a/packages/PHPUnit/tests/Rector/SpecificMethod/AssertCompareToSpecificMethodRector/Correct/correct.php.inc
+++ b/packages/PHPUnit/tests/Rector/SpecificMethod/AssertCompareToSpecificMethodRector/Correct/correct.php.inc
@@ -5,6 +5,7 @@ final class MyTest extends \PHPUnit\Framework\TestCase
     public function test()
     {
         $this->assertCount(5, $something);
+        $this->assertCount(10, $something);
         $this->assertNotCount($count, $something, 'third argument');
         $this->assertInternalType('string', $something);
         $this->assertEquals('string', $something['property']());

--- a/packages/PHPUnit/tests/Rector/SpecificMethod/AssertCompareToSpecificMethodRector/Wrong/wrong.php.inc
+++ b/packages/PHPUnit/tests/Rector/SpecificMethod/AssertCompareToSpecificMethodRector/Wrong/wrong.php.inc
@@ -5,6 +5,7 @@ final class MyTest extends \PHPUnit\Framework\TestCase
     public function test()
     {
         $this->assertSame(5, count($something));
+        $this->assertEquals(10, iterator_count($something));
         $this->assertNotEquals($count, sizeof($something), 'third argument');
         $this->assertEquals('string', gettype($something));
         $this->assertEquals('string', $something['property']());


### PR DESCRIPTION
[Since PHPUnit 4](https://github.com/sebastianbergmann/phpunit/blob/4.0/src/Framework/Constraint/Count.php#L105) this is supported.

[Example of usage](https://github.com/aws/aws-sdk-php/pull/1435/files#diff-fe0d42e9e0bbedd4b5770a1c7f74a8a8L379).