### PR TITLE
[Php] Add NullCoalescingOperatorRector

### DIFF
--- a/config/level/php/php74.yml
+++ b/config/level/php/php74.yml
@@ -14,3 +14,4 @@ services:
     Rector\Php\Rector\FuncCall\GetCalledClassToStaticClassRector: ~
     Rector\Php\Rector\FuncCall\MbStrrposEncodingArgumentPositionRector: ~
     Rector\Php\Rector\Double\RealToFloatTypeCastRector: ~
+    Rector\Php\Rector\Assign\NullCoalescingOperatorRector: ~

--- a/docs/AllRectorsOverview.md
+++ b/docs/AllRectorsOverview.md
@@ -47,6 +47,7 @@
 - [Php\BinaryOp](#phpbinaryop)
 - [Php\ClassConst](#phpclassconst)
 - [Php\ConstFetch](#phpconstfetch)
+- [Php\Double](#phpdouble)
 - [Php\Each](#phpeach)
 - [Php\FuncCall](#phpfunccall)
 - [Php\FunctionLike](#phpfunctionlike)
@@ -409,6 +410,33 @@ Shortens if return false/true to direct return
 -
 -return false;
 +return strpos($docToken->getContent(), "\n") === false;
+```
+
+<br>
+
+### `ConsecutiveNullCompareReturnsToNullCoalesceQueueRector`
+
+- class: `Rector\CodeQuality\Rector\If_\ConsecutiveNullCompareReturnsToNullCoalesceQueueRector`
+
+Change multiple null compares to ?? queue
+
+```diff
+ class SomeClass
+ {
+     public function run()
+     {
+-        if (null !== $this->orderItem) {
+-            return $this->orderItem;
+-        }
+-
+-        if (null !== $this->orderItemUnit) {
+-            return $this->orderItemUnit;
+-        }
+-
+-        return null;
++        return $this->orderItem ?? $this->orderItemUnit;
+     }
+ }
 ```
 
 <br>
@@ -1540,6 +1568,20 @@ String cannot be turned into array by assignment anymore
 
 <br>
 
+### `NullCoalescingOperatorRector`
+
+- class: `Rector\Php\Rector\Assign\NullCoalescingOperatorRector`
+
+Use null coalescing operator ??=
+
+```diff
+ $array = [];
+-$array['user_id'] = $array['user_id'] ?? 'value';
++$array['user_id'] ??= 'value';
+```
+
+<br>
+
 ### `MysqlAssignToMysqliRector`
 
 - class: `Rector\Php\Rector\Assign\MysqlAssignToMysqliRector`
@@ -1627,6 +1669,29 @@ Changes unquoted non-existing constants to strings
 ```diff
 -var_dump(VAR);
 +var_dump("VAR");
+```
+
+<br>
+
+## Php\Double
+
+### `RealToFloatTypeCastRector`
+
+- class: `Rector\Php\Rector\Double\RealToFloatTypeCastRector`
+
+Change deprecated (real) to (float)
+
+```diff
+ class SomeClass
+ {
+     public function run()
+     {
+-        $number = (real) 5;
++        $number = (float) 5;
+         $number = (float) 5;
+         $number = (double) 5;
+     }
+ }
 ```
 
 <br>
@@ -1743,7 +1808,7 @@ Null is no more allowed in get_class()
 
 - class: `Rector\Php\Rector\FuncCall\TrailingCommaArgumentsRector`
 
-Adds trailing commas to function and methods calls
+Adds trailing commas to function and methods calls 
 
 ```diff
  calling(
@@ -3493,6 +3558,29 @@ services:
 <br>
 
 ## Interface_
+
+### `RemoveInterfacesRector`
+
+- class: `Rector\Rector\Interface_\RemoveInterfacesRector`
+
+Removes interfaces usage from class.
+
+```yaml
+services:
+    Rector\Rector\Interface_\RemoveInterfacesRector:
+        - SomeInterface
+```
+
+↓
+
+```diff
+-class SomeClass implements SomeInterface
++class SomeClass
+ {
+ }
+```
+
+<br>
 
 ### `MergeInterfacesRector`
 

--- a/packages/Php/src/Rector/Assign/NullCoalescingOperatorRector.php
+++ b/packages/Php/src/Rector/Assign/NullCoalescingOperatorRector.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Php\Rector\Assign;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\BinaryOp\Coalesce;
+use Rector\Rector\AbstractRector;
+use Rector\RectorDefinition\CodeSample;
+use Rector\RectorDefinition\RectorDefinition;
+
+/**
+ * @see https://wiki.php.net/rfc/null_coalesce_equal_operator
+ */
+final class NullCoalescingOperatorRector extends AbstractRector
+{
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Use null coalescing operator ??=', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+$array = [];
+$array['user_id'] = $array['user_id'] ?? 'value';
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+$array = [];
+$array['user_id'] ??= 'value';
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [Assign::class];
+    }
+
+    /**
+     * @param Assign $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $node->expr instanceof Coalesce) {
+            return null;
+        }
+
+        if (! $this->areNodesEqual($node->var, $node->expr->left)) {
+            return null;
+        }
+
+        $coalesceNode = new Coalesce($node->var, $node->expr->right);
+        $coalesceNode->setAttribute('null_coalesce', true);
+
+        return $coalesceNode;
+    }
+}

--- a/packages/Php/tests/Rector/Assign/NullCoalescingOperatorRector/Fixture/fixture.php.inc
+++ b/packages/Php/tests/Rector/Assign/NullCoalescingOperatorRector/Fixture/fixture.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+$array = [];
+$array['user_id'] = $array['user_id'] ?? 'value';
+$array['user_id'] = $array['user_id_'] ?? 'value';
+
+?>
+-----
+<?php
+
+$array = [];
+$array['user_id'] ??= 'value';
+$array['user_id'] = $array['user_id_'] ?? 'value';
+
+?>

--- a/packages/Php/tests/Rector/Assign/NullCoalescingOperatorRector/NullCoalescingOperatorRectorTest.php
+++ b/packages/Php/tests/Rector/Assign/NullCoalescingOperatorRector/NullCoalescingOperatorRectorTest.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Php\Tests\Rector\Assign\NullCoalescingOperatorRector;
+
+use Rector\Php\Rector\Assign\NullCoalescingOperatorRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class NullCoalescingOperatorRectorTest extends AbstractRectorTestCase
+{
+    public function test(): void
+    {
+        $this->doTestFiles([__DIR__ . '/Fixture/fixture.php.inc']);
+    }
+
+    protected function getRectorClass(): string
+    {
+        return NullCoalescingOperatorRector::class;
+    }
+}

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -6,6 +6,7 @@ use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\BinaryOp\Coalesce;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
@@ -212,6 +213,18 @@ final class BetterStandardPrinter extends Standard
             . '(' . $this->pCommaSeparated($node->params) . ')'
             . ($node->returnType !== null ? ': ' . $this->p($node->returnType) : '')
             . ($node->stmts !== null ? $this->nl . '{' . $this->pStmts($node->stmts) . $this->nl . '}' : ';');
+    }
+
+    /**
+     * Print ??= since PHP 7.4
+     */
+    protected function pExpr_BinaryOp_Coalesce(Coalesce $node): string
+    {
+        if (! $node->getAttribute('null_coalesce')) {
+            return parent::pExpr_BinaryOp_Coalesce($node);
+        }
+
+        return $this->pInfixOp(Coalesce::class, $node->left, ' ??= ', $node->right);
     }
 
     /**


### PR DESCRIPTION
Closes #974, `??=` is now part of PHP 7.4

Reverts https://github.com/php/php-src/pull/3747 