### PR TITLE
Add "exclude_rectors" parameters to skip selected rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ parameters:
         - 'vendor/project-without-composer'
 ```
 
+## Exclude Paths and Rectors
+
 You can also **exclude files or directories** (with regex or [fnmatch](http://php.net/manual/en/function.fnmatch.php)):
 
 ```yaml
@@ -80,6 +82,15 @@ You can also **exclude files or directories** (with regex or [fnmatch](http://ph
 parameters:
     exclude_paths:
         - '*/src/*/Tests/*'
+```
+
+Do you want to use whole set, except that one rule? Exclude it:
+
+```yaml
+# rector.yml
+parameters:
+    exclude_rectors:
+        - 'Rector\CodeQuality\Rector\If_\SimplifyIfReturnBoolRector'
 ```
 
 ## Running Rector

--- a/packages/ContributorTools/src/Command/GenerateDocsCommand.php
+++ b/packages/ContributorTools/src/Command/GenerateDocsCommand.php
@@ -44,7 +44,7 @@ final class GenerateDocsCommand extends AbstractCommand implements ContributorCo
     protected function configure(): void
     {
         $this->setName(CommandNaming::classToName(self::class));
-        $this->setDescription('Generates markdown documentation of all Rectors.');
+        $this->setDescription('Generates markdown documentation of all Rectors');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Console/Command/LevelsCommand.php
+++ b/src/Console/Command/LevelsCommand.php
@@ -30,7 +30,7 @@ final class LevelsCommand extends AbstractCommand
     protected function configure(): void
     {
         $this->setName(CommandNaming::classToName(self::class));
-        $this->setDescription('List available levels.');
+        $this->setDescription('List available levels');
         $this->addArgument('name', InputArgument::OPTIONAL, 'Filter levels by provded name');
     }
 

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -93,7 +93,7 @@ final class ProcessCommand extends AbstractCommand
     protected function configure(): void
     {
         $this->setName(CommandNaming::classToName(self::class));
-        $this->setDescription('Reconstruct set of your code.');
+        $this->setDescription('Upgrade or refactor source code with provided rectors');
         $this->addArgument(
             Option::SOURCE,
             InputArgument::REQUIRED | InputArgument::IS_ARRAY,

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -131,7 +131,7 @@ final class ProcessCommand extends AbstractCommand
     {
         $this->rectorGuard->ensureSomeRectorsAreRegistered();
 
-        $source = (string) $input->getArgument(Option::SOURCE);
+        $source = (array) $input->getArgument(Option::SOURCE);
 
         $this->configuration->resolveFromInput($input);
 

--- a/src/DependencyInjection/CompilerPass/RemoveExcludedRectorsCompilerPass.php
+++ b/src/DependencyInjection/CompilerPass/RemoveExcludedRectorsCompilerPass.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Rector\DependencyInjection\CompilerPass;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class RemoveExcludedRectorsCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @var string
+     */
+    private const EXCLUDE_RECTORS_KEY = 'exclude_rectors';
+
+    public function process(ContainerBuilder $containerBuilder): void
+    {
+        $parameterBag = $containerBuilder->getParameterBag();
+        if ($parameterBag->has(self::EXCLUDE_RECTORS_KEY) === false) {
+            return;
+        }
+
+        $excludedRectors = (array) $parameterBag->get(self::EXCLUDE_RECTORS_KEY);
+
+        foreach ($containerBuilder->getDefinitions() as $id => $definition) {
+            if ($definition->getClass() === null) {
+                continue;
+            }
+
+            if (! in_array($definition->getClass(), $excludedRectors, true)) {
+                continue;
+            }
+
+            $containerBuilder->removeDefinition($id);
+        }
+    }
+}

--- a/src/DependencyInjection/RectorKernel.php
+++ b/src/DependencyInjection/RectorKernel.php
@@ -3,6 +3,7 @@
 namespace Rector\DependencyInjection;
 
 use Rector\Contract\Rector\PhpRectorInterface;
+use Rector\DependencyInjection\CompilerPass\RemoveExcludedRectorsCompilerPass;
 use Rector\DependencyInjection\Loader\TolerantRectorYamlFileLoader;
 use Rector\FileSystemRector\Contract\FileSystemRectorInterface;
 use Symfony\Component\Config\Loader\DelegatingLoader;
@@ -52,6 +53,8 @@ final class RectorKernel extends Kernel
 
     protected function build(ContainerBuilder $containerBuilder): void
     {
+        $containerBuilder->addCompilerPass(new RemoveExcludedRectorsCompilerPass());
+
         // for defaults
         $containerBuilder->addCompilerPass(new AutowireSinglyImplementedCompilerPass());
         $containerBuilder->addCompilerPass(new AutowireArrayParameterCompilerPass());

--- a/src/config/config.yml
+++ b/src/config/config.yml
@@ -1,10 +1,9 @@
 imports:
-    - { resource: '../../packages/**/src/config/config.yml' }
-    # new config location
     - { resource: '../../packages/**/config/config.yml' }
     - { resource: 'services.yml' }
     - { resource: 'external-services.yml' }
 
 parameters:
     exclude_paths: []
+    exclude_rectors: []
     autoload_paths: []

--- a/src/config/external-services.yml
+++ b/src/config/external-services.yml
@@ -35,8 +35,31 @@ services:
     Symplify\PackageBuilder\EventSubscriber\ParameterTypoProofreaderEventSubscriber: ~
     Symplify\PackageBuilder\Parameter\ParameterTypoProofreader:
         $correctToTypos:
+            # keep "exclude_" explicit, to get typos to the correct key
             exclude_paths:
-                - '#(ex(c)?lude|ignore)((d)?_(path(s)?|dir(s)?|file(s)?))?#'
+                - 'exclude_path'
+                - 'exclude_dir'
+                - 'exclude_dirs'
+                - 'exclude_file'
+                - 'exclude_files'
+                - 'ignore_path'
+                - 'ignore_paths'
+                - 'ignore_dir'
+                - 'ignore_dirs'
+                - 'ignore_file'
+                - 'ignore_files'
+                - 'skip_path'
+                - 'skip_paths'
+                - 'skip_dir'
+                - 'skip_dirs'
+                - 'skip_file'
+                - 'skip_files'
+            exclude_rectors:
+                - 'exclude_rector'
+                - 'excluded_rector'
+                - 'excluded_rectors'
+                - 'skip_rector'
+                - 'skip_rectors'
             autoload_paths:
                 # https://regex101.com/r/aXEZYk/1
                 - '#(autoload|include|bootstrap)((ed)?_(path(s)?|dir(s)?|file(s)?))?#'


### PR DESCRIPTION
Do you want to use whole set, except that one rule? Exclude it:

```yaml
# rector.yml
parameters:
    exclude_rectors:
        - 'Rector\CodeQuality\Rector\If_\SimplifyIfReturnBoolRector'
```