### PR TITLE
Add custom ReturnTypeExtensions for static analysis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -97,12 +97,12 @@
     },
     "scripts": {
         "complete-check": ["@check-cs", "phpunit", "@phpstan", "@update-docs"],
-        "check-cs": "vendor/bin/ecs check bin packages src tests",
+        "check-cs": "vendor/bin/ecs check bin packages src tests utils",
         "fix-cs": [
-            "vendor/bin/ecs check bin packages src tests --fix",
+            "vendor/bin/ecs check bin packages src tests utils --fix",
             "bin/clean_trailing_spaces.sh"
         ],
-        "phpstan-ci": "vendor/bin/phpstan analyse packages src tests",
+        "phpstan-ci": "vendor/bin/phpstan analyse packages src tests utils",
         "phpstan": [
             "php utils/phpstan/generate-paths.php",
             "vendor/bin/phpstan analyse --paths-file phpstan-paths.txt"

--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
     },
     "autoload-dev": {
         "psr-4": {
+            "Rector\\PHPStanExtensions\\": "utils/phpstan/src",
             "Rector\\Tests\\": "tests",
             "Rector\\NodeTypeResolver\\Tests\\": "packages/NodeTypeResolver/tests",
             "Rector\\CakePHP\\Tests\\": "packages/CakePHP/tests",

--- a/ecs.yml
+++ b/ecs.yml
@@ -121,6 +121,7 @@ parameters:
             - 'packages/Php/src/Rector/ConstFetch/BarewordStringRector.php'
             - 'packages/CodeQuality/src/Rector/Foreach_/ForeachToInArrayRector.php'
             - 'packages/Php/src/Rector/MagicConstClass/ClassConstantToSelfClassRector.php'
+            - 'utils/phpstan/src/Rector/Type/*TypeExtension.php'
             # array type check
             - 'src/RectorDefinition/RectorDefinition.php'
 

--- a/packages/CodeQuality/src/Rector/Return_/SimplifyUselessVariableRector.php
+++ b/packages/CodeQuality/src/Rector/Return_/SimplifyUselessVariableRector.php
@@ -66,9 +66,13 @@ CODE_SAMPLE
             return null;
         }
 
-        /** @var AssignOp|Assign $previousNode */
-        $previousNode = $node->getAttribute(Attribute::PREVIOUS_NODE)->expr;
+        $previousNode = $node->getAttribute(Attribute::PREVIOUS_NODE);
+        if (! $previousNode instanceof Expression) {
+            return null;
+        }
 
+        /** @var AssignOp|Assign $previousNode */
+        $previousNode = $previousNode->expr;
         $previousVariableNode = $previousNode->var;
 
         // has some comment

--- a/packages/CodingStyle/src/Rector/Use_/RemoveUnusedAliasRector.php
+++ b/packages/CodingStyle/src/Rector/Use_/RemoveUnusedAliasRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Use_;
 use PhpParser\NodeVisitor\NameResolver;
+use Rector\Exception\ShouldNotHappenException;
 use Rector\NodeTypeResolver\Node\Attribute;
 use Rector\PhpParser\Node\BetterNodeFinder;
 use Rector\Rector\AbstractRector;
@@ -62,8 +63,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $parentNode = $node->getAttribute(Attribute::PARENT_NODE);
-        $usedNameNodes = $this->resolveUsedNameNodes($parentNode);
+        $usedNameNodes = $this->resolveUsedNameNodes($node);
         if ($usedNameNodes === []) {
             return null;
         }
@@ -100,19 +100,20 @@ CODE_SAMPLE
     /**
      * @return Node[][][]
      */
-    private function resolveUsedNameNodes(Node $parentNode): array
+    private function resolveUsedNameNodes(Use_ $node): array
     {
+        $parentNode = $node->getAttribute(Attribute::PARENT_NODE);
+        if ($parentNode === null) {
+            throw new ShouldNotHappenException();
+        }
+
         $usedNameNodes = [];
 
         // assumption for namespaced content
         if ($parentNode instanceof Namespace_) {
             /** @var Name[] $namedNodes */
             $namedNodes = $this->betterNodeFinder->find($parentNode, function (Node $node) {
-                if ($node instanceof Name) {
-                    return true;
-                }
-
-                return false;
+                return $node instanceof Name;
             });
 
             foreach ($namedNodes as $nameNode) {
@@ -124,7 +125,6 @@ CODE_SAMPLE
 
                 /** @var Node $parentNode */
                 $parentNode = $nameNode->getAttribute(Attribute::PARENT_NODE);
-
                 $usedNameNodes[$originalName->toString()][] = [$nameNode, $parentNode];
             }
         }

--- a/packages/CodingStyle/src/Rector/Use_/RemoveUnusedAliasRector.php
+++ b/packages/CodingStyle/src/Rector/Use_/RemoveUnusedAliasRector.php
@@ -123,8 +123,11 @@ CODE_SAMPLE
                     continue;
                 }
 
-                /** @var Node $parentNode */
                 $parentNode = $nameNode->getAttribute(Attribute::PARENT_NODE);
+                if ($parentNode === null) {
+                    continue;
+                }
+
                 $usedNameNodes[$originalName->toString()][] = [$nameNode, $parentNode];
             }
         }

--- a/packages/DeadCode/src/Rector/Assign/RemoveDoubleAssignRector.php
+++ b/packages/DeadCode/src/Rector/Assign/RemoveDoubleAssignRector.php
@@ -7,7 +7,6 @@ use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
-use PhpParser\Node\Stmt\Expression;
 use Rector\NodeTypeResolver\Node\Attribute;
 use Rector\Rector\AbstractRector;
 use Rector\RectorDefinition\CodeSample;
@@ -42,7 +41,6 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        /** @var Expression|null $previousExpression */
         $previousExpression = $node->getAttribute(Attribute::PREVIOUS_EXPRESSION);
         if ($previousExpression === null) {
             return null;

--- a/packages/DeadCode/src/Rector/ClassMethod/RemoveEmptyClassMethodRector.php
+++ b/packages/DeadCode/src/Rector/ClassMethod/RemoveEmptyClassMethodRector.php
@@ -58,7 +58,8 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $node->getAttribute(Attribute::CLASS_NODE) instanceof Class_) {
+        $classNode = $node->getAttribute(Attribute::CLASS_NODE);
+        if (! $classNode instanceof Class_) {
             return null;
         }
 

--- a/packages/DeadCode/src/Rector/ClassMethod/RemoveUnusedParameterRector.php
+++ b/packages/DeadCode/src/Rector/ClassMethod/RemoveUnusedParameterRector.php
@@ -70,7 +70,8 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $node->getAttribute(Attribute::CLASS_NODE) instanceof Class_) {
+        $classNode = $node->getAttribute(Attribute::CLASS_NODE);
+        if (! $classNode instanceof Class_) {
             return null;
         }
 
@@ -78,13 +79,12 @@ CODE_SAMPLE
             return null;
         }
 
-        /** @var string $class */
-        $class = $node->getAttribute(Attribute::CLASS_NAME);
-        $methodName = $this->getName($node);
-        if ($methodName === null) {
+        $class = $this->getName($classNode);
+        if ($class === null) {
             return null;
         }
 
+        $methodName = $this->getName($node);
         if ($this->classMaintainer->hasParentMethodOrInterface($class, $methodName)) {
             return null;
         }

--- a/packages/DeadCode/src/Rector/StaticCall/RemoveParentCallWithoutParentRector.php
+++ b/packages/DeadCode/src/Rector/StaticCall/RemoveParentCallWithoutParentRector.php
@@ -70,9 +70,12 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->classMethodMaintainer->hasParentMethodOrInterfaceMethod(
-            $node->getAttribute(Attribute::METHOD_NODE)
-        )) {
+        $methodNode = $node->getAttribute(Attribute::METHOD_NODE);
+        if ($methodNode === null) {
+            return null;
+        }
+
+        if ($this->classMethodMaintainer->hasParentMethodOrInterfaceMethod($methodNode)) {
             return null;
         }
 

--- a/packages/DomainDrivenDesign/src/Rector/ObjectToScalar/ObjectToScalarDocBlockRector.php
+++ b/packages/DomainDrivenDesign/src/Rector/ObjectToScalar/ObjectToScalarDocBlockRector.php
@@ -121,6 +121,10 @@ CODE_SAMPLE
             $node = $exprNode->getAttribute(Attribute::PARENT_NODE);
         }
 
+        if ($node === null) {
+            return;
+        }
+
         $this->docBlockAnalyzer->changeType($node, $oldType, $newType);
     }
 

--- a/packages/DomainDrivenDesign/src/Rector/ObjectToScalar/ObjectToScalarDocBlockRector.php
+++ b/packages/DomainDrivenDesign/src/Rector/ObjectToScalar/ObjectToScalarDocBlockRector.php
@@ -7,7 +7,6 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Param;
-use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Property;
 use Rector\NodeTypeResolver\Node\Attribute;
 use Rector\RectorDefinition\ConfiguredCodeSample;
