### PR TITLE
[PHP 7.4] Add deprecations

### DIFF
--- a/config/level/php/php74.yml
+++ b/config/level/php/php74.yml
@@ -9,3 +9,4 @@ services:
         apache_request_headers: 'getallheaders'
         hebrevc: ['nl2br', 'hebrev']
     Rector\Php\Rector\FuncCall\ArrayKeyExistsOnPropertyRector: ~
+    Rector\Php\Rector\FuncCall\FilterVarToAddSlashesRector: ~

--- a/config/level/php/php74.yml
+++ b/config/level/php/php74.yml
@@ -10,3 +10,4 @@ services:
         hebrevc: ['nl2br', 'hebrev']
     Rector\Php\Rector\FuncCall\ArrayKeyExistsOnPropertyRector: ~
     Rector\Php\Rector\FuncCall\FilterVarToAddSlashesRector: ~
+    Rector\Php\Rector\StaticCall\ExportToReflectionFunctionRector: ~

--- a/config/level/php/php74.yml
+++ b/config/level/php/php74.yml
@@ -1,3 +1,10 @@
 services:
     Rector\Php\Rector\Property\TypedPropertyRector: ~
     Rector\Php\Rector\Assign\NullCoalescingOperatorRector: ~
+
+    Rector\Rector\Function_\FunctionReplaceRector:
+        # https://wiki.php.net/rfc/deprecations_php_7_4#the_real_type
+        is_float: 'is_real'
+        # https://wiki.php.net/rfc/deprecations_php_7_4#apache_request_headers_function
+        apache_request_headers: 'getallheaders'
+        hebrevc: ['nl2br', 'hebrev']

--- a/config/level/php/php74.yml
+++ b/config/level/php/php74.yml
@@ -12,3 +12,4 @@ services:
     Rector\Php\Rector\FuncCall\FilterVarToAddSlashesRector: ~
     Rector\Php\Rector\StaticCall\ExportToReflectionFunctionRector: ~
     Rector\Php\Rector\ConstFetch\ClassConstantToSelfClassRector: ~
+    Rector\Php\Rector\FuncCall\GetCalledClassToStaticClassRector: ~

--- a/config/level/php/php74.yml
+++ b/config/level/php/php74.yml
@@ -13,3 +13,4 @@ services:
     Rector\Php\Rector\StaticCall\ExportToReflectionFunctionRector: ~
     Rector\Php\Rector\ConstFetch\ClassConstantToSelfClassRector: ~
     Rector\Php\Rector\FuncCall\GetCalledClassToStaticClassRector: ~
+    Rector\Php\Rector\FuncCall\MbStrrposEncodingArgumentPositionRector: ~

--- a/config/level/php/php74.yml
+++ b/config/level/php/php74.yml
@@ -11,3 +11,4 @@ services:
     Rector\Php\Rector\FuncCall\ArrayKeyExistsOnPropertyRector: ~
     Rector\Php\Rector\FuncCall\FilterVarToAddSlashesRector: ~
     Rector\Php\Rector\StaticCall\ExportToReflectionFunctionRector: ~
+    Rector\Php\Rector\ConstFetch\ClassConstantToSelfClassRector: ~

--- a/config/level/php/php74.yml
+++ b/config/level/php/php74.yml
@@ -8,3 +8,4 @@ services:
         # https://wiki.php.net/rfc/deprecations_php_7_4#apache_request_headers_function
         apache_request_headers: 'getallheaders'
         hebrevc: ['nl2br', 'hebrev']
+    Rector\Php\Rector\FuncCall\ArrayKeyExistsOnPropertyRector: ~

--- a/ecs.yml
+++ b/ecs.yml
@@ -110,6 +110,7 @@ parameters:
             - 'packages/Php/src/Rector/Unset_/UnsetCastRector.php'
             - 'packages/Php/src/Rector/ConstFetch/BarewordStringRector.php'
             - 'packages/CodeQuality/src/Rector/Foreach_/ForeachToInArrayRector.php'
+            - 'packages/Php/src/Rector/MagicConstClass/ClassConstantToSelfClassRector.php'
             # array type check
             - 'src/RectorDefinition/RectorDefinition.php'
 

