### PR TITLE
Fix docs typo

### DIFF
--- a/docs/HowItWorks.md
+++ b/docs/HowItWorks.md
@@ -4,7 +4,7 @@
 
 ## 1. Finds all files and Load Configured Rectors
 
-- The application finds files in source you provide and registeres Rectors - from `--level`, `--configur` or local `rector.yml`
+- The application finds files in source you provide and registeres Rectors - from `--level`, `--config` or local `rector.yml`
 - Then it iterates all found files and applies relevant Rectors to them.
 - *Rector* in this context is 1 single class that modifies 1 thing, e.g. changes class name
 


### PR DESCRIPTION
Fix typo in `--config` option described in documentation.