@@ -130,8 +129,10 @@ CODE_SAMPLE
 
     private function processParamNode(NullableType $nullableTypeNode, Param $paramNode, string $newType): void
     {
-        /** @var ClassMethod $classMethodNode */
         $classMethodNode = $paramNode->getAttribute(Attribute::PARENT_NODE);
+        if ($classMethodNode === null) {
+            return;
+        }
 
         $oldType = $this->namespaceAnalyzer->resolveTypeToFullyQualified(
             (string) $nullableTypeNode->type,

--- a/packages/Jms/src/Rector/Property/JmsInjectAnnotationRector.php
+++ b/packages/Jms/src/Rector/Property/JmsInjectAnnotationRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Stmt\Property;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use Rector\Application\ErrorAndDiffCollector;
 use Rector\Bridge\Contract\AnalyzedApplicationContainerInterface;
+use Rector\Exception\ShouldNotHappenException;
 use Rector\NodeTypeResolver\Node\Attribute;
 use Rector\NodeTypeResolver\PhpDoc\NodeAnalyzer\DocBlockAnalyzer;
 use Rector\Rector\AbstractRector;
@@ -127,7 +128,12 @@ CODE_SAMPLE
         // set to private
         $node->flags = Class_::MODIFIER_PRIVATE;
 
-        $this->addPropertyToClass($node->getAttribute(Attribute::CLASS_NODE), $type, $name);
+        $classNode = $node->getAttribute(Attribute::CLASS_NODE);
+        if (! $classNode instanceof Class_) {
+            throw new ShouldNotHappenException();
+        }
+
+        $this->addPropertyToClass($classNode, $type, $name);
 
         return $node;
     }

--- a/packages/NodeTypeResolver/src/Application/ClassLikeNodeCollector.php
+++ b/packages/NodeTypeResolver/src/Application/ClassLikeNodeCollector.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Interface_;
 use PhpParser\Node\Stmt\Trait_;
 use PhpParser\Node\Stmt\TraitUse;
+use Rector\Exception\ShouldNotHappenException;
 use Rector\NodeTypeResolver\Node\Attribute;
 use Rector\PhpParser\Node\Resolver\NameResolver;
 
@@ -39,7 +40,11 @@ final class ClassLikeNodeCollector
 
     public function addClass(Class_ $classNode): void
     {
-        $name = (string) $classNode->getAttribute(Attribute::CLASS_NAME);
+        $name = $classNode->getAttribute(Attribute::CLASS_NAME);
+        if ($name === null) {
+            throw new ShouldNotHappenException();
+        }
+
         $this->classes[$name] = $classNode;
     }
 
@@ -50,13 +55,21 @@ final class ClassLikeNodeCollector
 
     public function addInterface(Interface_ $interfaceNode): void
     {
-        $name = (string) $interfaceNode->getAttribute(Attribute::CLASS_NAME);
+        $name = $interfaceNode->getAttribute(Attribute::CLASS_NAME);
+        if ($name === null) {
+            throw new ShouldNotHappenException();
+        }
+
         $this->interfaces[$name] = $interfaceNode;
     }
 
     public function addTrait(Trait_ $traitNode): void
     {
-        $name = (string) $traitNode->getAttribute(Attribute::CLASS_NAME);
+        $name = $traitNode->getAttribute(Attribute::CLASS_NAME);
+        if ($name === null) {
+            throw new ShouldNotHappenException();
+        }
+
         $this->traits[$name] = $traitNode;
     }
 
@@ -85,11 +98,16 @@ final class ClassLikeNodeCollector
     {
         $childrenClasses = [];
         foreach ($this->classes as $classNode) {
-            if (! is_a($classNode->getAttribute(Attribute::CLASS_NAME), $class, true)) {
+            $className = $classNode->getAttribute(Attribute::CLASS_NAME);
+            if ($className === null) {
+                return [];
+            }
+
+            if (! is_a($className, $class, true)) {
                 continue;
             }
 
-            if ($classNode->getAttribute(Attribute::CLASS_NAME) === $class) {
+            if ($className === $class) {
                 continue;
             }
 
@@ -106,11 +124,16 @@ final class ClassLikeNodeCollector
     {
         $implementerInterfaces = [];
         foreach ($this->interfaces as $interfaceNode) {
-            if (! is_a($interfaceNode->getAttribute(Attribute::CLASS_NAME), $interface, true)) {
+            $className = $interfaceNode->getAttribute(Attribute::CLASS_NAME);
+            if ($className === null) {
+                return [];
+            }
+
+            if (! is_a($className, $interface, true)) {
                 continue;
             }
 
-            if ($interfaceNode->getAttribute(Attribute::CLASS_NAME) === $interface) {
+            if ($className === $interface) {
                 continue;
             }
 

--- a/packages/NodeTypeResolver/src/Application/ConstantNodeCollector.php
+++ b/packages/NodeTypeResolver/src/Application/ConstantNodeCollector.php
@@ -2,7 +2,6 @@
 
 namespace Rector\NodeTypeResolver\Application;
 
-use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassConst;
 use Rector\Exception\ShouldNotHappenException;
 use Rector\NodeTypeResolver\Node\Attribute;

--- a/packages/NodeTypeResolver/src/Application/ConstantNodeCollector.php
+++ b/packages/NodeTypeResolver/src/Application/ConstantNodeCollector.php
@@ -2,7 +2,9 @@
 
 namespace Rector\NodeTypeResolver\Application;
 
+use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassConst;
+use Rector\Exception\ShouldNotHappenException;
 use Rector\NodeTypeResolver\Node\Attribute;
 use Rector\PhpParser\Node\Resolver\NameResolver;
 
@@ -25,7 +27,11 @@ final class ConstantNodeCollector
 
     public function addConstant(ClassConst $classConst): void
     {
-        $className = (string) $classConst->getAttribute(Attribute::CLASS_NAME);
+        $className = $classConst->getAttribute(Attribute::CLASS_NAME);
+        if ($className === null) {
+            throw new ShouldNotHappenException();
+        }
+
         $constantName = $this->nameResolver->resolve($classConst);
 
         $this->constantsByType[$className][$constantName] = $classConst;

--- a/packages/NodeTypeResolver/src/Application/FunctionLikeNodeCollector.php
+++ b/packages/NodeTypeResolver/src/Application/FunctionLikeNodeCollector.php
@@ -5,6 +5,7 @@ namespace Rector\NodeTypeResolver\Application;
 use Nette\Utils\Strings;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
+use Rector\Exception\ShouldNotHappenException;
 use Rector\NodeTypeResolver\Node\Attribute;
 use Rector\PhpParser\Node\Resolver\NameResolver;
 use ReflectionClass;
@@ -33,7 +34,11 @@ final class FunctionLikeNodeCollector
 
     public function addMethod(ClassMethod $classMethodNode): void
     {
-        $className = (string) $classMethodNode->getAttribute(Attribute::CLASS_NAME);
+        $className = $classMethodNode->getAttribute(Attribute::CLASS_NAME);
+        if ($className === null) {
+            throw new ShouldNotHappenException();
+        }
+
         $methodName = $this->nameResolver->resolve($classMethodNode);
 
         $this->methodsByType[$className][$methodName] = $classMethodNode;

--- a/packages/NodeTypeResolver/src/Node/Attribute.php
+++ b/packages/NodeTypeResolver/src/Node/Attribute.php
@@ -30,6 +30,7 @@ final class Attribute
     public const CLASS_NAME = 'className';
 
     /**
+     * @todo split Class node, interface node and trait node, to be compatible with other SpecificNode|null, values
      * @var string
      */
     public const CLASS_NODE = 'classNode';

--- a/packages/NodeTypeResolver/src/NodeTypeResolver.php
+++ b/packages/NodeTypeResolver/src/NodeTypeResolver.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Stmt\ClassConst;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
 use PHPStan\Broker\Broker;
+use Rector\Exception\ShouldNotHappenException;
 use Rector\NodeTypeResolver\Contract\NodeTypeResolverAwareInterface;
 use Rector\NodeTypeResolver\Contract\PerNodeTypeResolver\PerNodeTypeResolverInterface;
 use Rector\NodeTypeResolver\Node\Attribute;
@@ -64,7 +65,7 @@ final class NodeTypeResolver
     public function resolve(Node $node): array
     {
         if ($node instanceof ClassMethod || $node instanceof ClassConst) {
-            return $this->resolve($node->getAttribute(Attribute::CLASS_NODE));
+            return $this->resolveClassNode($node);
         }
 
         if ($node instanceof StaticCall || $node instanceof ClassConstFetch) {
@@ -104,6 +105,20 @@ final class NodeTypeResolver
         if ($perNodeTypeResolver instanceof NodeTypeResolverAwareInterface) {
             $perNodeTypeResolver->setNodeTypeResolver($this);
         }
+    }
+
+    /**
+     * @param ClassConst|ClassMethod $node
+     * @return string[]
+     */
+    private function resolveClassNode(Node $node): array
+    {
+        $classNode = $node->getAttribute(Attribute::CLASS_NODE);
+        if ($classNode === null) {
+            throw new ShouldNotHappenException();
+        }
+
+        return $this->resolve($classNode);
     }
 
     /**

--- a/packages/NodeTypeResolver/src/PerNodeTypeResolver/ClassAndInterfaceTypeResolver.php
+++ b/packages/NodeTypeResolver/src/PerNodeTypeResolver/ClassAndInterfaceTypeResolver.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Interface_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
+use Rector\Exception\ShouldNotHappenException;
 use Rector\NodeTypeResolver\Contract\PerNodeTypeResolver\PerNodeTypeResolverInterface;
 use Rector\NodeTypeResolver\Node\Attribute;
 use Rector\NodeTypeResolver\Reflection\ClassReflectionTypesResolver;
@@ -37,8 +38,10 @@ final class ClassAndInterfaceTypeResolver implements PerNodeTypeResolverInterfac
      */
     public function resolve(Node $node): array
     {
-        /** @var Scope $nodeScope */
         $nodeScope = $node->getAttribute(Attribute::SCOPE);
+        if ($nodeScope === null) {
+            throw new ShouldNotHappenException();
+        }
 
         /** @var ClassReflection $classReflection */
         $classReflection = $nodeScope->getClassReflection();

--- a/packages/NodeTypeResolver/src/PerNodeTypeResolver/NameTypeResolver.php
+++ b/packages/NodeTypeResolver/src/PerNodeTypeResolver/NameTypeResolver.php
@@ -25,13 +25,23 @@ final class NameTypeResolver implements PerNodeTypeResolverInterface
     public function resolve(Node $nameNode): array
     {
         if ($nameNode->toString() === 'parent') {
-            return [$nameNode->getAttribute(Attribute::PARENT_CLASS_NAME)];
+            $parentClassName = $nameNode->getAttribute(Attribute::PARENT_CLASS_NAME);
+            if ($parentClassName === null) {
+                return [];
+            }
+
+            return [$parentClassName];
         }
 
-        return [$this->resolveFullyQualifiedName($nameNode, $nameNode->toString())];
+        $fullyQualifiedName = $this->resolveFullyQualifiedName($nameNode, $nameNode->toString());
+        if ($fullyQualifiedName === null) {
+            return [];
+        }
+
+        return [$fullyQualifiedName];
     }
 
-    private function resolveFullyQualifiedName(Node $nameNode, string $name): string
+    private function resolveFullyQualifiedName(Node $nameNode, string $name): ?string
     {
         if (in_array($name, ['self', 'static', 'this'], true)) {
             return $nameNode->getAttribute(Attribute::CLASS_NAME);

--- a/packages/NodeTypeResolver/src/PerNodeTypeResolver/VariableTypeResolver.php
+++ b/packages/NodeTypeResolver/src/PerNodeTypeResolver/VariableTypeResolver.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr\Variable;
 use PHPStan\Analyser\Scope;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\ThisType;
+use Rector\Exception\ShouldNotHappenException;
 use Rector\NodeTypeResolver\Contract\PerNodeTypeResolver\PerNodeTypeResolverInterface;
 use Rector\NodeTypeResolver\Node\Attribute;
 use Rector\NodeTypeResolver\PhpDoc\NodeAnalyzer\DocBlockAnalyzer;
@@ -54,11 +55,15 @@ final class VariableTypeResolver implements PerNodeTypeResolverInterface
      */
     public function resolve(Node $variableNode): array
     {
-        /** @var Scope $nodeScope */
         $nodeScope = $variableNode->getAttribute(Attribute::SCOPE);
+        if ($nodeScope === null) {
+            throw new ShouldNotHappenException();
+        }
 
-        /** @var string $variableName */
         $variableName = $this->nameResolver->resolve($variableNode);
+        if ($variableName === null) {
+            return [];
+        }
 
         if ($nodeScope->hasVariableType($variableName) === TrinaryLogic::createYes()) {
             $type = $nodeScope->getVariableType($variableName);

--- a/packages/NodeTypeResolver/src/PhpDoc/NodeAnalyzer/NamespaceAnalyzer.php
+++ b/packages/NodeTypeResolver/src/PhpDoc/NodeAnalyzer/NamespaceAnalyzer.php
@@ -24,7 +24,12 @@ final class NamespaceAnalyzer
 
     public function resolveTypeToFullyQualified(string $type, Node $node): string
     {
-        $useStatementMatch = $this->matchUseStatements($type, (array) $node->getAttribute(Attribute::USE_NODES));
+        $useNodes = $node->getAttribute(Attribute::USE_NODES);
+        if ($useNodes === null) {
+            $useNodes = [];
+        }
+
+        $useStatementMatch = $this->matchUseStatements($type, $useNodes);
         if ($useStatementMatch) {
             return $useStatementMatch;
         }

--- a/packages/PHPStan/src/Rector/Assign/PHPStormVarAnnotationRector.php
+++ b/packages/PHPStan/src/Rector/Assign/PHPStormVarAnnotationRector.php
@@ -7,8 +7,8 @@ use PhpParser\Comment\Doc;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Nop;
+use Rector\Exception\ShouldNotHappenException;
 use Rector\NodeTypeResolver\Node\Attribute;
 use Rector\Rector\AbstractRector;
 use Rector\RectorDefinition\CodeSample;
@@ -49,10 +49,11 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        /** @var Expression $expression */
         $expression = $node->getAttribute(Attribute::CURRENT_EXPRESSION);
+        if ($expression === null) {
+            throw new ShouldNotHappenException();
+        }
 
-        /** @var Node|null $nextNode */
         $nextNode = $expression->getAttribute(Attribute::NEXT_NODE);
         if ($nextNode === null) {
             return null;

--- a/packages/PHPStan/src/Rector/Cast/RecastingRemovalRector.php
+++ b/packages/PHPStan/src/Rector/Cast/RecastingRemovalRector.php
@@ -3,7 +3,6 @@
 namespace Rector\PHPStan\Rector\Cast;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Cast;
 use PhpParser\Node\Expr\Cast\Array_;
 use PhpParser\Node\Expr\Cast\Bool_;
@@ -11,15 +10,12 @@ use PhpParser\Node\Expr\Cast\Double;
 use PhpParser\Node\Expr\Cast\Int_;
 use PhpParser\Node\Expr\Cast\Object_;
 use PhpParser\Node\Expr\Cast\String_;
-use PHPStan\Analyser\Scope;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\FloatType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
-use PHPStan\Type\Type;
-use Rector\NodeTypeResolver\Node\Attribute;
 use Rector\Rector\AbstractRector;
 use Rector\RectorDefinition\CodeSample;
 use Rector\RectorDefinition\RectorDefinition;
@@ -79,21 +75,16 @@ CODE_SAMPLE
             return null;
         }
 
-        $nodeType = $this->getNodeType($node->expr);
-        $sameNodeType = $this->castClassToNodeType[$nodeClass];
+        $nodeType = $this->getStaticType($node->expr);
+        if ($nodeType === null) {
+            return null;
+        }
 
+        $sameNodeType = $this->castClassToNodeType[$nodeClass];
         if (! is_a($nodeType, $sameNodeType, true)) {
             return null;
         }
 
         return $node->expr;
-    }
-
-    private function getNodeType(Expr $node): Type
-    {
-        /** @var Scope $nodeScope */
-        $nodeScope = $node->getAttribute(Attribute::SCOPE);
-
-        return $nodeScope->getType($node);
     }
 }

--- a/packages/Php/src/Rector/Assign/MysqlAssignToMysqliRector.php
+++ b/packages/Php/src/Rector/Assign/MysqlAssignToMysqliRector.php
@@ -14,6 +14,7 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\For_;
+use Rector\Exception\ShouldNotHappenException;
 use Rector\NodeTypeResolver\Node\Attribute;
 use Rector\Rector\AbstractRector;
 use Rector\RectorDefinition\CodeSample;
@@ -150,7 +151,12 @@ CODE_SAMPLE
             'stmts' => [new Expression($funcCallNode)],
         ]);
 
-        $this->addNodeAfterNode($forNode, $assignNode->getAttribute(Attribute::PREVIOUS_EXPRESSION));
+        $previousExpression = $assignNode->getAttribute(Attribute::PREVIOUS_EXPRESSION);
+        if ($previousExpression === null) {
+            throw new ShouldNotHappenException();
+        }
+
+        $this->addNodeAfterNode($forNode, $previousExpression);
 
         return $assignNode;
     }

--- a/packages/Php/src/Rector/ConstFetch/BarewordStringRector.php
+++ b/packages/Php/src/Rector/ConstFetch/BarewordStringRector.php
@@ -6,12 +6,12 @@ use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Scalar\String_;
+use Rector\Exception\ShouldNotHappenException;
 use Rector\NodeTypeResolver\Node\Attribute;
 use Rector\Rector\AbstractRector;
 use Rector\RectorDefinition\CodeSample;
 use Rector\RectorDefinition\RectorDefinition;
 use function Safe\sprintf;
-use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
 
 /**
  * @see https://wiki.php.net/rfc/deprecate-bareword-strings
@@ -50,8 +50,10 @@ final class BarewordStringRector extends AbstractRector
         }
 
         // load the file!
-        /** @var SmartFileInfo $fileInfo */
         $fileInfo = $node->getAttribute(Attribute::FILE_INFO);
+        if ($fileInfo === null) {
+            throw new ShouldNotHappenException();
+        }
 
         $this->undefinedConstants = [];
         $previousErrorHandler = set_error_handler(function ($severity, $message, $file, $line): void {

--- a/packages/Php/src/Rector/FuncCall/ArrayKeyFirstLastRector.php
+++ b/packages/Php/src/Rector/FuncCall/ArrayKeyFirstLastRector.php
@@ -5,7 +5,6 @@ namespace Rector\Php\Rector\FuncCall;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name;
-use PhpParser\Node\Stmt\Expression;
 use Rector\NodeTypeResolver\Node\Attribute;
 use Rector\Rector\AbstractRector;
 use Rector\RectorDefinition\CodeSample;
@@ -70,7 +69,6 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        /** @var Expression|null $previousExpression */
         $previousExpression = $node->getAttribute(Attribute::PREVIOUS_EXPRESSION);
         if ($previousExpression === null) {
             return null;

--- a/packages/Php/src/Rector/FuncCall/CreateFunctionToAnonymousFunctionRector.php
+++ b/packages/Php/src/Rector/FuncCall/CreateFunctionToAnonymousFunctionRector.php
@@ -159,7 +159,6 @@ CODE_SAMPLE
             $paramNames[] = $this->getName($paramNode);
         }
 
-        /** @var Variable[] $variableNodes */
         $variableNodes = $this->betterNodeFinder->findInstanceOf($nodes, Variable::class);
 
         $filteredVariables = [];
@@ -169,11 +168,12 @@ CODE_SAMPLE
                 continue;
             }
 
-            if (in_array($this->getName($variableNode), $paramNames, true)) {
+            $variableName = $this->getName($variableNode);
+            if (in_array($variableName, $paramNames, true)) {
                 continue;
             }
 
-            $filteredVariables[$this->getName($variableNode)] = $variableNode;
+            $filteredVariables[$variableName] = $variableNode;
         }
 
         return $filteredVariables;

--- a/packages/Php/src/Rector/FuncCall/ParseStrWithResultArgumentRector.php
+++ b/packages/Php/src/Rector/FuncCall/ParseStrWithResultArgumentRector.php
@@ -6,7 +6,6 @@ use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Stmt\Expression;
 use Rector\NodeTypeResolver\Node\Attribute;
 use Rector\PhpParser\NodeTraverser\CallableNodeTraverser;
 use Rector\Rector\AbstractRector;
@@ -64,17 +63,19 @@ CODE_SAMPLE
             return null;
         }
 
-        if (isset($node->args[1])) {
-            return null;
-        }
-
         $resultVariable = new Variable('result');
         $node->args[1] = new Arg($resultVariable);
 
-        /** @var Expression $expression */
         $expression = $node->getAttribute(Attribute::CURRENT_EXPRESSION);
+        if ($expression === null) {
+            return null;
+        }
+
         // @todo maybe solve in generic way as attribute?
         $nextExpression = $expression->getAttribute(Attribute::NEXT_NODE);
+        if ($nextExpression === null) {
+            return null;
+        }
 
         $this->callableNodeTraverser->traverseNodesWithCallable([$nextExpression], function (Node $node) use (
             $resultVariable

--- a/packages/Php/src/Rector/FuncCall/RegexDashEscapeRector.php
+++ b/packages/Php/src/Rector/FuncCall/RegexDashEscapeRector.php
@@ -224,6 +224,9 @@ CODE_SAMPLE
     private function findAssigners(Node $variableNode): array
     {
         $methodNode = $variableNode->getAttribute(Attribute::METHOD_NODE);
+        if ($methodNode === null) {
+            return [];
+        }
 
         /** @var Assign[] $assignNode */
         return $this->betterNodeFinder->find([$methodNode], function (Node $node) use ($variableNode) {

--- a/packages/Php/src/Rector/FuncCall/RegexDashEscapeRector.php
+++ b/packages/Php/src/Rector/FuncCall/RegexDashEscapeRector.php
@@ -173,7 +173,11 @@ CODE_SAMPLE
 
     private function processClassConstFetch(Expr $expr): void
     {
-        $className = (string) $expr->getAttribute(Attribute::CLASS_NAME);
+        $className = $expr->getAttribute(Attribute::CLASS_NAME);
+        if (! is_string($className)) {
+            return;
+        }
+
         $constantName = $this->getName($expr);
         if ($constantName === null) {
             return;

--- a/packages/Php/src/Rector/FuncCall/StringifyStrNeedlesRector.php
+++ b/packages/Php/src/Rector/FuncCall/StringifyStrNeedlesRector.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr\Cast\String_;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Type\Constant\ConstantStringType;
+use Rector\Exception\ShouldNotHappenException;
 use Rector\NodeTypeResolver\Node\Attribute;
 use Rector\Rector\AbstractRector;
 use Rector\RectorDefinition\CodeSample;
@@ -70,8 +71,11 @@ CODE_SAMPLE
         // is argument string?
         $needleArgNode = $node->args[1]->value;
 
-        /** @var Scope $nodeScope */
         $nodeScope = $needleArgNode->getAttribute(Attribute::SCOPE);
+        if ($nodeScope === null) {
+            throw new ShouldNotHappenException();
+        }
+
         if ($nodeScope->getType($needleArgNode) instanceof ConstantStringType) {
             return null;
         }

--- a/packages/Php/src/Rector/FunctionLike/AbstractTypeDeclarationRector.php
+++ b/packages/Php/src/Rector/FunctionLike/AbstractTypeDeclarationRector.php
@@ -83,9 +83,7 @@ abstract class AbstractTypeDeclarationRector extends AbstractRector
         }
 
         $methodName = $this->getName($classMethodNode);
-        if ($methodName === null) {
-            return false;
-        }
+
         // @todo extract to some "inherited parent method" service
 
         /** @var string|null $parentClassName */

--- a/packages/Php/src/Rector/FunctionLike/Php4ConstructorRector.php
+++ b/packages/Php/src/Rector/FunctionLike/Php4ConstructorRector.php
@@ -12,7 +12,7 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
 use Rector\NodeTypeResolver\Node\Attribute;
-use Rector\PhpParser\Node\BetterNodeFinder;
+use Rector\PhpParser\Node\Maintainer\ClassMaintainer;
 use Rector\Rector\AbstractRector;
 use Rector\RectorDefinition\CodeSample;
 use Rector\RectorDefinition\RectorDefinition;
@@ -23,13 +23,13 @@ use Rector\RectorDefinition\RectorDefinition;
 final class Php4ConstructorRector extends AbstractRector
 {
     /**
-     * @var BetterNodeFinder
+     * @var ClassMaintainer
      */
-    private $betterNodeFinder;
+    private $classMaintainer;
 
-    public function __construct(BetterNodeFinder $betterNodeFinder)
+    public function __construct(ClassMaintainer $classMaintainer)
     {
-        $this->betterNodeFinder = $betterNodeFinder;
+        $this->classMaintainer = $classMaintainer;
     }
 
     public function getDefinition(): RectorDefinition
@@ -73,9 +73,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $namespace = $node->getAttribute(Attribute::NAMESPACE_NAME);
-        // catch only classes without namespace
-        if ($namespace) {
+        if ($this->shouldSkip($node)) {
             return null;
         }
 
@@ -84,21 +82,16 @@ CODE_SAMPLE
             return null;
         }
 
-        // anonymous class → skip
-        if ($classNode->name === null || $node->isAbstract() || $node->isStatic()) {
-            return null;
-        }
-
         // process parent call references first
         $this->processClassMethodStatementsForParentConstructorCalls($node);
 
         // not PSR-4 constructor
-        if (! $this->isNameInsensitive($classNode, (string) $node->name)) {
+        if (! $this->isNameInsensitive($classNode, $this->getName($node))) {
             return null;
         }
 
         // does it already have a __construct method?
-        if (! in_array('__construct', $this->getClassMethodNames($classNode), true)) {
+        if (! $this->classMaintainer->hasClassMethod($classNode, '__construct')) {
             $node->name = new Identifier('__construct');
         }
 
@@ -120,6 +113,26 @@ CODE_SAMPLE
         return $node;
     }
 
+    private function shouldSkip(ClassMethod $classMethod): bool
+    {
+        $namespace = $classMethod->getAttribute(Attribute::NAMESPACE_NAME);
+        // catch only classes without namespace
+        if ($namespace !== null) {
+            return true;
+        }
+
+        if ($classMethod->isAbstract() || $classMethod->isStatic()) {
+            return true;
+        }
+
+        $classNode = $classMethod->getAttribute(Attribute::CLASS_NODE);
+        if ($classNode instanceof Class_ && $classNode->name === null) {
+            return true;
+        }
+
+        return false;
+    }
+
     private function processClassMethodStatementsForParentConstructorCalls(ClassMethod $classMethodNode): void
     {
         if (! is_iterable($classMethodNode->stmts)) {
@@ -138,22 +151,6 @@ CODE_SAMPLE
 
             $this->processParentPhp4ConstructCall($methodStmt);
         }
-    }
-
-    /**
-     * @return string[]
-     */
-    private function getClassMethodNames(Class_ $classNode): array
-    {
-        $classMethodNames = [];
-
-        /** @var ClassMethod[] $classMethodNodes */
-        $classMethodNodes = $this->betterNodeFinder->findInstanceOf($classNode->stmts, ClassMethod::class);
-        foreach ($classMethodNodes as $classMethodNode) {
-            $classMethodNames[] = $this->getName($classMethodNode);
-        }
-
-        return $classMethodNames;
     }
 
     private function isThisConstructCall(Node $node): bool
@@ -191,16 +188,16 @@ CODE_SAMPLE
         }
 
         // rename ParentClass
-        if ((string) $node->class === $parentClassName) {
+        if ($this->isName($node->class, $parentClassName)) {
             $node->class = new Name('parent');
         }
 
-        if ((string) $node->class !== 'parent') {
+        if ($this->isName($node->class, 'parent') === false) {
             return;
         }
 
         // it's not a parent PHP 4 constructor call
-        if (! $this->isNameInsensitive($node, $parentClassName)) {
+        if ($this->isNameInsensitive($node, $parentClassName) === false) {
             return;
         }
 

--- a/packages/Php/src/Rector/FunctionLike/Php4ConstructorRector.php
+++ b/packages/Php/src/Rector/FunctionLike/Php4ConstructorRector.php
@@ -79,8 +79,10 @@ CODE_SAMPLE
             return null;
         }
 
-        /** @var Class_ $classNode */
         $classNode = $node->getAttribute(Attribute::CLASS_NODE);
+        if (! $classNode instanceof Class_) {
+            return null;
+        }
 
         // anonymous class → skip
         if ($classNode->name === null || $node->isAbstract() || $node->isStatic()) {
@@ -148,7 +150,7 @@ CODE_SAMPLE
         /** @var ClassMethod[] $classMethodNodes */
         $classMethodNodes = $this->betterNodeFinder->findInstanceOf($classNode->stmts, ClassMethod::class);
         foreach ($classMethodNodes as $classMethodNode) {
-            $classMethodNames[] = (string) $classMethodNode->name;
+            $classMethodNames[] = $this->getName($classMethodNode);
         }
 
         return $classMethodNames;

--- a/packages/Php/src/Rector/FunctionLike/ReturnTypeDeclarationRector.php
+++ b/packages/Php/src/Rector/FunctionLike/ReturnTypeDeclarationRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
+use Rector\Exception\ShouldNotHappenException;
 use Rector\NodeTypeResolver\Node\Attribute;
 use Rector\NodeTypeResolver\Php\ReturnTypeInfo;
 use Rector\RectorDefinition\CodeSample;
@@ -149,11 +150,15 @@ CODE_SAMPLE
             return;
         }
 
-        /** @var string $methodName */
         $methodName = $this->getName($node);
+        if ($methodName === null) {
+            throw new ShouldNotHappenException();
+        }
 
-        /** @var string $className */
         $className = $node->getAttribute(Attribute::CLASS_NAME);
+        if (! is_string($className)) {
+            throw new ShouldNotHappenException();
+        }
 
         $childrenClassLikes = $this->classLikeNodeCollector->findClassesAndInterfacesByType($className);
 

--- a/packages/Php/src/Rector/MethodCall/ThisCallOnStaticMethodToStaticCallRector.php
+++ b/packages/Php/src/Rector/MethodCall/ThisCallOnStaticMethodToStaticCallRector.php
@@ -79,8 +79,10 @@ CODE_SAMPLE
             return null;
         }
 
-        /** @var string $className */
         $className = $node->getAttribute(Attribute::CLASS_NAME);
+        if (! is_string($className)) {
+            return null;
+        }
 
         $methodName = $this->getName($node);
         if ($methodName === null) {

--- a/packages/Php/src/Rector/Property/CompleteVarDocTypePropertyRector.php
+++ b/packages/Php/src/Rector/Property/CompleteVarDocTypePropertyRector.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Property;
+use Rector\Exception\ShouldNotHappenException;
 use Rector\NodeTypeResolver\Node\Attribute;
 use Rector\NodeTypeResolver\Node\NodeToStringTypeResolver;
 use Rector\NodeTypeResolver\NodeTypeAnalyzer;
@@ -133,8 +134,10 @@ CODE_SAMPLE
             $types[] = $this->nodeToStringTypeResolver->resolver($propertyDefault);
         }
 
-        /** @var Class_ $classNode */
         $classNode = $propertyNode->getAttribute(Attribute::CLASS_NODE);
+        if (! $classNode instanceof Class_) {
+            throw new ShouldNotHappenException();
+        }
 
         $propertyName = $this->getName($propertyNode);
         if ($propertyName === null) {
@@ -145,11 +148,9 @@ CODE_SAMPLE
         $propertyAssignNodes = $this->betterNodeFinder->find([$classNode], function (Node $node) use (
             $propertyName
         ): bool {
-            if ($node instanceof Assign) {
-                if ($node->var instanceof PropertyFetch) {
-                    // is property match
-                    return $this->isName($node->var, $propertyName);
-                }
+            if ($node instanceof Assign && $node->var instanceof PropertyFetch) {
+                // is property match
+                return $this->isName($node->var, $propertyName);
             }
 
             return false;

--- a/packages/Php/src/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector.php
+++ b/packages/Php/src/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector.php
@@ -104,7 +104,9 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->getName($node->class) === $node->getAttribute(Attribute::PARENT_CLASS_NAME)) {
+        $className = $this->getName($node->class);
+        $parentClassName = $node->getAttribute(Attribute::PARENT_CLASS_NAME);
+        if ($className === $parentClassName) {
             return null;
         }
 

--- a/packages/Symfony/src/Rector/FrameworkBundle/AbstractToConstructorInjectionRector.php
+++ b/packages/Symfony/src/Rector/FrameworkBundle/AbstractToConstructorInjectionRector.php
@@ -7,7 +7,9 @@ use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
 use Rector\Bridge\Contract\AnalyzedApplicationContainerInterface;
+use Rector\Exception\ShouldNotHappenException;
 use Rector\Naming\PropertyNaming;
 use Rector\NodeTypeResolver\Node\Attribute;
 use Rector\Rector\AbstractRector;
@@ -43,12 +45,12 @@ abstract class AbstractToConstructorInjectionRector extends AbstractRector
         }
 
         $propertyName = $this->propertyNaming->fqnToVariableName($serviceType);
+        $classNode = $methodCallNode->getAttribute(Attribute::CLASS_NODE);
+        if (! $classNode instanceof Class_) {
+            throw new ShouldNotHappenException();
+        }
 
-        $this->addPropertyToClass(
-            $methodCallNode->getAttribute(Attribute::CLASS_NODE),
-            $serviceType,
-            $propertyName
-        );
+        $this->addPropertyToClass($classNode, $serviceType, $propertyName);
 
         return $this->createPropertyFetch('this', $propertyName);
     }

--- a/packages/Symfony/src/Rector/FrameworkBundle/GetParameterToConstructorInjectionRector.php
+++ b/packages/Symfony/src/Rector/FrameworkBundle/GetParameterToConstructorInjectionRector.php
@@ -5,6 +5,7 @@ namespace Rector\Symfony\Rector\FrameworkBundle;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
 use Rector\Naming\PropertyNaming;
 use Rector\NodeTypeResolver\Node\Attribute;
 use Rector\Rector\AbstractRector;
@@ -94,8 +95,13 @@ CODE_SAMPLE
         $parameterName = $stringArgument->value;
         $propertyName = $this->propertyNaming->underscoreToName($parameterName);
 
+        $classNode = $node->getAttribute(Attribute::CLASS_NODE);
+        if (! $classNode instanceof Class_) {
+            return null;
+        }
+
         $this->addPropertyToClass(
-            $node->getAttribute(Attribute::CLASS_NODE),
+            $classNode,
             'string', // @todo: resolve type from container provider? see parameter autowire compiler pass
             $propertyName
         );

--- a/packages/Symfony/src/Rector/HttpKernel/GetRequestRector.php
+++ b/packages/Symfony/src/Rector/HttpKernel/GetRequestRector.php
@@ -147,6 +147,9 @@ CODE_SAMPLE
         }
 
         $methodNode = $node->getAttribute(Attribute::METHOD_NODE);
+        if ($methodNode === null) {
+            return false;
+        }
 
         return $this->controllerMethodAnalyzer->isAction($methodNode);
     }

--- a/packages/Symfony/src/Rector/MethodCall/CascadeValidationFormBuilderRector.php
+++ b/packages/Symfony/src/Rector/MethodCall/CascadeValidationFormBuilderRector.php
@@ -148,6 +148,7 @@ CODE_SAMPLE
         );
 
         $parentNode = $node->getAttribute(Attribute::PARENT_NODE);
+
         while ($parentNode instanceof MethodCall) {
             if ($this->isName($parentNode, 'add')) {
                 /** @var Array_ $addOptionsArrayNode */

--- a/packages/Symfony/src/Rector/New_/RootNodeTreeBuilderRector.php
+++ b/packages/Symfony/src/Rector/New_/RootNodeTreeBuilderRector.php
@@ -101,9 +101,15 @@ CODE_SAMPLE
 
     private function getRootMethodCallNode(Node $node): ?Node
     {
-        /** @var Node $node */
         $expression = $node->getAttribute(Attribute::CURRENT_EXPRESSION);
+        if ($expression === null) {
+            return null;
+        }
+
         $nextExpression = $expression->getAttribute(Attribute::NEXT_NODE);
+        if ($nextExpression === null) {
+            return null;
+        }
 
         return $this->betterNodeFinder->findFirst([$nextExpression], function (Node $node) {
             if (! $node instanceof MethodCall) {

--- a/packages/Symfony/src/Rector/Yaml/ParseFileRector.php
+++ b/packages/Symfony/src/Rector/Yaml/ParseFileRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\StaticCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Type\Constant\ConstantStringType;
+use Rector\Exception\ShouldNotHappenException;
 use Rector\NodeTypeResolver\Node\Attribute;
 use Rector\Rector\AbstractRector;
 use Rector\RectorDefinition\CodeSample;
@@ -72,8 +73,11 @@ final class ParseFileRector extends AbstractRector
         }
 
         // try to detect current value
-        /** @var Scope $nodeScope */
         $nodeScope = $possibleFileNode->getAttribute(Attribute::SCOPE);
+        if ($nodeScope === null) {
+            throw new ShouldNotHappenException();
+        }
+
         $nodeType = $nodeScope->getType($possibleFileNode);
 
         if ($nodeType instanceof ConstantStringType) {

--- a/packages/Twig/src/Rector/SimpleFunctionAndFilterRector.php
+++ b/packages/Twig/src/Rector/SimpleFunctionAndFilterRector.php
@@ -118,6 +118,10 @@ CODE_SAMPLE
         }
 
         $classNode = $node->getAttribute(Attribute::CLASS_NODE);
+        if ($classNode === null) {
+            return null;
+        }
+
         if (! $this->isTypes($classNode, [$this->twigExtensionClass])) {
             return null;
         }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,7 +5,7 @@ includes:
 
 parameters:
     # to allow intalling with various phsptan versions without reporting old errors here
-    reportUnmatchedIgnoredErrors: false
+#    reportUnmatchedIgnoredErrors: false
     level: 7
 
     excludes_analyse:
@@ -63,7 +63,6 @@ parameters:
         - '#Access to an undefined property PhpParser\\Node\\Expr\\MethodCall\|PhpParser\\Node\\Stmt\\ClassMethod::\$params#'
         - '#Cannot call method getName\(\) on PHPStan\\Reflection\\ClassReflection\|null#'
 
-        - '#Cannot call method getAttribute\(\) on PhpParser\\Node\\Name\|null#'
         - '#Cannot call method getText\(\) on PhpParser\\Comment\\Doc\|null#'
         - '#Method Rector\\PhpParser\\Node\\Maintainer\\PropertyMaintainer::getAllPropertyFetch\(\) should return array<PhpParser\\Node\\Expr\\PropertyFetch> but returns array<PhpParser\\Node>#'
 
@@ -101,8 +100,10 @@ parameters:
         - '#Strict comparison using === between PhpParser\\Node\\Expr and null will always evaluate to false#'
         - '#Cannot cast array<string>\|string\|null to string#'
 
+        # false positive on anonymous classes
+        - '#http\:\/\/bit\.ly\/typehintarray#'
+
 services:
-    -
-        class: Symplify\PHPStanExtensions\Type\SplFileInfoTolerantDynamicMethodReturnTypeExtension
-        tags:
-            - phpstan.broker.dynamicMethodReturnTypeExtension
+    - { class: Symplify\PHPStanExtensions\Type\SplFileInfoTolerantDynamicMethodReturnTypeExtension, tags: [phpstan.broker.dynamicMethodReturnTypeExtension] }
+    # $node->geAttribute($1) => Type|null by $1
+    - { class: Rector\PHPStanExtensions\Rector\Type\GetAttributeReturnTypeExtension, tags: [phpstan.broker.dynamicMethodReturnTypeExtension] }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,5 @@
 includes:
+     - 'utils/phpstan/config/phpstan-extensions.neon'
      - 'vendor/symplify/phpstan-extensions/config/config.neon'
      - 'vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon'
      - 'vendor/thecodingmachine/phpstan-safe-rule/phpstan-safe-rule.neon'
@@ -70,7 +71,6 @@ parameters:
         - '#Method Rector\\CodeQuality\\Rector\\Foreach_\\SimplifyForeachToCoalescingRector\:\:matchReturnOrAssignNode\(\) should return PhpParser\\Node\\Expr\\Assign\|PhpParser\\Node\\Stmt\\Return_\|null but returns PhpParser\\Node\|null#'
         - '#Access to an undefined property PhpParser\\Node::\$(\w+)#'
         - '#Parameter \#2 \$boolConstFetchNode of method Rector\\CodeQuality\\Rector\\Identical\\SimplifyArraySearchRector::resolveIsNot\(\) expects PhpParser\\Node\\Expr\\ConstFetch, PhpParser\\Node given#'
-        - '#Method Rector\\PhpParser\\Node\\BetterNodeFinder::findFirstAncestorInstanceOf\(\) should return PhpParser\\Node\|null but returns object#'
 
         # false positive, resolved in previous method
         - '#Parameter (.*?) of method Rector\\PhpParser\\Node\\Maintainer\\IdentifierMaintainer\:\:(.*?)\(\) expects PhpParser\\Node\\Expr\\ClassConstFetch\|PhpParser\\Node\\Expr\\MethodCall\|PhpParser\\Node\\Expr\\PropertyFetch\|PhpParser\\Node\\Expr\\StaticCall\|PhpParser\\Node\\Stmt\\ClassMethod, PhpParser\\Node given#'
@@ -98,12 +98,3 @@ parameters:
         # known values
         - '#Parameter \#(1|2) \$(left|right) of class PhpParser\\Node\\Expr\\BinaryOp\\Coalesce constructor expects PhpParser\\Node\\Expr, PhpParser\\Node\\Expr\|null given#'
         - '#Strict comparison using === between PhpParser\\Node\\Expr and null will always evaluate to false#'
-        - '#Cannot cast array<string>\|string\|null to string#'
-
-        # false positive on anonymous classes
-        - '#http\:\/\/bit\.ly\/typehintarray#'
-
-services:
-    - { class: Symplify\PHPStanExtensions\Type\SplFileInfoTolerantDynamicMethodReturnTypeExtension, tags: [phpstan.broker.dynamicMethodReturnTypeExtension] }
-    # $node->geAttribute($1) => Type|null by $1
-    - { class: Rector\PHPStanExtensions\Rector\Type\GetAttributeReturnTypeExtension, tags: [phpstan.broker.dynamicMethodReturnTypeExtension] }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,7 +5,7 @@ includes:
 
 parameters:
     # to allow intalling with various phsptan versions without reporting old errors here
-#    reportUnmatchedIgnoredErrors: false
+    reportUnmatchedIgnoredErrors: false
     level: 7
 
     excludes_analyse:

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -22,9 +22,7 @@ final class BetterNodeFinder
 
     public function findFirstAncestorInstanceOf(Node $node, string $type): ?Node
     {
-        /** @var Node|null $currentNode */
         $currentNode = $node->getAttribute(Attribute::PARENT_NODE);
-
         while ($currentNode !== null) {
             if ($currentNode instanceof $type) {
                 return $currentNode;
@@ -86,6 +84,9 @@ final class BetterNodeFinder
     public function findFirstPrevious(Node $node, callable $filter): ?Node
     {
         $node = $node instanceof Expression ? $node : $node->getAttribute(Attribute::CURRENT_EXPRESSION);
+        if ($node === null) {
+            return null;
+        }
 
         $foundNode = $this->findFirst([$node], $filter);
         // we found what we need

--- a/src/PhpParser/Node/Maintainer/ChildAndParentClassMaintainer.php
+++ b/src/PhpParser/Node/Maintainer/ChildAndParentClassMaintainer.php
@@ -39,8 +39,9 @@ final class ChildAndParentClassMaintainer
 
     public function completeParentConstructor(Class_ $classNode, ClassMethod $constructorClassMethodNode): void
     {
-        $parentClassName = (string) $classNode->getAttribute(Attribute::PARENT_CLASS_NAME);
-        if (! $parentClassName) {
+        /** @var string|null $parentClassName */
+        $parentClassName = $classNode->getAttribute(Attribute::PARENT_CLASS_NAME);
+        if ($parentClassName === null) {
             return;
         }
 
@@ -114,9 +115,9 @@ final class ChildAndParentClassMaintainer
                 return $constructMethodNode;
             }
 
-            /** @var string $parentClassName */
+            /** @var string|null $parentClassName */
             $parentClassName = $classNode->getAttribute(Attribute::PARENT_CLASS_NAME);
-            if (! $parentClassName) {
+            if ($parentClassName === null) {
                 return null;
             }
 

--- a/src/PhpParser/Node/Maintainer/ClassMethodMaintainer.php
+++ b/src/PhpParser/Node/Maintainer/ClassMethodMaintainer.php
@@ -42,17 +42,21 @@ final class ClassMethodMaintainer
     public function hasParentMethodOrInterfaceMethod(ClassMethod $classMethod): bool
     {
         $class = $classMethod->getAttribute(Attribute::CLASS_NAME);
+        if ($class === null) {
+            return false;
+        }
+
         $method = $classMethod->getAttribute(Attribute::METHOD_NAME);
+        if ($method === null) {
+            return false;
+        }
 
         if (! class_exists($class)) {
             return false;
         }
 
-        $parentClass = $class;
-        while ($parentClass = get_parent_class($parentClass)) {
-            if (method_exists($parentClass, $method)) {
-                return true;
-            }
+        if ($this->isMethodInParent($class, $method)) {
+            return true;
         }
 
         $implementedInterfaces = class_implements($class);
@@ -82,6 +86,19 @@ final class ClassMethodMaintainer
             }
 
             return $this->isArrayOfArrays($statement->expr);
+        }
+
+        return false;
+    }
+
+    private function isMethodInParent(string $class, string $method): bool
+    {
+        $parentClass = $class;
+
+        while ($parentClass = get_parent_class($parentClass)) {
+            if (method_exists($parentClass, $method)) {
+                return true;
+            }
         }
 
         return false;

--- a/src/PhpParser/Node/Maintainer/PropertyFetchMaintainer.php
+++ b/src/PhpParser/Node/Maintainer/PropertyFetchMaintainer.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr\PropertyFetch;
 use PHPStan\Analyser\Scope;
 use PHPStan\Broker\Broker;
 use PHPStan\Type\ObjectType;
+use Rector\Exception\ShouldNotHappenException;
 use Rector\NodeTypeResolver\Node\Attribute;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\PhpParser\Node\Resolver\NameResolver;
@@ -60,8 +61,10 @@ final class PropertyFetchMaintainer
 
     private function hasPublicProperty(PropertyFetch $node, string $propertyName): bool
     {
-        /** @var Scope $nodeScope */
         $nodeScope = $node->getAttribute(Attribute::SCOPE);
+        if ($nodeScope === null) {
+            throw new ShouldNotHappenException();
+        }
 
         $propertyFetchType = $nodeScope->getType($node->var);
         if ($propertyFetchType instanceof ObjectType) {

--- a/src/PhpParser/Node/Maintainer/PropertyMaintainer.php
+++ b/src/PhpParser/Node/Maintainer/PropertyMaintainer.php
@@ -47,6 +47,9 @@ final class PropertyMaintainer
     public function getAllPropertyFetch(Property $propertyNode): array
     {
         $classNode = $propertyNode->getAttribute(Attribute::CLASS_NODE);
+        if ($classNode === null) {
+            return [];
+        }
 
         return $this->betterNodeFinder->find($classNode, function (Node $node) use ($propertyNode) {
             // itself

--- a/src/Rector/AbstractPHPUnitRector.php
+++ b/src/Rector/AbstractPHPUnitRector.php
@@ -3,14 +3,12 @@
 namespace Rector\Rector;
 
 use PhpParser\Node;
-use PhpParser\Node\Stmt\Class_;
 use Rector\NodeTypeResolver\Node\Attribute;
 
 abstract class AbstractPHPUnitRector extends AbstractRector
 {
     protected function isInTestClass(Node $node): bool
     {
-        /** @var Class_|null $classNode */
         $classNode = $node->getAttribute(Attribute::CLASS_NODE);
         if ($classNode === null) {
             return false;

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -161,7 +161,6 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
 
     protected function notifyNodeChangeFileInfo(Node $node): void
     {
-        /** @var SmartFileInfo|null $fileInfo */
         $fileInfo = $node->getAttribute(Attribute::FILE_INFO);
         if ($fileInfo === null) {
             throw new ShouldNotHappenException(sprintf(

--- a/src/Rector/Annotation/AnnotationReplacerRector.php
+++ b/src/Rector/Annotation/AnnotationReplacerRector.php
@@ -5,6 +5,7 @@ namespace Rector\Rector\Annotation;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Property;
+use Rector\Exception\ShouldNotHappenException;
 use Rector\NodeTypeResolver\Node\Attribute;
 use Rector\NodeTypeResolver\PhpDoc\NodeAnalyzer\DocBlockAnalyzer;
 use Rector\Rector\AbstractPHPUnitRector;
@@ -94,8 +95,11 @@ CODE_SAMPLE
             return null;
         }
 
-        /** @var Node $parentNode */
         $parentNode = $node->getAttribute(Attribute::PARENT_NODE);
+        if ($parentNode === null) {
+            throw new ShouldNotHappenException();
+        }
+
         $parentNodeTypes = $this->getTypes($parentNode);
         foreach ($this->classToAnnotationMap as $type => $annotationMap) {
             if (! in_array($type, $parentNodeTypes, true)) {
@@ -122,9 +126,9 @@ CODE_SAMPLE
             return true;
         }
 
-        /** @var Node|null $parentNode */
         $parentNode = $node->getAttribute(Attribute::PARENT_NODE);
-        return ! $parentNode;
+
+        return $parentNode === null;
     }
 
     private function hasAnyAnnotation(Node $node): bool

--- a/src/Rector/Architecture/DependencyInjection/ActionInjectionToConstructorInjectionRector.php
+++ b/src/Rector/Architecture/DependencyInjection/ActionInjectionToConstructorInjectionRector.php
@@ -104,12 +104,11 @@ CODE_SAMPLE
             }
 
             $paramNodeTypes = $this->getTypes($paramNode);
-            $paramName = $this->getName($paramNode->var);
-            if ($paramName === null) {
-                continue;
-            }
+            $paramNodeType = $paramNodeTypes[0] ?? 'mixed';
 
-            $this->addPropertyToClass($classNode, $paramNodeTypes[0], $paramName);
+            /** @var string $paramName */
+            $paramName = $this->getName($paramNode->var);
+            $this->addPropertyToClass($classNode, $paramNodeType, $paramName);
 
             // remove arguments
             unset($classMethodNode->params[$key]);

--- a/src/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector.php
+++ b/src/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector.php
@@ -109,12 +109,8 @@ CODE_SAMPLE
             return;
         }
 
-        $mainPropertyType = $this->getTypes($propertyNode)[0];
+        $mainPropertyType = $this->getTypes($propertyNode)[0] ?? 'mixed';
         $propertyName = $this->getName($propertyNode);
-        if ($propertyName === null) {
-            return;
-        }
-
         $this->addPropertyToClass($classNode, $mainPropertyType, $propertyName);
     }
 }

--- a/src/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector.php
+++ b/src/Rector/Architecture/DependencyInjection/AnnotatedPropertyInjectToConstructorInjectionRector.php
@@ -105,6 +105,10 @@ CODE_SAMPLE
     private function addPropertyToCollector(Property $propertyNode): void
     {
         $classNode = $propertyNode->getAttribute(Attribute::CLASS_NODE);
+        if (! $classNode instanceof Class_) {
+            return;
+        }
+
         $mainPropertyType = $this->getTypes($propertyNode)[0];
         $propertyName = $this->getName($propertyNode);
         if ($propertyName === null) {

--- a/src/Rector/Architecture/DependencyInjection/ReplaceVariableByPropertyFetchRector.php
+++ b/src/Rector/Architecture/DependencyInjection/ReplaceVariableByPropertyFetchRector.php
@@ -7,6 +7,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\Configuration\Rector\Architecture\DependencyInjection\VariablesToPropertyFetchCollection;
+use Rector\Exception\ShouldNotHappenException;
 use Rector\NodeTypeResolver\Node\Attribute;
 use Rector\Rector\AbstractRector;
 use Rector\RectorDefinition\CodeSample;
@@ -108,7 +109,12 @@ CODE_SAMPLE
 
     private function isInControllerActionMethod(Node $node): bool
     {
-        if (! Strings::endsWith((string) $node->getAttribute(Attribute::CLASS_NAME), 'Controller')) {
+        $className = $node->getAttribute(Attribute::CLASS_NAME);
+        if ($className === null) {
+            throw new ShouldNotHappenException();
+        }
+
+        if (! Strings::endsWith($className, 'Controller')) {
             return false;
         }
 

--- a/src/Rector/Architecture/DependencyInjection/ReplaceVariableByPropertyFetchRector.php
+++ b/src/Rector/Architecture/DependencyInjection/ReplaceVariableByPropertyFetchRector.php
@@ -7,7 +7,6 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\Configuration\Rector\Architecture\DependencyInjection\VariablesToPropertyFetchCollection;
-use Rector\Exception\ShouldNotHappenException;
 use Rector\NodeTypeResolver\Node\Attribute;
 use Rector\Rector\AbstractRector;
 use Rector\RectorDefinition\CodeSample;
@@ -107,11 +106,12 @@ CODE_SAMPLE
         return null;
     }
 
-    private function isInControllerActionMethod(Node $node): bool
+    private function isInControllerActionMethod(Variable $node): bool
     {
         $className = $node->getAttribute(Attribute::CLASS_NAME);
+
         if ($className === null) {
-            throw new ShouldNotHappenException();
+            return false;
         }
 
         if (! Strings::endsWith($className, 'Controller')) {

--- a/src/Rector/Architecture/RepositoryAsService/ServiceLocatorToDIRector.php
+++ b/src/Rector/Architecture/RepositoryAsService/ServiceLocatorToDIRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
 use Rector\Bridge\Contract\DoctrineEntityAndRepositoryMapperInterface;
 use Rector\Exception\Bridge\RectorProviderException;
 use Rector\Exception\ShouldNotHappenException;
@@ -123,9 +124,13 @@ CODE_SAMPLE
         }
 
         $repositoryFqn = $this->repositoryFqn($node);
+        $classNode = $node->getAttribute(Attribute::CLASS_NODE);
+        if (! $classNode instanceof Class_) {
+            return null;
+        }
 
         $this->addPropertyToClass(
-            $node->getAttribute(Attribute::CLASS_NODE),
+            $classNode,
             $repositoryFqn,
             $this->propertyNaming->fqnToVariableName($repositoryFqn)
         );

--- a/src/Rector/MethodBody/ReturnThisRemoveRector.php
+++ b/src/Rector/MethodBody/ReturnThisRemoveRector.php
@@ -4,8 +4,8 @@ namespace Rector\Rector\MethodBody;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Return_;
+use Rector\Exception\ShouldNotHappenException;
 use Rector\NodeTypeResolver\Node\Attribute;
 use Rector\NodeTypeResolver\PhpDoc\NodeAnalyzer\DocBlockAnalyzer;
 use Rector\Rector\AbstractRector;
@@ -97,8 +97,11 @@ CODE_SAMPLE
 
         $this->removeNode($node);
 
-        /** @var ClassMethod $methodNode */
         $methodNode = $node->getAttribute(Attribute::METHOD_NODE);
+        if ($methodNode === null) {
+            throw new ShouldNotHappenException();
+        }
+
         $this->docBlockAnalyzer->removeTagFromNode($methodNode, 'return');
 
         return null;

--- a/src/Rector/Psr4/MultipleClassFileToPsr4ClassesRector.php
+++ b/src/Rector/Psr4/MultipleClassFileToPsr4ClassesRector.php
@@ -122,7 +122,6 @@ CODE_SAMPLE
             $smartFileInfo->getRealPath()
         );
 
-        /** @var Namespace_[] $namespaceNodes */
         $namespaceNodes = $this->betterNodeFinder->findInstanceOf($newStmts, Namespace_::class);
 
         if ($this->shouldSkip($smartFileInfo, $newStmts, $namespaceNodes)) {

--- a/src/Rector/Visibility/ChangePropertyVisibilityRector.php
+++ b/src/Rector/Visibility/ChangePropertyVisibilityRector.php
@@ -83,7 +83,12 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         foreach ($this->propertyToVisibilityByClass as $type => $propertyToVisibility) {
-            if (! $this->isType($node->getAttribute(Attribute::CLASS_NODE), $type)) {
+            $classNode = $node->getAttribute(Attribute::CLASS_NODE);
+            if ($classNode === null) {
+                continue;
+            }
+
+            if (! $this->isType($classNode, $type)) {
                 continue;
             }
 

--- a/tests/Rector/Annotation/AnnotationReplacerRector/ScenarioToTestAnnotationRectorTest.php
+++ b/tests/Rector/Annotation/AnnotationReplacerRector/ScenarioToTestAnnotationRectorTest.php
@@ -2,7 +2,6 @@
 
 namespace Rector\Tests\Rector\Annotation\AnnotationReplacerRector;
 
-use PHPUnit\Framework\TestCase;
 use Rector\Rector\Annotation\AnnotationReplacerRector;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
@@ -23,6 +22,8 @@ final class ScenarioToTestAnnotationRectorTest extends AbstractRectorTestCase
      */
     protected function getRectorConfiguration(): array
     {
-        return [TestCase::class => ['scenario' => 'test']];
+        return [
+            'PHPUnit\Framework\TestCase' => ['scenario' => 'test'],
+        ];
     }
 }

--- a/utils/phpstan/config/phpstan-extensions.neon
+++ b/utils/phpstan/config/phpstan-extensions.neon
@@ -1,5 +1,8 @@
 services:
+    - Rector\PHPStanExtensions\Utils\ValueResolver
+
     - { class: Symplify\PHPStanExtensions\Type\SplFileInfoTolerantDynamicMethodReturnTypeExtension, tags: [phpstan.broker.dynamicMethodReturnTypeExtension] }
+
     # $node->geAttribute($1) => Type|null by $1
     - { class: Rector\PHPStanExtensions\Rector\Type\GetAttributeReturnTypeExtension, tags: [phpstan.broker.dynamicMethodReturnTypeExtension] }
 
@@ -7,3 +10,6 @@ services:
     - { class: Rector\PHPStanExtensions\Rector\Type\NameResolverReturnTypeExtension, tags: [phpstan.broker.dynamicMethodReturnTypeExtension] }
     # $nameResolverTrait->getName() => in some cases always string
     - { class: Rector\PHPStanExtensions\Rector\Type\NameResolverTraitReturnTypeExtension, tags: [phpstan.broker.dynamicMethodReturnTypeExtension] }
+
+    # $betterNodeFinder->findByInstance(..., $1) => $1[]
+    - { class: Rector\PHPStanExtensions\Rector\Type\BetterNodeFinderReturnTypeExtension, tags: [phpstan.broker.dynamicMethodReturnTypeExtension] }

--- a/utils/phpstan/config/phpstan-extensions.neon
+++ b/utils/phpstan/config/phpstan-extensions.neon
@@ -1,0 +1,9 @@
+services:
+    - { class: Symplify\PHPStanExtensions\Type\SplFileInfoTolerantDynamicMethodReturnTypeExtension, tags: [phpstan.broker.dynamicMethodReturnTypeExtension] }
+    # $node->geAttribute($1) => Type|null by $1
+    - { class: Rector\PHPStanExtensions\Rector\Type\GetAttributeReturnTypeExtension, tags: [phpstan.broker.dynamicMethodReturnTypeExtension] }
+
+    # $nameResolver->resolve() => in some cases always string
+    - { class: Rector\PHPStanExtensions\Rector\Type\NameResolverReturnTypeExtension, tags: [phpstan.broker.dynamicMethodReturnTypeExtension] }
+    # $nameResolverTrait->getName() => in some cases always string
+    - { class: Rector\PHPStanExtensions\Rector\Type\NameResolverTraitReturnTypeExtension, tags: [phpstan.broker.dynamicMethodReturnTypeExtension] }

--- a/utils/phpstan/generate-paths.php
+++ b/utils/phpstan/generate-paths.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 // experimental, phpstan 0.10.7
 // @todo refactor to classes later, if proven working
@@ -72,15 +72,13 @@ function resolveNewFiles(): array
 
     $gitStatusOutput = $process->getOutput();
 
-    var_dump($gitStatusOutput);
-
     $files = [];
     foreach (Strings::matchAll($gitStatusOutput, '#\?\? ([\w\/\.]+)#m') as $match) {
         $directoryOrFile = getcwd() . '/' . $match[1];
         if (file_exists($directoryOrFile) && is_file($directoryOrFile)) {
             $files[] = $directoryOrFile;
         } else {
-            $finder = (Finder::create())
+            $finder = Finder::create()
                 ->files()
                 ->in($directoryOrFile)
                 ->name('*.php');

--- a/utils/phpstan/src/Rector/Type/AbstractResolvedNameReturnTypeExtension.php
+++ b/utils/phpstan/src/Rector/Type/AbstractResolvedNameReturnTypeExtension.php
@@ -11,7 +11,6 @@ use PhpParser\Node\Stmt\Const_;
 use PhpParser\Node\Stmt\Interface_;
 use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\PropertyProperty;
-use PhpParser\Node\Stmt\Static_;
 use PhpParser\Node\Stmt\Trait_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
@@ -46,12 +45,15 @@ abstract class AbstractResolvedNameReturnTypeExtension implements DynamicMethodR
         Name::class,
     ];
 
-    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
-    {
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope
+    ): Type {
         $returnType = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
 
         $argumentValueType = $scope->getType($methodCall->args[0]->value);
-        if ( ! $argumentValueType instanceof ObjectType) {
+        if (! $argumentValueType instanceof ObjectType) {
             return $returnType;
         }
 

--- a/utils/phpstan/src/Rector/Type/AbstractResolvedNameReturnTypeExtension.php
+++ b/utils/phpstan/src/Rector/Type/AbstractResolvedNameReturnTypeExtension.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+namespace Rector\PHPStanExtensions\Rector\Type;
+
+use PhpParser\Node\Const_ as NodeConst;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Name;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Const_;
+use PhpParser\Node\Stmt\Interface_;
+use PhpParser\Node\Stmt\Property;
+use PhpParser\Node\Stmt\PropertyProperty;
+use PhpParser\Node\Stmt\Static_;
+use PhpParser\Node\Stmt\Trait_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use Rector\PhpParser\Node\Resolver\NameResolver;
+use Rector\Rector\NameResolverTrait;
+
+/**
+ * @see NameResolver::resolve()
+ * @see NameResolverTrait::getName()
+ *
+ * These returns always strings for nodes with required names, e.g. for @see ClassMethod
+ */
+abstract class AbstractResolvedNameReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    /**
+     * @var string[]
+     */
+    private $alwaysNamedTypes = [
+        ClassMethod::class,
+        Trait_::class,
+        Interface_::class,
+        Property::class,
+        PropertyProperty::class,
+        Const_::class,
+        NodeConst::class,
+        Param::class,
+        Name::class,
+    ];
+
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
+    {
+        $returnType = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
+
+        $argumentValueType = $scope->getType($methodCall->args[0]->value);
+        if ( ! $argumentValueType instanceof ObjectType) {
+            return $returnType;
+        }
+
+        if (in_array($argumentValueType->getClassName(), $this->alwaysNamedTypes, true)) {
+            return new StringType();
+        }
+
+        return $returnType;
+    }
+}

--- a/utils/phpstan/src/Rector/Type/BetterNodeFinderReturnTypeExtension.php
+++ b/utils/phpstan/src/Rector/Type/BetterNodeFinderReturnTypeExtension.php
@@ -14,20 +14,9 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use Rector\PhpParser\Node\BetterNodeFinder;
-use Rector\PHPStanExtensions\Utils\ValueResolver;
 
 final class BetterNodeFinderReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
-    /**
-     * @var ValueResolver
-     */
-    private $valueResolver;
-
-    public function __construct(ValueResolver $valueResolver)
-    {
-        $this->valueResolver = $valueResolver;
-    }
-
     public function getClass(): string
     {
         return BetterNodeFinder::class;
@@ -38,8 +27,11 @@ final class BetterNodeFinderReturnTypeExtension implements DynamicMethodReturnTy
         return $methodReflection->getName() === 'findInstanceOf';
     }
 
-    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
-    {
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope
+    ): Type {
         $returnType = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
 
         $secondArgumentNode = $methodCall->args[1]->value;

--- a/utils/phpstan/src/Rector/Type/BetterNodeFinderReturnTypeExtension.php
+++ b/utils/phpstan/src/Rector/Type/BetterNodeFinderReturnTypeExtension.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace Rector\PHPStanExtensions\Rector\Type;
+
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use Rector\PhpParser\Node\BetterNodeFinder;
+use Rector\PHPStanExtensions\Utils\ValueResolver;
+
+final class BetterNodeFinderReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    /**
+     * @var ValueResolver
+     */
+    private $valueResolver;
+
+    public function __construct(ValueResolver $valueResolver)
+    {
+        $this->valueResolver = $valueResolver;
+    }
+
+    public function getClass(): string
+    {
+        return BetterNodeFinder::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'findInstanceOf';
+    }
+
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
+    {
+        $returnType = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
+
+        $secondArgumentNode = $methodCall->args[1]->value;
+        if (! $secondArgumentNode instanceof ClassConstFetch) {
+            return $returnType;
+        }
+
+        if (! $secondArgumentNode->class instanceof Name) {
+            return $returnType;
+        }
+
+        $class = $secondArgumentNode->class->toString();
+
+        return new ArrayType(new MixedType(), new ObjectType($class));
+    }
+}

--- a/utils/phpstan/src/Rector/Type/GetAttributeReturnTypeExtension.php
+++ b/utils/phpstan/src/Rector/Type/GetAttributeReturnTypeExtension.php
@@ -26,6 +26,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use Rector\Php\PhpTypeSupport;
 use Rector\Php\TypeAnalyzer;
+use Rector\PHPStanExtensions\Utils\ValueResolver;
 use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
 
 final class GetAttributeReturnTypeExtension implements DynamicMethodReturnTypeExtension
@@ -53,6 +54,15 @@ final class GetAttributeReturnTypeExtension implements DynamicMethodReturnTypeEx
         'Rector\NodeTypeResolver\Node\Attribute::CLASS_NAME' => 'string',
         'Rector\NodeTypeResolver\Node\Attribute::METHOD_NAME' => 'string',
     ];
+    /**
+     * @var ValueResolver
+     */
+    private $valueResolver;
+
+    public function __construct(ValueResolver $valueResolver)
+    {
+        $this->valueResolver = $valueResolver;
+    }
 
     public function getClass(): string
     {
@@ -92,22 +102,10 @@ final class GetAttributeReturnTypeExtension implements DynamicMethodReturnTypeEx
 
     private function resolveArgumentValue(Expr $node): ?string
     {
-        $value = null;
-
         if ($node instanceof ClassConstFetch) {
-            if ($node->class instanceof Name) {
-                $value = $node->class->toString();
-            } else {
-                return null;
-            }
-
-            if ($node->name instanceof Identifier) {
-                $value .= '::' . $node->name->toString();
-            } else {
-                return null;
-            }
+            return $this->valueResolver->resolveClassConstFetch($node);
         }
 
-        return $value;
+        return null;
     }
 }

--- a/utils/phpstan/src/Rector/Type/GetAttributeReturnTypeExtension.php
+++ b/utils/phpstan/src/Rector/Type/GetAttributeReturnTypeExtension.php
@@ -1,0 +1,113 @@
+<?php declare(strict_types=1);
+
+namespace Rector\PHPStanExtensions\Rector\Type;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Use_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
+use Rector\Php\PhpTypeSupport;
+use Rector\Php\TypeAnalyzer;
+use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
+
+final class GetAttributeReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    /**
+     * @var string[]
+     */
+    private $argumentKeyToReturnType = [
+        'Rector\NodeTypeResolver\Node\Attribute::FILE_INFO' => SmartFileInfo::class,
+        'Rector\NodeTypeResolver\Node\Attribute::RESOLVED_NAME' => Name::class,
+        'Rector\NodeTypeResolver\Node\Attribute::CLASS_NODE' => ClassLike::class,
+        'Rector\NodeTypeResolver\Node\Attribute::METHOD_NODE' => ClassMethod::class,
+        'Rector\NodeTypeResolver\Node\Attribute::CURRENT_EXPRESSION' => Expression::class,
+        'Rector\NodeTypeResolver\Node\Attribute::PREVIOUS_EXPRESSION' => Expression::class,
+        'Rector\NodeTypeResolver\Node\Attribute::SCOPE' => Scope::class,
+        # Node
+        'Rector\NodeTypeResolver\Node\Attribute::ORIGINAL_NODE' => Node::class,
+        'Rector\NodeTypeResolver\Node\Attribute::PARENT_NODE' => Node::class,
+        'Rector\NodeTypeResolver\Node\Attribute::NEXT_NODE' => Node::class,
+        'Rector\NodeTypeResolver\Node\Attribute::PREVIOUS_NODE' => Node::class,
+        'Rector\NodeTypeResolver\Node\Attribute::USE_NODES' => [Use_::class],
+        # scalars
+        'Rector\NodeTypeResolver\Node\Attribute::PARENT_CLASS_NAME' => 'string',
+        'Rector\NodeTypeResolver\Node\Attribute::NAMESPACE_NAME' => 'string',
+        'Rector\NodeTypeResolver\Node\Attribute::CLASS_NAME' => 'string',
+        'Rector\NodeTypeResolver\Node\Attribute::METHOD_NAME' => 'string',
+    ];
+
+    public function getClass(): string
+    {
+        return Node::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'getAttribute';
+    }
+
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
+    {
+        $returnType = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
+
+        $argumentValue = $this->resolveArgumentValue($methodCall->args[0]->value);
+        if ($argumentValue === null) {
+            return $returnType;
+        }
+
+        if (! isset($this->argumentKeyToReturnType[$argumentValue])) {
+            return $returnType;
+        }
+
+        $returnType = $this->argumentKeyToReturnType[$argumentValue];
+        if ($returnType === 'string') {
+            return new UnionType([new StringType(), new NullType()]);
+        }
+
+        if (is_array($returnType) && count($returnType) === 1) {
+            $arrayType = new ArrayType(new IntegerType(), new ObjectType($returnType[0]));
+            return new UnionType([$arrayType, new NullType()]);
+        }
+
+        return new UnionType([new ObjectType($returnType), new NullType()]);
+    }
+
+    private function resolveArgumentValue(Expr $node): ?string
+    {
+        $value = null;
+
+        if ($node instanceof ClassConstFetch) {
+            if ($node->class instanceof Name) {
+                $value = $node->class->toString();
+            } else {
+                return null;
+            }
+
+            if ($node->name instanceof Identifier) {
+                $value .= '::' . $node->name->toString();
+            } else {
+                return null;
+            }
+        }
+
+        return $value;
+    }
+}

--- a/utils/phpstan/src/Rector/Type/NameResolverReturnTypeExtension.php
+++ b/utils/phpstan/src/Rector/Type/NameResolverReturnTypeExtension.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Rector\PHPStanExtensions\Rector\Type;
+
+use PHPStan\Reflection\MethodReflection;
+use Rector\PhpParser\Node\Resolver\NameResolver;
+
+final class NameResolverReturnTypeExtension extends AbstractResolvedNameReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return NameResolver::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'resolve';
+    }
+}

--- a/utils/phpstan/src/Rector/Type/NameResolverTraitReturnTypeExtension.php
+++ b/utils/phpstan/src/Rector/Type/NameResolverTraitReturnTypeExtension.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Rector\PHPStanExtensions\Rector\Type;
+
+use PHPStan\Reflection\MethodReflection;
+use Rector\Rector\AbstractRector;
+use Rector\Rector\NameResolverTrait;
+
+final class NameResolverTraitReturnTypeExtension extends AbstractResolvedNameReturnTypeExtension
+{
+    /**
+     * Original scope @see NameResolverTrait
+     */
+    public function getClass(): string
+    {
+        return AbstractRector::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'getName';
+    }
+}

--- a/utils/phpstan/src/Utils/ValueResolver.php
+++ b/utils/phpstan/src/Utils/ValueResolver.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Rector\PHPStanExtensions\Utils;
+
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+
+final class ValueResolver
+{
+    public function resolveClassConstFetch(ClassConstFetch $classConstFetch): ?string
+    {
+        $value = null;
+
+        if ($classConstFetch->class instanceof Name) {
+            $value = $classConstFetch->class->toString();
+        } else {
+            return null;
+        }
+
+        if ($classConstFetch->name instanceof Identifier) {
+            $value .= '::' . $classConstFetch->name->toString();
+        } else {
+            return null;
+        }
+
+        return $value;
+    }
+}


### PR DESCRIPTION
Improve static analysis for known `getAttribute()` nullables

```diff
-/** @var Node|Null */
 $previousNode = $node->getAttribute(Attribute::PREVIOUS_NODE);
```

Improve `getName()`

```diff
-/** @var string|null */
 $previousNode = $this->getName($clsasMethod); // only "string"
```

Improve BetterNodeFinder:

```diff
-/** @var New[] $newNodes */
 $newNodes = $betterNodeFinder->findInstanceOf($nodes, New_::class);
```