--- a/examples/ConfiguredProvideConfigRector.php
+++ b/examples/ConfiguredProvideConfigRector.php
@@ -82,7 +82,7 @@ final class ConfiguredProvideConfigRector extends AbstractRector
 
             [$class, $configuration] = $resolved;
 
-            $returnNode = new Return_(new ClassConstFetch(new FullyQualified($class), 'class'));
+            $returnNode = new Return_($this->createClassConstant($class, 'class'));
             $node->stmts[] = $this->builderFactory->method('getRectorClass')
                 ->makeProtected()
                 ->setReturnType('string')

--- a/examples/MergeIsCandidateRector.php
+++ b/examples/MergeIsCandidateRector.php
@@ -185,13 +185,13 @@ final class MergeIsCandidateRector extends AbstractRector
 
         if (count($paramTypes) > 1) {
             foreach ($paramTypes as $paramType) {
-                $classConstFetchNode = $this->createClassConstFetchFromClassName($paramType);
+                $classConstFetchNode = $this->createClassConstant($paramType, 'class');
                 $nodeToBeReturned->items[] = new ArrayItem($classConstFetchNode);
             }
         } elseif (count($paramTypes) === 1) {
-            $nodeToBeReturned->items[] = $this->createClassConstFetchFromClassName($paramTypes[0]);
+            $nodeToBeReturned->items[] = $this->createClassConstant($paramTypes[0], 'class');
         } else { // fallback to basic node
-            $nodeToBeReturned->items[] = $this->createClassConstFetchFromClassName(Node::class);
+            $nodeToBeReturned->items[] = $this->createClassConstant(Node::class, 'class');
         }
 
         return $this->builderFactory->method('getNodeTypes')
@@ -217,11 +217,6 @@ final class MergeIsCandidateRector extends AbstractRector
         $paramTagValueNode = $paramNode->value;
 
         return $this->resolveParamTagValueNodeToStrings($paramTagValueNode);
-    }
-
-    private function createClassConstFetchFromClassName(string $className): ClassConstFetch
-    {
-        return new ClassConstFetch(new FullyQualified($className), 'class');
     }
 
     private function replaceReturnFalseWithReturnNull(ClassMethod $classMethod): void

