### PR TITLE
Fix file by removing extra unallowed trailing

### DIFF
--- a/packages/NetteToSymfony/src/Event/EventInfosFactory.php
+++ b/packages/NetteToSymfony/src/Event/EventInfosFactory.php
@@ -20,7 +20,7 @@ final class EventInfosFactory
             ],
             'Symfony\Component\HttpKernel\KernelEvents',
             'REQUEST',
-            'Symfony\Component\HttpKernel\Event\GetResponseEvent',
+            'Symfony\Component\HttpKernel\Event\GetResponseEvent'
         );
 
         $eventInfos[] = new EventInfo(
@@ -59,7 +59,7 @@ final class EventInfosFactory
             ],
             'Symfony\Component\HttpKernel\KernelEvents',
             'CONTROLLER',
-            'Symfony\Component\HttpKernel\Event\FilterControllerEvent',
+            'Symfony\Component\HttpKernel\Event\FilterControllerEvent'
         );
 
         $eventInfos[] = new EventInfo(


### PR DESCRIPTION
https://github.com/rectorphp/rector/issues/1040

Trailing comma in function call [is valid with PHP7.3](https://wiki.php.net/rfc/trailing-comma-function-calls)

Actual minimum php requirement is 7.2 so this is not consistent.