--- a/packages/ContributorTools/src/TemplateVariablesFactory.php
+++ b/packages/ContributorTools/src/TemplateVariablesFactory.php
@@ -84,7 +84,8 @@ CODE_SAMPLE;
     {
         $arrayNodes = [];
         foreach ($configuration->getNodeTypes() as $nodeType) {
-            $arrayNodes[] = new ArrayItem(new ClassConstFetch(new FullyQualified($nodeType), 'class'));
+            $classConstFetchNode = new ClassConstFetch(new FullyQualified($nodeType), 'class');
+            $arrayNodes[] = new ArrayItem($classConstFetchNode);
         }
 
         return $this->betterStandardPrinter->print(new Array_($arrayNodes));

--- a/packages/Php/src/Rector/FuncCall/ArrayKeyExistsOnPropertyRector.php
+++ b/packages/Php/src/Rector/FuncCall/ArrayKeyExistsOnPropertyRector.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Php\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use PHPStan\Type\ObjectType;
+use Rector\Rector\AbstractRector;
+use Rector\RectorDefinition\CodeSample;
+use Rector\RectorDefinition\RectorDefinition;
+
+/**
+ * @see https://wiki.php.net/rfc/deprecations_php_7_4 (not confirmed yet)
+ */
+final class ArrayKeyExistsOnPropertyRector extends AbstractRector
+{
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Change array_key_exists() on property to property_exists()', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+class SomeClass {
+     public $value;
+}
+$someClass = new SomeClass;
+
+array_key_exists('value', $someClass);
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+class SomeClass {
+     public $value;
+}
+$someClass = new SomeClass;
+
+property_exists($someClass, 'value');
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    /**
+     * @param FuncCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isName($node, 'array_key_exists')) {
+            return null;
+        }
+
+        if (! $this->getStaticType($node->args[1]->value) instanceof ObjectType) {
+            return null;
+        }
+
+        $node->name = new Name('property_exists');
+        $node->args = array_reverse($node->args);
+
+        return $node;
+    }
+}

--- a/packages/Php/src/Rector/FuncCall/GetCalledClassToStaticClassRector.php
+++ b/packages/Php/src/Rector/FuncCall/GetCalledClassToStaticClassRector.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Php\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use Rector\Rector\AbstractRector;
+use Rector\RectorDefinition\CodeSample;
+use Rector\RectorDefinition\RectorDefinition;
+
+/**
+ * @see https://wiki.php.net/rfc/deprecations_php_7_4 (not confirmed yet)
+ * @see https://3v4l.org/dJgXd
+ */
+final class GetCalledClassToStaticClassRector extends AbstractRector
+{
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Change __CLASS__ to self::class', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+   public function callOnMe()
+   {
+       var_dump( get_called_class());
+   }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+class SomeClass
+    {
+       public function callOnMe()
+       {
+           var_dump( static::class);
+       }
+    }
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    /**
+     * @param FuncCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isName($node, 'get_called_class')) {
+            return null;
+        }
+
+        return $this->createClassConstant('static', 'class');
+    }
+}

--- a/packages/Php/src/Rector/FuncCall/MbStrrposEncodingArgumentPositionRector.php
+++ b/packages/Php/src/Rector/FuncCall/MbStrrposEncodingArgumentPositionRector.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Php\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Scalar\LNumber;
+use PHPStan\Type\IntegerType;
+use Rector\Rector\AbstractRector;
+use Rector\RectorDefinition\CodeSample;
+use Rector\RectorDefinition\RectorDefinition;
+
+/**
+ * @see https://wiki.php.net/rfc/deprecations_php_7_4 (not confirmed yet)
+ * @see https://3v4l.org/kLdtB
+ */
+final class MbStrrposEncodingArgumentPositionRector extends AbstractRector
+{
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Change mb_strrpos() encoding argument position', [
+            new CodeSample('mb_strrpos($text, "abc", "UTF-8");', 'mb_strrpos($text, "abc", 0, "UTF-8");'),
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    /**
+     * @param FuncCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isName($node, 'mb_strrpos')) {
+            return null;
+        }
+
+        if (! isset($node->args[2])) {
+            return null;
+        }
+
+        if (isset($node->args[3])) {
+            return null;
+        }
+
+        if ($this->getStaticType($node->args[2]->value) instanceof IntegerType) {
+            return null;
+        }
+
+        $node->args[3] = $node->args[2];
+        $node->args[2] = new Arg(new LNumber(0));
+
+        return $node;
+    }
+}

--- a/packages/Php/src/Rector/MagicConstClass/ClassConstantToSelfClassRector.php
+++ b/packages/Php/src/Rector/MagicConstClass/ClassConstantToSelfClassRector.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Php\Rector\MagicConstClass;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\MagicConst\Class_;
+use Rector\Rector\AbstractRector;
+use Rector\RectorDefinition\CodeSample;
+use Rector\RectorDefinition\RectorDefinition;
+
+/**
+ * @see https://wiki.php.net/rfc/deprecations_php_7_4 (not confirmed yet)
+ * @see https://3v4l.org/INd7o
+ */
+final class ClassConstantToSelfClassRector extends AbstractRector
+{
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Change __CLASS__ to self::class', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+   public function callOnMe()
+   {
+       var_dump(__CLASS__);
+   }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+   public function callOnMe()
+   {
+       var_dump(self::class);
+   }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        return new ClassConstFetch(new Name('self'), 'class');
+    }
+}

--- a/packages/Php/src/Rector/StaticCall/ExportToReflectionFunctionRector.php
+++ b/packages/Php/src/Rector/StaticCall/ExportToReflectionFunctionRector.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Php\Rector\StaticCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\Cast\String_;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\StaticCall;
+use Rector\Rector\AbstractRector;
+use Rector\RectorDefinition\CodeSample;
+use Rector\RectorDefinition\RectorDefinition;
+
+/**
+ * @see https://wiki.php.net/rfc/deprecations_php_7_4 (not confirmed yet)
+ * @see https://3v4l.org/RTCUq
+ */
+final class ExportToReflectionFunctionRector extends AbstractRector
+{
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Change export() to ReflectionFunction alternatives', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+$reflectionFunction = ReflectionFunction::export('foo');
+$reflectionFunctionAsString = ReflectionFunction::export('foo', true);
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+$reflectionFunction = new ReflectionFunction('foo');
+$reflectionFunctionAsString = (string) new ReflectionFunction('foo');
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [StaticCall::class];
+    }
+
+    /**
+     * @param StaticCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isName($node->class, 'ReflectionFunction')) {
+            return null;
+        }
+
+        if (! $this->isName($node, 'export')) {
+            return null;
+        }
+
+        $newNode = new New_($node->class, [new Arg($node->args[0]->value)]);
+
+        if (isset($node->args[1]) && $this->isTrue($node->args[1]->value)) {
+            return new String_($newNode);
+        }
+
+        return $newNode;
+    }
+}

--- a/packages/Php/tests/Rector/FuncCall/ArrayKeyExistsOnPropertyRector/ArrayKeyExistsOnPropertyRectorTest.php
+++ b/packages/Php/tests/Rector/FuncCall/ArrayKeyExistsOnPropertyRector/ArrayKeyExistsOnPropertyRectorTest.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Php\Tests\Rector\FuncCall\ArrayKeyExistsOnPropertyRector;
+
+use Rector\Php\Rector\FuncCall\ArrayKeyExistsOnPropertyRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ArrayKeyExistsOnPropertyRectorTest extends AbstractRectorTestCase
+{
+    public function test(): void
+    {
+        $this->doTestFiles([__DIR__ . '/Fixture/fixture.php.inc']);
+    }
+
+    protected function getRectorClass(): string
+    {
+        return ArrayKeyExistsOnPropertyRector::class;
+    }
+}

--- a/packages/Php/tests/Rector/FuncCall/ArrayKeyExistsOnPropertyRector/Fixture/fixture.php.inc
+++ b/packages/Php/tests/Rector/FuncCall/ArrayKeyExistsOnPropertyRector/Fixture/fixture.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Php\Tests\Rector\FuncCall\ArrayKeyExistsOnPropertyRector\Fixture;
+
+class SomeClass {
+     public $value;
+}
+$someClass = new SomeClass;
+
+array_key_exists('value', $someClass);
+
+?>
+-----
+<?php
+
+namespace Rector\Php\Tests\Rector\FuncCall\ArrayKeyExistsOnPropertyRector\Fixture;
+
+class SomeClass {
+     public $value;
+}
+$someClass = new SomeClass;
+
+property_exists($someClass, 'value');
+
+?>

--- a/packages/Php/tests/Rector/FuncCall/FilterVarToAddSlashesRector/FilterVarToAddSlashesRectorTest.php
+++ b/packages/Php/tests/Rector/FuncCall/FilterVarToAddSlashesRector/FilterVarToAddSlashesRectorTest.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Php\Tests\Rector\FuncCall\FilterVarToAddSlashesRector;
+
+use Rector\Php\Rector\FuncCall\FilterVarToAddSlashesRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class FilterVarToAddSlashesRectorTest extends AbstractRectorTestCase
+{
+    public function test(): void
+    {
+        $this->doTestFiles([__DIR__ . '/Fixture/fixture.php.inc']);
+    }
+
+    protected function getRectorClass(): string
+    {
+        return FilterVarToAddSlashesRector::class;
+    }
+}

--- a/packages/Php/tests/Rector/FuncCall/FilterVarToAddSlashesRector/Fixture/fixture.php.inc
+++ b/packages/Php/tests/Rector/FuncCall/FilterVarToAddSlashesRector/Fixture/fixture.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Php\Tests\Rector\FuncCall\FilterVarToAddSlashesRector\Fixture;
+
+$var= "Satya's here!";
+filter_var($var, FILTER_SANITIZE_MAGIC_QUOTES);
+
+?>
+-----
+<?php
+
+namespace Rector\Php\Tests\Rector\FuncCall\FilterVarToAddSlashesRector\Fixture;
+
+$var= "Satya's here!";
+addslashes($var);
+
+?>

--- a/packages/Php/tests/Rector/FuncCall/GetCalledClassToStaticClassRector/Fixture/fixture.php.inc
+++ b/packages/Php/tests/Rector/FuncCall/GetCalledClassToStaticClassRector/Fixture/fixture.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Php\Tests\Rector\FuncCall\GetCalledClassToStaticClassRector\Fixture;
+
+class SomeClass
+{
+    public function callOnMe()
+    {
+        var_dump( get_called_class());
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Php\Tests\Rector\FuncCall\GetCalledClassToStaticClassRector\Fixture;
+
+class SomeClass
+{
+    public function callOnMe()
+    {
+        var_dump( static::class);
+    }
+}
+
+?>

--- a/packages/Php/tests/Rector/FuncCall/GetCalledClassToStaticClassRector/GetCalledClassToStaticClassRectorTest.php
+++ b/packages/Php/tests/Rector/FuncCall/GetCalledClassToStaticClassRector/GetCalledClassToStaticClassRectorTest.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Php\Tests\Rector\FuncCall\GetCalledClassToStaticClassRector;
+
+use Rector\Php\Rector\FuncCall\GetCalledClassToStaticClassRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class GetCalledClassToStaticClassRectorTest extends AbstractRectorTestCase
+{
+    public function test(): void
+    {
+        $this->doTestFiles([__DIR__ . '/Fixture/fixture.php.inc']);
+    }
+
+    protected function getRectorClass(): string
+    {
+        return GetCalledClassToStaticClassRector::class;
+    }
+}

--- a/packages/Php/tests/Rector/FuncCall/MbStrrposEncodingArgumentPositionRector/Fixture/fixture.php.inc
+++ b/packages/Php/tests/Rector/FuncCall/MbStrrposEncodingArgumentPositionRector/Fixture/fixture.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Php\Tests\Rector\FuncCall\MbStrrposEncodingArgumentPositionRector\Fixture;
+
+class FirstClass
+{
+    public function run()
+    {
+        $text = '123';
+        mb_strrpos($text, 'abc', 'UTF-8');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Php\Tests\Rector\FuncCall\MbStrrposEncodingArgumentPositionRector\Fixture;
+
+class FirstClass
+{
+    public function run()
+    {
+        $text = '123';
+        mb_strrpos($text, 'abc', 0, 'UTF-8');
+    }
+}
+
+?>

--- a/packages/Php/tests/Rector/FuncCall/MbStrrposEncodingArgumentPositionRector/MbStrrposEncodingArgumentPositionRectorTest.php
+++ b/packages/Php/tests/Rector/FuncCall/MbStrrposEncodingArgumentPositionRector/MbStrrposEncodingArgumentPositionRectorTest.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Php\Tests\Rector\FuncCall\MbStrrposEncodingArgumentPositionRector;
+
+use Rector\Php\Rector\FuncCall\MbStrrposEncodingArgumentPositionRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class MbStrrposEncodingArgumentPositionRectorTest extends AbstractRectorTestCase
+{
+    public function test(): void
+    {
+        $this->doTestFiles([__DIR__ . '/Fixture/fixture.php.inc']);
+    }
+
+    protected function getRectorClass(): string
+    {
+        return MbStrrposEncodingArgumentPositionRector::class;
+    }
+}

--- a/packages/Php/tests/Rector/MagicConstClass/ClassConstantToSelfClassRector/ClassConstantToSelfClassRectorTest.php
+++ b/packages/Php/tests/Rector/MagicConstClass/ClassConstantToSelfClassRector/ClassConstantToSelfClassRectorTest.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Php\Tests\Rector\MagicConstClass\ClassConstantToSelfClassRector;
+
+use Rector\Php\Rector\MagicConstClass\ClassConstantToSelfClassRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ClassConstantToSelfClassRectorTest extends AbstractRectorTestCase
+{
+    public function test(): void
+    {
+        $this->doTestFiles([__DIR__ . '/Fixture/fixture.php.inc']);
+    }
+
+    protected function getRectorClass(): string
+    {
+        return ClassConstantToSelfClassRector::class;
+    }
+}

--- a/packages/Php/tests/Rector/MagicConstClass/ClassConstantToSelfClassRector/Fixture/fixture.php.inc
+++ b/packages/Php/tests/Rector/MagicConstClass/ClassConstantToSelfClassRector/Fixture/fixture.php.inc
@@ -4,10 +4,10 @@ namespace Rector\Php\Tests\Rector\ConstFetch\ClassConstantToSelfClassRector\Fixt
 
 class SomeClass
 {
-   public function callOnMe()
-   {
-       var_dump(__CLASS__);
-   }
+    public function callOnMe()
+    {
+        var_dump(__CLASS__);
+    }
 }
 
 ?>
@@ -18,10 +18,10 @@ namespace Rector\Php\Tests\Rector\ConstFetch\ClassConstantToSelfClassRector\Fixt
 
 class SomeClass
 {
-   public function callOnMe()
-   {
-       var_dump(self::class);
-   }
+    public function callOnMe()
+    {
+        var_dump(self::class);
+    }
 }
 
 ?>

--- a/packages/Php/tests/Rector/MagicConstClass/ClassConstantToSelfClassRector/Fixture/fixture.php.inc
+++ b/packages/Php/tests/Rector/MagicConstClass/ClassConstantToSelfClassRector/Fixture/fixture.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Php\Tests\Rector\ConstFetch\ClassConstantToSelfClassRector\Fixture;
+
+class SomeClass
+{
+   public function callOnMe()
+   {
+       var_dump(__CLASS__);
+   }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Php\Tests\Rector\ConstFetch\ClassConstantToSelfClassRector\Fixture;
+
+class SomeClass
+{
+   public function callOnMe()
+   {
+       var_dump(self::class);
+   }
+}
+
+?>

--- a/packages/Php/tests/Rector/StaticCall/ExportToReflectionFunctionRector/ExportToReflectionFunctionRectorTest.php
+++ b/packages/Php/tests/Rector/StaticCall/ExportToReflectionFunctionRector/ExportToReflectionFunctionRectorTest.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Php\Tests\Rector\StaticCall\ExportToReflectionFunctionRector;
+
+use Rector\Php\Rector\StaticCall\ExportToReflectionFunctionRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ExportToReflectionFunctionRectorTest extends AbstractRectorTestCase
+{
+    public function test(): void
+    {
+        $this->doTestFiles([__DIR__ . '/Fixture/fixture.php.inc']);
+    }
+
+    protected function getRectorClass(): string
+    {
+        return ExportToReflectionFunctionRector::class;
+    }
+}

--- a/packages/Php/tests/Rector/StaticCall/ExportToReflectionFunctionRector/Fixture/fixture.php.inc
+++ b/packages/Php/tests/Rector/StaticCall/ExportToReflectionFunctionRector/Fixture/fixture.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Php\Tests\Rector\StaticCall\ExportToReflectionFunctionRector\Fixture;
+
+class ReflectableFunction
+{
+    public function run()
+    {
+        $reflectionFunction = \ReflectionFunction::export('foo');
+        $reflectionFunctionAsString = \ReflectionFunction::export('foo', true);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Php\Tests\Rector\StaticCall\ExportToReflectionFunctionRector\Fixture;
+
+class ReflectableFunction
+{
+    public function run()
+    {
+        $reflectionFunction = new \ReflectionFunction('foo');
+        $reflectionFunctionAsString = (string) new \ReflectionFunction('foo');
+    }
+}
+
+?>

--- a/src/PhpParser/Node/NodeFactory.php
+++ b/src/PhpParser/Node/NodeFactory.php
@@ -50,7 +50,11 @@ final class NodeFactory
      */
     public function createClassConstant(string $className, string $constantName): ClassConstFetch
     {
-        $classNameNode = new FullyQualified($className);
+        if (in_array($className, ['static', 'parent', 'self'], true)) {
+            $classNameNode = new Name($className);
+        } else {
+            $classNameNode = new FullyQualified($className);
+        }
 
         $classConstFetchNode = $this->builderFactory->classConstFetch($classNameNode, $constantName);
         $classConstFetchNode->class->setAttribute(Attribute::RESOLVED_NAME, $classNameNode);

--- a/src/Rector/Function_/FunctionReplaceRector.php
+++ b/src/Rector/Function_/FunctionReplaceRector.php
@@ -13,12 +13,12 @@ use Rector\RectorDefinition\RectorDefinition;
 final class FunctionReplaceRector extends AbstractRector
 {
     /**
-     * @var string[]
+     * @var string[]|string[][]
      */
     private $oldFunctionToNewFunction = [];
 
     /**
-     * @param string[] $oldFunctionToNewFunction
+     * @param string[]|string[][] $oldFunctionToNewFunction
      */
     public function __construct(array $oldFunctionToNewFunction)
     {

--- a/src/Rector/Function_/FunctionReplaceRector.php
+++ b/src/Rector/Function_/FunctionReplaceRector.php
@@ -3,6 +3,7 @@
 namespace Rector\Rector\Function_;
 
 use PhpParser\Node;
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name\FullyQualified;
 use Rector\Rector\AbstractRector;
@@ -55,9 +56,37 @@ final class FunctionReplaceRector extends AbstractRector
                 continue;
             }
 
+            // rename of function into wrap function
+            // e.g. one($arg) → three(two($agr));
+            if (is_array($newFunction)) {
+                return $this->wrapFuncCalls($node, $newFunction);
+            }
+
             $node->name = new FullyQualified($newFunction);
         }
 
         return $node;
+    }
+
+    /**
+     * @param string[] $newFunctions
+     */
+    private function wrapFuncCalls(FuncCall $funcCallNode, array $newFunctions): FuncCall
+    {
+        $previousNode = null;
+        $newFunctions = array_reverse($newFunctions);
+
+        foreach ($newFunctions as $wrapFunction) {
+            if ($previousNode === null) {
+                $arguments = $funcCallNode->args;
+            } else {
+                $arguments = [new Arg($previousNode)];
+            }
+
+            $funcCallNode = new FuncCall(new FullyQualified($wrapFunction), $arguments);
+            $previousNode = $funcCallNode;
+        }
+
+        return $funcCallNode;
     }
 }

--- a/tests/Rector/Function_/FunctionReplaceRector/Fixture/double_function.php.inc
+++ b/tests/Rector/Function_/FunctionReplaceRector/Fixture/double_function.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\Rector\Function_\FunctionReplaceRector\Fixture;
+
+class DoubleFunction
+{
+    public function run($text)
+    {
+        hebrevc($text);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Rector\Function_\FunctionReplaceRector\Fixture;
+
+class DoubleFunction
+{
+    public function run($text)
+    {
+        \nl2br(\hebrev($text));
+    }
+}
+
+?>

--- a/tests/Rector/Function_/FunctionReplaceRector/Fixture/fixture.php.inc
+++ b/tests/Rector/Function_/FunctionReplaceRector/Fixture/fixture.php.inc
@@ -1,5 +1,7 @@
 <?php
 
+namespace Rector\Tests\Rector\Function_\FunctionReplaceRector\Fixture;
+
 class SomeClass
 {
     public function someMethod()
@@ -15,6 +17,8 @@ function a(callable $a) {
 ?>
 -----
 <?php
+
+namespace Rector\Tests\Rector\Function_\FunctionReplaceRector\Fixture;
 
 class SomeClass
 {

--- a/tests/Rector/Function_/FunctionReplaceRector/Fixture/fixture2.php.inc
+++ b/tests/Rector/Function_/FunctionReplaceRector/Fixture/fixture2.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\Rector\Function_\FunctionReplaceRector\Fixture;
 
-class SomeClass
+class CaseSensitive
 {
     protected function configure(): void
     {
@@ -22,7 +22,7 @@ class SomeClass
 
 namespace Rector\Tests\Rector\Function_\FunctionReplaceRector\Fixture;
 
-class SomeClass
+class CaseSensitive
 {
     protected function configure(): void
     {

--- a/tests/Rector/Function_/FunctionReplaceRector/FunctionReplaceRectorTest.php
+++ b/tests/Rector/Function_/FunctionReplaceRector/FunctionReplaceRectorTest.php
@@ -9,7 +9,11 @@ final class FunctionReplaceRectorTest extends AbstractRectorTestCase
 {
     public function test(): void
     {
-        $this->doTestFiles([__DIR__ . '/Fixture/fixture.php.inc', __DIR__ . '/Fixture/fixture2.php.inc']);
+        $this->doTestFiles([
+            __DIR__ . '/Fixture/fixture.php.inc',
+            __DIR__ . '/Fixture/fixture2.php.inc',
+            __DIR__ . '/Fixture/double_function.php.inc',
+        ]);
     }
 
     protected function getRectorClass(): string
@@ -25,6 +29,7 @@ final class FunctionReplaceRectorTest extends AbstractRectorTestCase
         return [
             'view' => 'Laravel\Templating\render',
             'sprintf' => 'Safe\sprintf',
+            'hebrevc' => ['nl2br', 'hebrev'],
         ];
     }
 }

--- a/tests/Rector/Property/PropertyNameReplacerRector/Fixture/fixture.php.inc
+++ b/tests/Rector/Property/PropertyNameReplacerRector/Fixture/fixture.php.inc
@@ -1,6 +1,10 @@
 <?php
 
-$someService = new SomeClass;
+namespace Rector\Tests\Rector\Property\PropertyNameReplacerRector\Fixture;
+
+use Rector\Tests\Rector\Property\PropertyNameReplacerRector\Source\ClassWithProperties;
+
+$someService = new ClassWithProperties();
 $someService->oldProperty = 5;
 $someService->anotherOLDProperty = 5;
 
@@ -8,7 +12,11 @@ $someService->anotherOLDProperty = 5;
 -----
 <?php
 
-$someService = new SomeClass;
+namespace Rector\Tests\Rector\Property\PropertyNameReplacerRector\Fixture;
+
+use Rector\Tests\Rector\Property\PropertyNameReplacerRector\Source\ClassWithProperties;
+
+$someService = new ClassWithProperties();
 $someService->newProperty = 5;
 $someService->anotherNewProperty = 5;
 

--- a/tests/Rector/Property/PropertyNameReplacerRector/PropertyNameReplacerRectorTest.php
+++ b/tests/Rector/Property/PropertyNameReplacerRector/PropertyNameReplacerRectorTest.php
@@ -4,6 +4,7 @@ namespace Rector\Tests\Rector\Property\PropertyNameReplacerRector;
 
 use Rector\Rector\Property\PropertyNameReplacerRector;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Rector\Tests\Rector\Property\PropertyNameReplacerRector\Source\ClassWithProperties;
 
 final class PropertyNameReplacerRectorTest extends AbstractRectorTestCase
 {
@@ -22,9 +23,11 @@ final class PropertyNameReplacerRectorTest extends AbstractRectorTestCase
      */
     protected function getRectorConfiguration(): array
     {
-        return ['SomeClass' => [
-            'oldProperty' => 'newProperty',
-            'anotherOldProperty' => 'anotherNewProperty',
-        ]];
+        return [
+            ClassWithProperties::class => [
+                'oldProperty' => 'newProperty',
+                'anotherOldProperty' => 'anotherNewProperty',
+            ],
+        ];
     }
 }

--- a/tests/Rector/Property/PropertyNameReplacerRector/Source/ClassWithProperties.php
+++ b/tests/Rector/Property/PropertyNameReplacerRector/Source/ClassWithProperties.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Tests\Rector\Property\PropertyNameReplacerRector\Source;
+
+final class ClassWithProperties
+{
+
+}


### PR DESCRIPTION
See https://wiki.php.net/rfc/deprecations_php_7_4

Ref #893 

## New Rectors

- `Rector\Php\Rector\FuncCall\ArrayKeyExistsOnPropertyRector`
- `Rector\Php\Rector\FuncCall\FilterVarToAddSlashesRector`
- `Rector\Php\Rector\StaticCall\ExportToReflectionFunctionRector`
- `Rector\Php\Rector\ConstFetch\ClassConstantToSelfClassRector`
- `Rector\Php\Rector\FuncCall\GetCalledClassToStaticClassRector`
- `Rector\Php\Rector\FuncCall\MbStrrposEncodingArgumentPositionRector`