### PR TITLE
[CodeQuality] Add ExplicitBoolCompareRector

### DIFF
--- a/config/level/code-quality/code-quality.yaml
+++ b/config/level/code-quality/code-quality.yaml
@@ -25,3 +25,4 @@ services:
     Rector\CodeQuality\Rector\Concat\JoinStringConcatRector: ~
     Rector\CodeQuality\Rector\If_\ConsecutiveNullCompareReturnsToNullCoalesceQueueRector: ~
     Rector\CodeQuality\Rector\If_\SimplifyIfIssetToNullCoalescingRector: ~
+    Rector\CodeQuality\Rector\If_\ExplicitBoolCompareRector: ~

--- a/packages/CodeQuality/src/Rector/Foreach_/SimplifyForeachToCoalescingRector.php
+++ b/packages/CodeQuality/src/Rector/Foreach_/SimplifyForeachToCoalescingRector.php
@@ -70,7 +70,7 @@ CODE_SAMPLE
     {
         $this->returnNode = null;
 
-        if (! $node->keyVar) {
+        if ($node->keyVar === null) {
             return null;
         }
 
@@ -152,7 +152,7 @@ CODE_SAMPLE
             $checkedNode
         ), $this->returnNode && $this->returnNode->expr !== null ? $this->returnNode->expr : $checkedNode);
 
-        if ($this->returnNode) {
+        if ($this->returnNode !== null) {
             return new Return_($coalesceNode);
         }
 

--- a/packages/CodeQuality/src/Rector/If_/ConsecutiveNullCompareReturnsToNullCoalesceQueueRector.php
+++ b/packages/CodeQuality/src/Rector/If_/ConsecutiveNullCompareReturnsToNullCoalesceQueueRector.php
@@ -89,7 +89,7 @@ CODE_SAMPLE
         while ($currentNode !== null) {
             if ($currentNode instanceof If_) {
                 $comparedNode = $this->ifMaintainer->matchIfNotNullReturnValue($currentNode);
-                if ($comparedNode) {
+                if ($comparedNode !== null) {
                     $this->coalescingNodes[] = $comparedNode;
                     $this->nodesToRemove[] = $currentNode;
 

--- a/packages/CodeQuality/src/Rector/If_/ExplicitBoolCompareRector.php
+++ b/packages/CodeQuality/src/Rector/If_/ExplicitBoolCompareRector.php
@@ -67,10 +67,15 @@ CODE_SAMPLE
     }
 
     /**
-     * @param If_|ElseIf_ $node
+     * @param If_|ElseIf_|Ternary $node
      */
     public function refactor(Node $node): ?Node
     {
+        // skip short ternary
+        if ($node instanceof Ternary && $node->if === null) {
+            return null;
+        }
+
         if ($node->cond instanceof BooleanNot) {
             $conditionNode = $node->cond->expr;
             $isNegated = true;
@@ -124,7 +129,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @return Smaller|Greater
+     * @return Identical|Greater
      */
     private function resolveCount(bool $isNegated, Expr $conditionNode): BinaryOp
     {

--- a/packages/CodeQuality/src/Rector/If_/ExplicitBoolCompareRector.php
+++ b/packages/CodeQuality/src/Rector/If_/ExplicitBoolCompareRector.php
@@ -1,0 +1,209 @@
+<?php declare(strict_types=1);
+
+namespace Rector\CodeQuality\Rector\If_;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\BinaryOp;
+use PhpParser\Node\Expr\BinaryOp\Greater;
+use PhpParser\Node\Expr\BinaryOp\Identical;
+use PhpParser\Node\Expr\BinaryOp\NotIdentical;
+use PhpParser\Node\Expr\BooleanNot;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Ternary;
+use PhpParser\Node\Scalar\DNumber;
+use PhpParser\Node\Scalar\LNumber;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\ElseIf_;
+use PhpParser\Node\Stmt\If_;
+use Rector\Rector\AbstractRector;
+use Rector\RectorDefinition\CodeSample;
+use Rector\RectorDefinition\RectorDefinition;
+
+/**
+ * @see https://www.reddit.com/r/PHP/comments/aqk01p/is_there_a_situation_in_which_if_countarray_0/
+ * @see https://3v4l.org/UCd1b
+ */
+final class ExplicitBoolCompareRector extends AbstractRector
+{
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Make if conditions more explicit', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+final class SomeController
+{
+    public function run($items)
+    {
+        if (!count($items)) {
+            return 'no items';
+        }
+    }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+final class SomeController
+{
+    public function run($items)
+    {
+        if (count($items) < 0) {
+            return 'no items';
+        }
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [If_::class, ElseIf_::class, Ternary::class];
+    }
+
+    /**
+     * @param If_|ElseIf_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($node->cond instanceof BooleanNot) {
+            $conditionNode = $node->cond->expr;
+            $isNegated = true;
+        } else {
+            $conditionNode = $node->cond;
+            $isNegated = false;
+        }
+
+        if ($this->isBoolType($conditionNode)) {
+            return null;
+        }
+
+        $newConditionNode = $this->resolveNewConditionNode($conditionNode, $isNegated);
+        if ($newConditionNode === null) {
+            return null;
+        }
+
+        $node->cond = $newConditionNode;
+
+        return $node;
+    }
+
+    private function resolveNewConditionNode(Expr $conditionNode, bool $isNegated): ?BinaryOp
+    {
+        // various cases
+        if ($conditionNode instanceof FuncCall && $this->isName($conditionNode, 'count')) {
+            return $this->resolveCount($isNegated, $conditionNode);
+        }
+
+        if ($this->isArrayType($conditionNode)) {
+            return $this->resolveArray($isNegated, $conditionNode);
+        }
+
+        if ($this->isStringyType($conditionNode)) {
+            return $this->resolveString($isNegated, $conditionNode);
+        }
+
+        if ($this->isIntegerType($conditionNode)) {
+            return $this->resolveInteger($isNegated, $conditionNode);
+        }
+
+        if ($this->isFloatType($conditionNode)) {
+            return $this->resolveFloat($isNegated, $conditionNode);
+        }
+
+        if ($this->isNullableObjectType($conditionNode)) {
+            return $this->resolveNullable($isNegated, $conditionNode);
+        }
+
+        return null;
+    }
+
+    /**
+     * @return Smaller|Greater
+     */
+    private function resolveCount(bool $isNegated, Expr $conditionNode): BinaryOp
+    {
+        $valueNode = new LNumber(0);
+
+        // compare === 0, assumption
+        if ($isNegated) {
+            return new Identical($conditionNode, $valueNode);
+        }
+
+        return new Greater($conditionNode, $valueNode);
+    }
+
+    /**
+     * @return Identical|NotIdentical
+     */
+    private function resolveArray(bool $isNegated, Expr $conditionNode): BinaryOp
+    {
+        $valueNode = new Array_([]);
+
+        // compare === []
+        if ($isNegated) {
+            return new Identical($conditionNode, $valueNode);
+        }
+
+        return new NotIdentical($conditionNode, $valueNode);
+    }
+
+    /**
+     * @return Identical|NotIdentical
+     */
+    private function resolveString(bool $isNegated, Expr $conditionNode): BinaryOp
+    {
+        $valueNode = new String_('');
+
+        // compare === ''
+        if ($isNegated) {
+            return new Identical($conditionNode, $valueNode);
+        }
+
+        return new NotIdentical($conditionNode, $valueNode);
+    }
+
+    /**
+     * @return Identical|NotIdentical
+     */
+    private function resolveInteger(bool $isNegated, Expr $conditionNode): BinaryOp
+    {
+        $valueNode = new LNumber(0);
+
+        if ($isNegated) {
+            return new Identical($conditionNode, $valueNode);
+        }
+
+        return new NotIdentical($conditionNode, $valueNode);
+    }
+
+    private function resolveFloat(bool $isNegated, Expr $conditionNode): BinaryOp
+    {
+        $valueNode = new DNumber(0.0);
+
+        if ($isNegated) {
+            return new Identical($conditionNode, $valueNode);
+        }
+
+        return new NotIdentical($conditionNode, $valueNode);
+    }
+
+    /**
+     * @return Identical|NotIdentical
+     */
+    private function resolveNullable(bool $isNegated, Expr $conditionNode): BinaryOp
+    {
+        $valueNode = $this->createNull();
+
+        if ($isNegated) {
+            return new Identical($conditionNode, $valueNode);
+        }
+
+        return new NotIdentical($conditionNode, $valueNode);
+    }
+}

--- a/packages/CodeQuality/src/Rector/If_/SimplifyIfNotNullReturnRector.php
+++ b/packages/CodeQuality/src/Rector/If_/SimplifyIfNotNullReturnRector.php
@@ -58,7 +58,7 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         $comparedNode = $this->ifMaintainer->matchIfNotNullReturnValue($node);
-        if ($comparedNode) {
+        if ($comparedNode !== null) {
             $insideIfNode = $node->stmts[0];
 
             $nextNode = $node->getAttribute(Attribute::NEXT_NODE);
@@ -75,7 +75,7 @@ CODE_SAMPLE
         }
 
         $comparedNode = $this->ifMaintainer->matchIfValueReturnValue($node);
-        if ($comparedNode) {
+        if ($comparedNode !== null) {
             $nextNode = $node->getAttribute(Attribute::NEXT_NODE);
             if (! $nextNode instanceof Return_) {
                 return null;

--- a/packages/CodeQuality/tests/Rector/If_/ExplicitBoolCompareRector/ExplicitBoolCompareRectorTest.php
+++ b/packages/CodeQuality/tests/Rector/If_/ExplicitBoolCompareRector/ExplicitBoolCompareRectorTest.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Rector\CodeQuality\Tests\Rector\If_\ExplicitBoolCompareRector;
+
+use Rector\CodeQuality\Rector\If_\ExplicitBoolCompareRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ExplicitBoolCompareRectorTest extends AbstractRectorTestCase
+{
+    public function test(): void
+    {
+        $this->doTestFiles([
+            __DIR__ . '/Fixture/count.php.inc',
+            __DIR__ . '/Fixture/array.php.inc',
+            __DIR__ . '/Fixture/string.php.inc',
+            __DIR__ . '/Fixture/numbers.php.inc',
+            __DIR__ . '/Fixture/nullable.php.inc',
+            __DIR__ . '/Fixture/ternary.php.inc',
+        ]);
+    }
+
+    protected function getRectorClass(): string
+    {
+        return ExplicitBoolCompareRector::class;
+    }
+}

--- a/packages/CodeQuality/tests/Rector/If_/ExplicitBoolCompareRector/Fixture/array.php.inc
+++ b/packages/CodeQuality/tests/Rector/If_/ExplicitBoolCompareRector/Fixture/array.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\CodeQuality\Tests\Rector\If_\ExplicitBoolCompareRector\Fixture;
+
+final class Array_
+{
+    public function run(array $items)
+    {
+        if (!$items) {
+            return 'no items';
+        }
+
+        if ($items) {
+            return 'many items';
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CodeQuality\Tests\Rector\If_\ExplicitBoolCompareRector\Fixture;
+
+final class Array_
+{
+    public function run(array $items)
+    {
+        if ($items === []) {
+            return 'no items';
+        }
+
+        if ($items !== []) {
+            return 'many items';
+        }
+    }
+}
+
+?>

--- a/packages/CodeQuality/tests/Rector/If_/ExplicitBoolCompareRector/Fixture/count.php.inc
+++ b/packages/CodeQuality/tests/Rector/If_/ExplicitBoolCompareRector/Fixture/count.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\CodeQuality\Tests\Rector\If_\ExplicitBoolCompareRector\Fixture;
+
+final class SomeController
+{
+    public function run($items)
+    {
+        if (!count($items)) {
+            return 'no items';
+        } elseif (count($items)) {
+            return 'many items';
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CodeQuality\Tests\Rector\If_\ExplicitBoolCompareRector\Fixture;
+
+final class SomeController
+{
+    public function run($items)
+    {
+        if (count($items) === 0) {
+            return 'no items';
+        } elseif (count($items) > 0) {
+            return 'many items';
+        }
+    }
+}
+
+?>

--- a/packages/CodeQuality/tests/Rector/If_/ExplicitBoolCompareRector/Fixture/nullable.php.inc
+++ b/packages/CodeQuality/tests/Rector/If_/ExplicitBoolCompareRector/Fixture/nullable.php.inc
@@ -1,0 +1,59 @@
+<?php
+
+namespace Rector\CodeQuality\Tests\Rector\If_\ExplicitBoolCompareRector\Fixture;
+
+final class Nullable
+{
+    public function run(?\stdClass $item)
+    {
+        if (!$item) {
+            return 'empty';
+        }
+    }
+
+    public function go(?\stdClass $item)
+    {
+        if ($item) {
+            return 'not empty';
+        }
+    }
+
+    public function away(?string $item)
+    {
+        if (!$item) {
+            return 'empty';
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CodeQuality\Tests\Rector\If_\ExplicitBoolCompareRector\Fixture;
+
+final class Nullable
+{
+    public function run(?\stdClass $item)
+    {
+        if ($item === null) {
+            return 'empty';
+        }
+    }
+
+    public function go(?\stdClass $item)
+    {
+        if ($item !== null) {
+            return 'not empty';
+        }
+    }
+
+    public function away(?string $item)
+    {
+        if (!$item) {
+            return 'empty';
+        }
+    }
+}
+
+?>

--- a/packages/CodeQuality/tests/Rector/If_/ExplicitBoolCompareRector/Fixture/numbers.php.inc
+++ b/packages/CodeQuality/tests/Rector/If_/ExplicitBoolCompareRector/Fixture/numbers.php.inc
@@ -1,0 +1,61 @@
+<?php
+
+namespace Rector\CodeQuality\Tests\Rector\If_\ExplicitBoolCompareRector\Fixture;
+
+final class Numbers
+{
+    public function run(int $item)
+    {
+        if (!$item) {
+            return 'empty';
+        }
+
+        if ($item) {
+            return 'not empty';
+        }
+    }
+
+    public function go(float $item)
+    {
+        if (!$item) {
+            return 'empty';
+        }
+
+        if ($item) {
+            return 'not empty';
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CodeQuality\Tests\Rector\If_\ExplicitBoolCompareRector\Fixture;
+
+final class Numbers
+{
+    public function run(int $item)
+    {
+        if ($item === 0) {
+            return 'empty';
+        }
+
+        if ($item !== 0) {
+            return 'not empty';
+        }
+    }
+
+    public function go(float $item)
+    {
+        if ($item === 0.0) {
+            return 'empty';
+        }
+
+        if ($item !== 0.0) {
+            return 'not empty';
+        }
+    }
+}
+
+?>

--- a/packages/CodeQuality/tests/Rector/If_/ExplicitBoolCompareRector/Fixture/string.php.inc
+++ b/packages/CodeQuality/tests/Rector/If_/ExplicitBoolCompareRector/Fixture/string.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\CodeQuality\Tests\Rector\If_\ExplicitBoolCompareRector\Fixture;
+
+final class String_
+{
+    public function run(string $item)
+    {
+        if (!$item) {
+            return 'empty';
+        }
+
+        if ($item) {
+            return 'not empty';
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CodeQuality\Tests\Rector\If_\ExplicitBoolCompareRector\Fixture;
+
+final class String_
+{
+    public function run(string $item)
+    {
+        if ($item === '') {
+            return 'empty';
+        }
+
+        if ($item !== '') {
+            return 'not empty';
+        }
+    }
+}
+
+?>

--- a/packages/CodeQuality/tests/Rector/If_/ExplicitBoolCompareRector/Fixture/ternary.php.inc
+++ b/packages/CodeQuality/tests/Rector/If_/ExplicitBoolCompareRector/Fixture/ternary.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\CodeQuality\Tests\Rector\If_\ExplicitBoolCompareRector\Fixture;
+
+final class Ternary
+{
+    public function run(int $item)
+    {
+        return $item ? 1 : 0;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CodeQuality\Tests\Rector\If_\ExplicitBoolCompareRector\Fixture;
+
+final class Ternary
+{
+    public function run(int $item)
+    {
+        return $item !== 0 ? 1 : 0;
+    }
+}
+
+?>

--- a/packages/CodeQuality/tests/Rector/If_/ExplicitBoolCompareRector/Fixture/ternary.php.inc
+++ b/packages/CodeQuality/tests/Rector/If_/ExplicitBoolCompareRector/Fixture/ternary.php.inc
@@ -7,6 +7,8 @@ final class Ternary
     public function run(int $item)
     {
         return $item ? 1 : 0;
+
+        return $item ?: 0;
     }
 }
 
@@ -21,6 +23,8 @@ final class Ternary
     public function run(int $item)
     {
         return $item !== 0 ? 1 : 0;
+
+        return $item ?: 0;
     }
 }
 

--- a/packages/CodingStyle/src/Rector/Switch_/BinarySwitchToIfElseRector.php
+++ b/packages/CodingStyle/src/Rector/Switch_/BinarySwitchToIfElseRector.php
@@ -77,7 +77,7 @@ CODE_SAMPLE
             return $ifNode;
         }
 
-        if ($secondCase->cond) {
+        if ($secondCase->cond !== null) {
             // has condition
             $equalNode = new Equal($node->cond, $secondCase->cond);
             $ifNode->elseifs[] = new ElseIf_($equalNode, $this->removeBreakNodes($secondCase->stmts));

--- a/packages/ContributorTools/src/Configuration/ConfigurationFactory.php
+++ b/packages/ContributorTools/src/Configuration/ConfigurationFactory.php
@@ -127,7 +127,7 @@ final class ConfigurationFactory
 
     private function resolveLevelConfig(string $level): ?string
     {
-        if (! $level) {
+        if ($level === '') {
             return null;
         }
 
@@ -137,7 +137,7 @@ final class ConfigurationFactory
 
         /** @var SplFileInfo[] $fileInfos */
         $fileInfos = iterator_to_array($finder->getIterator());
-        if (! count($fileInfos)) {
+        if (count($fileInfos) === 0) {
             // assume new one is created
             $match = Strings::match($level, '#(?<name>[a-zA-Z_-]+])#');
             if (isset($match['name'])) {

--- a/packages/ContributorTools/src/OutputFormatter/MarkdownOutputFormatter.php
+++ b/packages/ContributorTools/src/OutputFormatter/MarkdownOutputFormatter.php
@@ -99,7 +99,7 @@ final class MarkdownOutputFormatter implements OutputFormatterInterface
         $this->symfonyStyle->writeln(sprintf('- class: `%s`', get_class($rector)));
 
         $rectorDefinition = $rector->getDefinition();
-        if ($rectorDefinition->getDescription()) {
+        if ($rectorDefinition->getDescription() !== '') {
             $this->symfonyStyle->newLine();
             $this->symfonyStyle->writeln($rectorDefinition->getDescription());
         }

--- a/packages/ContributorTools/src/TemplateVariablesFactory.php
+++ b/packages/ContributorTools/src/TemplateVariablesFactory.php
@@ -61,7 +61,7 @@ final class TemplateVariablesFactory
      */
     private function createSourceDocBlock(array $source): string
     {
-        if (! $source) {
+        if ($source === []) {
             return '';
         }
 

--- a/packages/DeadCode/src/Rector/Property/RemoveUnusedPrivatePropertyRector.php
+++ b/packages/DeadCode/src/Rector/Property/RemoveUnusedPrivatePropertyRector.php
@@ -74,7 +74,7 @@ CODE_SAMPLE
 
         $uselessAssigns = $this->resolveUselessAssignNode($propertyFetches);
 
-        if (count($uselessAssigns)) {
+        if (count($uselessAssigns) > 0) {
             $this->removeNode($node);
             foreach ($uselessAssigns as $uselessAssign) {
                 $this->removeNode($uselessAssign);

--- a/packages/DeadCode/src/Rector/Stmt/RemoveDeadStmtRector.php
+++ b/packages/DeadCode/src/Rector/Stmt/RemoveDeadStmtRector.php
@@ -49,7 +49,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($node->getComments()) {
+        if ($node->getComments() !== []) {
             return null;
         }
 

--- a/packages/NetteToSymfony/src/Annotation/RouteTagValueNode.php
+++ b/packages/NetteToSymfony/src/Annotation/RouteTagValueNode.php
@@ -46,7 +46,7 @@ final class RouteTagValueNode implements PhpDocChildNode
             $string .= sprintf(', name="%s"', $this->name);
         }
 
-        if ($this->methods) {
+        if ($this->methods !== []) {
             $string .= sprintf(', methods={"%s"}', implode('", "', $this->methods));
         }
 

--- a/packages/NetteToSymfony/src/Rector/ClassMethod/RouterListToControllerAnnotationsRector.php
+++ b/packages/NetteToSymfony/src/Rector/ClassMethod/RouterListToControllerAnnotationsRector.php
@@ -311,7 +311,7 @@ CODE_SAMPLE
         }
 
         $methodReflection = new ReflectionMethod($className, $methodName);
-        if ($methodReflection->getReturnType()) {
+        if ($methodReflection->getReturnType() !== null) {
             $staticCallReturnType = (string) $methodReflection->getReturnType();
             if (is_a($staticCallReturnType, $this->routerClass, true)) {
                 return true;

--- a/packages/NodeTypeResolver/src/Application/FunctionLikeNodeCollector.php
+++ b/packages/NodeTypeResolver/src/Application/FunctionLikeNodeCollector.php
@@ -74,7 +74,7 @@ final class FunctionLikeNodeCollector
     public function isStaticMethod(string $methodName, string $className): bool
     {
         $methodNode = $this->findMethod($methodName, $className);
-        if ($methodNode) {
+        if ($methodNode !== null) {
             return $methodNode->isStatic();
         }
 

--- a/packages/NodeTypeResolver/src/ComplexNodeTypeResolver.php
+++ b/packages/NodeTypeResolver/src/ComplexNodeTypeResolver.php
@@ -56,7 +56,7 @@ final class ComplexNodeTypeResolver
         $types = [];
 
         $propertyDefault = $propertyNode->props[0]->default;
-        if ($propertyDefault) {
+        if ($propertyDefault !== null) {
             $types[] = $this->nodeToStringTypeResolver->resolver($propertyDefault);
         }
 

--- a/packages/NodeTypeResolver/src/NodeTypeAnalyzer.php
+++ b/packages/NodeTypeResolver/src/NodeTypeAnalyzer.php
@@ -15,6 +15,7 @@ use PHPStan\Type\Accessory\HasOffsetType;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\BooleanType;
+use PHPStan\Type\FloatType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
@@ -70,6 +71,11 @@ final class NodeTypeAnalyzer
     public function isIntType(Node $node): bool
     {
         return $this->getNodeStaticType($node) instanceof IntegerType;
+    }
+
+    public function isFloatType(Node $node): bool
+    {
+        return $this->getNodeStaticType($node) instanceof FloatType;
     }
 
     public function isStringyType(Node $node): bool
@@ -194,6 +200,30 @@ final class NodeTypeAnalyzer
         $nodeStaticType = $this->getNodeStaticType($node);
 
         return $this->staticTypeToStringResolver->resolve($nodeStaticType);
+    }
+
+    public function isNullableObjectType(Node $node): bool
+    {
+        $nodeType = $this->getNodeStaticType($node);
+        if (! $nodeType instanceof UnionType) {
+            return false;
+        }
+
+        if ($nodeType->isSuperTypeOf(new NullType())->no()) {
+            return false;
+        }
+
+        if (count($nodeType->getTypes()) !== 2) {
+            return false;
+        }
+
+        foreach ($nodeType->getTypes() as $subtype) {
+            if ($subtype instanceof ObjectType) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/packages/NodeTypeResolver/src/NodeTypeAnalyzer.php
+++ b/packages/NodeTypeResolver/src/NodeTypeAnalyzer.php
@@ -185,7 +185,7 @@ final class NodeTypeAnalyzer
                     $itemTypes[$key] = $itemType . '[]';
                 }
 
-                if (count($itemTypes)) {
+                if (count($itemTypes) > 0) {
                     return [implode('|', $itemTypes)];
                 }
             }

--- a/packages/NodeTypeResolver/src/NodeVisitor/NamespaceNodeVisitor.php
+++ b/packages/NodeTypeResolver/src/NodeVisitor/NamespaceNodeVisitor.php
@@ -54,7 +54,7 @@ final class NamespaceNodeVisitor extends NodeVisitorAbstract
     public function enterNode(Node $node): ?Node
     {
         if ($node instanceof Namespace_) {
-            $this->namespaceName = $node->name ? $node->name->toString() : null;
+            $this->namespaceName = $node->name !== null ? $node->name->toString() : null;
             $this->namespaceNode = $node;
             $this->useNodes = $this->betterNodeFinder->findInstanceOf($node, Use_::class);
         }

--- a/packages/NodeTypeResolver/src/PhpDoc/NodeAnalyzer/DocBlockAnalyzer.php
+++ b/packages/NodeTypeResolver/src/PhpDoc/NodeAnalyzer/DocBlockAnalyzer.php
@@ -90,7 +90,7 @@ final class DocBlockAnalyzer
 
     public function addTag(Node $node, PhpDocChildNode $phpDocChildNode): void
     {
-        if ($node->getDocComment()) {
+        if ($node->getDocComment() !== null) {
             $phpDocInfo = $this->createPhpDocInfoFromNode($node);
             $phpDocNode = $phpDocInfo->getPhpDocNode();
             $phpDocNode->children[] = $phpDocChildNode;
@@ -209,7 +209,7 @@ final class DocBlockAnalyzer
     public function addVarTag(Node $node, string $type): void
     {
         // there might be no phpdoc at all
-        if ($node->getDocComment()) {
+        if ($node->getDocComment() !== null) {
             $phpDocInfo = $this->createPhpDocInfoFromNode($node);
             $phpDocNode = $phpDocInfo->getPhpDocNode();
 
@@ -265,7 +265,7 @@ final class DocBlockAnalyzer
         }
 
         $phpDoc = $this->phpDocInfoPrinter->printFormatPreserving($phpDocInfo);
-        if ($phpDoc) {
+        if ($phpDoc !== '') {
             $node->setDocComment(new Doc($phpDoc));
             return;
         }

--- a/packages/PHPStan/src/Rector/Assign/PHPStormVarAnnotationRector.php
+++ b/packages/PHPStan/src/Rector/Assign/PHPStormVarAnnotationRector.php
@@ -96,11 +96,11 @@ CODE_SAMPLE
 
     private function getDocContent(Node $node): string
     {
-        if ($node->getDocComment()) {
+        if ($node->getDocComment() !== null) {
             return $node->getDocComment()->getText();
         }
 
-        if ($node->getComments()) {
+        if ($node->getComments() !== []) {
             $docContent = '';
             foreach ($node->getComments() as $comment) {
                 $docContent .= $comment->getText();

--- a/packages/Php/src/Rector/Each/WhileEachToForeachRector.php
+++ b/packages/Php/src/Rector/Each/WhileEachToForeachRector.php
@@ -95,7 +95,7 @@ CODE_SAMPLE
         ]);
 
         // is key included? add it to foreach
-        if (count($listNode->items)) {
+        if (count($listNode->items) > 0) {
             /** @var ArrayItem $keyItem */
             $keyItem = array_pop($listNode->items);
             $foreachNode->keyVar = $keyItem->value;

--- a/packages/Php/src/Rector/FuncCall/CreateFunctionToAnonymousFunctionRector.php
+++ b/packages/Php/src/Rector/FuncCall/CreateFunctionToAnonymousFunctionRector.php
@@ -105,7 +105,7 @@ CODE_SAMPLE
             $anonymousFunctionNode->params[] = new Param($parameter);
         }
 
-        if ($body) {
+        if ($body !== []) {
             $anonymousFunctionNode->stmts = $body;
         }
 

--- a/packages/Php/src/Rector/FuncCall/RegexDashEscapeRector.php
+++ b/packages/Php/src/Rector/FuncCall/RegexDashEscapeRector.php
@@ -184,7 +184,7 @@ CODE_SAMPLE
         }
 
         $classConstNode = $this->constantNodeCollector->findConstant($constantName, $className);
-        if ($classConstNode) {
+        if ($classConstNode !== null) {
             if ($classConstNode->consts[0]->value instanceof String_) {
                 /** @var String_ $stringNode */
                 $stringNode = $classConstNode->consts[0]->value;

--- a/packages/Php/src/Rector/FunctionLike/AbstractTypeDeclarationRector.php
+++ b/packages/Php/src/Rector/FunctionLike/AbstractTypeDeclarationRector.php
@@ -91,11 +91,11 @@ abstract class AbstractTypeDeclarationRector extends AbstractRector
 
         if ($parentClassName !== null) {
             $parentClassNode = $this->classLikeNodeCollector->findClass($parentClassName);
-            if ($parentClassNode) {
+            if ($parentClassNode !== null) {
                 $parentMethodNode = $parentClassNode->getMethod($methodName);
                 // @todo validate type is conflicting
                 // parent class method in local scope → it's ok
-                if ($parentMethodNode) {
+                if ($parentMethodNode !== null) {
                     // parent method has no type → we cannot change it here
                     return isset($parentMethodNode->params[$paramPosition]) && $parentMethodNode->params[$paramPosition]->type === null;
                 }
@@ -120,10 +120,10 @@ abstract class AbstractTypeDeclarationRector extends AbstractRector
         $interfaceNames = $this->getClassLikeNodeParentInterfaceNames($classNode);
         foreach ($interfaceNames as $interfaceName) {
             $interface = $this->classLikeNodeCollector->findInterface($interfaceName);
-            if ($interface) {
+            if ($interface !== null) {
                 // parent class method in local scope → it's ok
                 // @todo validate type is conflicting
-                if ($interface->getMethod($methodName)) {
+                if ($interface->getMethod($methodName) !== null) {
                     return false;
                 }
             }

--- a/packages/Php/src/Rector/If_/IfToSpaceshipRector.php
+++ b/packages/Php/src/Rector/If_/IfToSpaceshipRector.php
@@ -111,7 +111,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($node->else) {
+        if ($node->else !== null) {
             if (count($node->else->stmts) !== 1) {
                 return null;
             }

--- a/packages/Php/src/Rector/Property/CompleteVarDocTypePropertyRector.php
+++ b/packages/Php/src/Rector/Property/CompleteVarDocTypePropertyRector.php
@@ -77,7 +77,7 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         $varTypeInfo = $this->docBlockAnalyzer->getVarTypeInfo($node);
-        if ($varTypeInfo) {
+        if ($varTypeInfo !== null) {
             return null;
         }
 

--- a/packages/Sensio/src/Helper/TemplateGuesser.php
+++ b/packages/Sensio/src/Helper/TemplateGuesser.php
@@ -77,7 +77,7 @@ final class TemplateGuesser
     {
         $bundle = Strings::match($namespace, '#(?<bundle>[\w]*Bundle)#')['bundle'] ?? '';
         $bundle = Strings::replace($bundle, '#Bundle$#');
-        $bundle = $bundle ? '@' . $bundle . '/' : '';
+        $bundle = $bundle !== '' ? '@' . $bundle . '/' : '';
 
         $controller = $this->resolveControllerVersion5($class);
         $action = Strings::replace($method, '#Action$#');
@@ -96,6 +96,6 @@ final class TemplateGuesser
         $controller = strtolower($controller);
         $controller = str_replace('\\', '/', $controller);
 
-        return $controller ? $controller . '/' : '';
+        return $controller !== '' ? $controller . '/' : '';
     }
 }

--- a/packages/Sensio/src/Rector/FrameworkExtraBundle/TemplateAnnotationRector.php
+++ b/packages/Sensio/src/Rector/FrameworkExtraBundle/TemplateAnnotationRector.php
@@ -100,7 +100,7 @@ CODE_SAMPLE
         $renderArguments = $this->resolveRenderArguments($node, $returnNode);
         $thisRenderMethodCall = $this->createMethodCall('this', 'render', $renderArguments);
 
-        if (! $returnNode) {
+        if ($returnNode === null) {
             // or add as last statement in the method
             $node->stmts[] = new Return_($thisRenderMethodCall);
         }
@@ -122,7 +122,7 @@ CODE_SAMPLE
     private function resolveRenderArguments(ClassMethod $classMethodNode, ?Return_ $returnNode): array
     {
         $arguments = [$this->resolveTemplateName($classMethodNode)];
-        if (! $returnNode) {
+        if ($returnNode === null) {
             return $this->createArgs($arguments);
         }
 

--- a/packages/Symfony/src/Rector/MethodCall/FormTypeInstanceToClassConstRector.php
+++ b/packages/Symfony/src/Rector/MethodCall/FormTypeInstanceToClassConstRector.php
@@ -152,7 +152,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if (count($newNode->args)) {
+        if (count($newNode->args) > 0) {
             $methodCallNode = $this->moveArgumentsToOptions(
                 $methodCallNode,
                 $position,
@@ -230,7 +230,7 @@ CODE_SAMPLE
         $reflectionClass = new ReflectionClass($className);
         $constructorReflectionMethod = $reflectionClass->getConstructor();
 
-        if (! $constructorReflectionMethod) {
+        if ($constructorReflectionMethod === null) {
             return [];
         }
 
@@ -244,7 +244,7 @@ CODE_SAMPLE
 
     private function addBuildFormMethod(Class_ $classNode, ClassMethod $formTypeConstructorMethodNode): void
     {
-        if ($classNode->getMethod('buildForm')) {
+        if ($classNode->getMethod('buildForm') !== null) {
             // @todo
             return;
         }
@@ -278,7 +278,7 @@ CODE_SAMPLE
      */
     private function addConfigureOptionsMethod(Class_ $classNode, array $namesToArgs): void
     {
-        if ($classNode->getMethod('configureOptions')) {
+        if ($classNode->getMethod('configureOptions') !== null) {
             // @todo
             return;
         }

--- a/packages/Symfony/src/Rector/New_/StringToArrayArgumentProcessRector.php
+++ b/packages/Symfony/src/Rector/New_/StringToArrayArgumentProcessRector.php
@@ -125,7 +125,7 @@ CODE_SAMPLE
     {
         if ($firstArgument instanceof Concat) {
             $arrayNode = $this->nodeTransformer->transformConcatToStringArray($firstArgument);
-            if ($arrayNode) {
+            if ($arrayNode !== null) {
                 $node->args[$argumentPosition] = new Arg($arrayNode);
             }
 
@@ -134,7 +134,7 @@ CODE_SAMPLE
 
         if ($firstArgument instanceof FuncCall && $this->isName($firstArgument, 'sprintf')) {
             $arrayNode = $this->nodeTransformer->transformSprintfToArray($firstArgument);
-            if ($arrayNode) {
+            if ($arrayNode !== null) {
                 $node->args[$argumentPosition]->value = $arrayNode;
             }
         } elseif ($firstArgument instanceof String_) {
@@ -155,7 +155,7 @@ CODE_SAMPLE
             'sprintf'
         )) {
             $arrayNode = $this->nodeTransformer->transformSprintfToArray($createdNode->expr);
-            if ($arrayNode) {
+            if ($arrayNode !== null) {
                 $createdNode->expr = $arrayNode;
             }
         }

--- a/packages/Twig/src/Rector/SimpleFunctionAndFilterRector.php
+++ b/packages/Twig/src/Rector/SimpleFunctionAndFilterRector.php
@@ -155,7 +155,7 @@ CODE_SAMPLE
     private function processArrayItem(ArrayItem $node, array $newNodeTypes): ?Node
     {
         $matchedOldClasses = array_intersect(array_keys($this->oldToNewClasses), $newNodeTypes);
-        if (! $matchedOldClasses) {
+        if ($matchedOldClasses === []) {
             return null;
         }
 

--- a/packages/Twig/tests/Rector/SimpleFunctionAndFilterRector/SimpleFunctionAndFilterRectorTest.php
+++ b/packages/Twig/tests/Rector/SimpleFunctionAndFilterRector/SimpleFunctionAndFilterRectorTest.php
@@ -31,12 +31,12 @@ final class SimpleFunctionAndFilterRectorTest extends AbstractRectorTestCase
      */
     protected function getRectorConfiguration(): array
     {
-        return ['arguments' => [
+        return [
             '$twigExtensionClass' => TwigExtension::class,
             '$oldToNewClasses' => [
                 TwigFunctionMethod::class => TwigSimpleFunction::class,
                 TwigFilterMethod::class => TwigSimpleFilter::class,
             ],
-        ]];
+        ];
     }
 }

--- a/src/Autoloading/AdditionalAutoloader.php
+++ b/src/Autoloading/AdditionalAutoloader.php
@@ -89,7 +89,7 @@ final class AdditionalAutoloader
      */
     private function autoloadDirectories(array $directories): void
     {
-        if (! count($directories)) {
+        if (count($directories) === 0) {
             return;
         }
 

--- a/src/Collector/CallableCollectorPopulator.php
+++ b/src/Collector/CallableCollectorPopulator.php
@@ -74,7 +74,7 @@ final class CallableCollectorPopulator
 
     private function ensureParameterHasType(string $type): void
     {
-        if ($type) {
+        if ($type !== '') {
             return;
         }
 

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -145,7 +145,7 @@ final class ProcessCommand extends AbstractCommand
 
         $this->processCommandReporter->reportRemovedFiles();
 
-        if ($this->errorAndDiffCollector->getErrors()) {
+        if ($this->errorAndDiffCollector->getErrors() !== []) {
             $this->processCommandReporter->reportErrors($this->errorAndDiffCollector->getErrors());
             return Shell::CODE_ERROR;
         }

--- a/src/Console/Output/ProcessCommandReporter.php
+++ b/src/Console/Output/ProcessCommandReporter.php
@@ -58,7 +58,7 @@ final class ProcessCommandReporter
             $this->symfonyStyle->writeln($fileDiff->getDiff());
             $this->symfonyStyle->newLine();
 
-            if ($fileDiff->getAppliedRectorClasses()) {
+            if ($fileDiff->getAppliedRectorClasses() !== []) {
                 $this->symfonyStyle->writeln('Applied rectors:');
                 $this->symfonyStyle->newLine();
                 $this->symfonyStyle->listing($fileDiff->getAppliedRectorClasses());

--- a/src/DependencyInjection/Loader/RectorServiceParametersShifter.php
+++ b/src/DependencyInjection/Loader/RectorServiceParametersShifter.php
@@ -68,7 +68,7 @@ final class RectorServiceParametersShifter
             $nonReservedNonVariables = $this->resolveRectorConfiguration($serviceDefinition);
 
             // nothing to change
-            if (! count($nonReservedNonVariables)) {
+            if (count($nonReservedNonVariables) === 0) {
                 continue;
             }
 

--- a/src/FileSystem/FilesFinder.php
+++ b/src/FileSystem/FilesFinder.php
@@ -82,12 +82,12 @@ final class FilesFinder
      */
     private function findInDirectories(array $directories, array $suffixes): array
     {
-        if (! count($directories)) {
+        if (count($directories) === 0) {
             return [];
         }
 
         $absoluteDirectories = $this->filesystemTweaker->resolveDirectoriesWithFnmatch($directories);
-        if (! $absoluteDirectories) {
+        if ($absoluteDirectories === []) {
             return [];
         }
 
@@ -120,7 +120,7 @@ final class FilesFinder
 
     private function addFilterWithExcludedPaths(Finder $finder): void
     {
-        if (! $this->excludePaths) {
+        if ($this->excludePaths === []) {
             return;
         }
 

--- a/src/Guard/RectorGuard.php
+++ b/src/Guard/RectorGuard.php
@@ -19,7 +19,7 @@ final class RectorGuard
 
     public function ensureSomeRectorsAreRegistered(): void
     {
-        if ($this->rectorNodeTraverser->getRectorCount()) {
+        if ($this->rectorNodeTraverser->getRectorCount() !== 0) {
             return;
         }
 

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -57,7 +57,7 @@ final class BetterNodeFinder
     public function findLastInstanceOf($nodes, string $type): ?Node
     {
         $foundInstances = $this->nodeFinder->findInstanceOf($nodes, $type);
-        if (! $foundInstances) {
+        if ($foundInstances === []) {
             return null;
         }
 
@@ -90,7 +90,7 @@ final class BetterNodeFinder
 
         $foundNode = $this->findFirst([$node], $filter);
         // we found what we need
-        if ($foundNode) {
+        if ($foundNode !== null) {
             return $foundNode;
         }
 

--- a/src/PhpParser/Node/Maintainer/CallMaintainer.php
+++ b/src/PhpParser/Node/Maintainer/CallMaintainer.php
@@ -92,7 +92,7 @@ final class CallMaintainer
             $reflectionFunctionAbstract->getDeclaringClass()->getName()
         );
 
-        if ($classMethodNode) {
+        if ($classMethodNode !== null) {
             return $this->containsFuncGetArgsFuncCall($classMethodNode);
         }
         return $this->isExternalScopeVariadic($reflectionFunctionAbstract, $callNode);

--- a/src/PhpParser/Node/Maintainer/ChildAndParentClassMaintainer.php
+++ b/src/PhpParser/Node/Maintainer/ChildAndParentClassMaintainer.php
@@ -47,7 +47,7 @@ final class ChildAndParentClassMaintainer
 
         // not in analyzed scope, nothing we can do
         $parentClassNode = $this->classLikeNodeCollector->findClass($parentClassName);
-        if (! $parentClassNode) {
+        if ($parentClassNode === null) {
             return;
         }
 
@@ -57,7 +57,7 @@ final class ChildAndParentClassMaintainer
             return;
         }
 
-        if (! $firstParentConstructMethodNode->params) {
+        if ($firstParentConstructMethodNode->params === []) {
             return;
         }
 
@@ -83,7 +83,7 @@ final class ChildAndParentClassMaintainer
         $childClassNodes = $this->classLikeNodeCollector->findChildrenOfClass($className);
 
         foreach ($childClassNodes as $childClassNode) {
-            if (! $childClassNode->getMethod('__construct')) {
+            if ($childClassNode->getMethod('__construct') === null) {
                 continue;
             }
 
@@ -111,7 +111,7 @@ final class ChildAndParentClassMaintainer
     {
         while ($classNode !== null) {
             $constructMethodNode = $classNode->getMethod('__construct');
-            if ($constructMethodNode) {
+            if ($constructMethodNode !== null) {
                 return $constructMethodNode;
             }
 

--- a/src/PhpParser/Node/Maintainer/ClassMaintainer.php
+++ b/src/PhpParser/Node/Maintainer/ClassMaintainer.php
@@ -124,7 +124,7 @@ final class ClassMaintainer
     ): void {
         $constructorMethod = $classNode->getMethod('__construct');
         /** @var ClassMethod $constructorMethod */
-        if ($constructorMethod) {
+        if ($constructorMethod !== null) {
             $this->addParameterAndAssignToMethod($constructorMethod, $variableInfo, $assignNode);
             return;
         }

--- a/src/PhpParser/Node/Resolver/NameResolver.php
+++ b/src/PhpParser/Node/Resolver/NameResolver.php
@@ -33,21 +33,21 @@ final class NameResolver
             Empty_::class => 'empty',
             // more complex
             function (ClassConst $classConstNode): ?string {
-                if (! count($classConstNode->consts)) {
+                if (count($classConstNode->consts) === 0) {
                     return null;
                 }
 
                 return $this->resolve($classConstNode->consts[0]);
             },
             function (Property $propertyNode): ?string {
-                if (! count($propertyNode->props)) {
+                if (count($propertyNode->props) === 0) {
                     return null;
                 }
 
                 return $this->resolve($propertyNode->props[0]);
             },
             function (Use_ $useNode): ?string {
-                if (! count($useNode->uses)) {
+                if (count($useNode->uses) === 0) {
                     return null;
                 }
 

--- a/src/PhpParser/NodeTransformer.php
+++ b/src/PhpParser/NodeTransformer.php
@@ -85,7 +85,7 @@ final class NodeTransformer
 
         foreach ($arrayNode->items as $arrayItem) {
             $expressionNode = new Expression(new Yield_($arrayItem->value, $arrayItem->key));
-            if ($arrayItem->getComments()) {
+            if ($arrayItem->getComments() !== []) {
                 $expressionNode->setAttribute('comments', $arrayItem->getComments());
             }
 
@@ -156,7 +156,7 @@ final class NodeTransformer
         $arrayItems = [];
         $parts = $this->splitBySpace($node->value);
         foreach ($parts as $part) {
-            if (trim($part)) {
+            if (trim($part) !== '') {
                 $arrayItems[] = new String_($part);
             }
         }

--- a/src/Rector/Architecture/RepositoryAsService/MoveRepositoryFromParentToConstructorRector.php
+++ b/src/Rector/Architecture/RepositoryAsService/MoveRepositoryFromParentToConstructorRector.php
@@ -112,7 +112,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $node->extends) {
+        if ($node->extends === null) {
             return null;
         }
 

--- a/src/Rector/Interface_/MergeInterfacesRector.php
+++ b/src/Rector/Interface_/MergeInterfacesRector.php
@@ -65,7 +65,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $node->implements) {
+        if ($node->implements === []) {
             return null;
         }
 

--- a/src/Rector/Interface_/RemoveInterfacesRector.php
+++ b/src/Rector/Interface_/RemoveInterfacesRector.php
@@ -57,7 +57,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $node->implements) {
+        if ($node->implements === []) {
             return null;
         }
 

--- a/src/Rector/MagicDisclosure/UnsetAndIssetToMethodCallRector.php
+++ b/src/Rector/MagicDisclosure/UnsetAndIssetToMethodCallRector.php
@@ -91,7 +91,7 @@ CODE_SAMPLE
                 }
 
                 $newNode = $this->processArrayDimFetchNode($node, $arrayDimFetchNode, $transformation);
-                if ($newNode) {
+                if ($newNode !== null) {
                     return $newNode;
                 }
             }

--- a/src/Rector/Namespace_/PseudoNamespaceToNamespaceRector.php
+++ b/src/Rector/Namespace_/PseudoNamespaceToNamespaceRector.php
@@ -83,7 +83,7 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         // no name → skip
-        if (! $node->toString()) {
+        if ($node->toString() === '') {
             return null;
         }
 

--- a/src/Rector/Psr4/MultipleClassFileToPsr4ClassesRector.php
+++ b/src/Rector/Psr4/MultipleClassFileToPsr4ClassesRector.php
@@ -164,7 +164,7 @@ CODE_SAMPLE
     private function shouldSkip(SmartFileInfo $smartFileInfo, array $nodes, array $namespaceNodes): bool
     {
         // process only namespaced file
-        if (! $namespaceNodes) {
+        if ($namespaceNodes === []) {
             return true;
         }
 
@@ -176,7 +176,7 @@ CODE_SAMPLE
         });
 
         // only process file with multiple classes || class with non PSR-4 format
-        if (! $nonAnonymousClassNodes) {
+        if ($nonAnonymousClassNodes === []) {
             return true;
         }
 

--- a/src/Rector/TypeAnalyzerTrait.php
+++ b/src/Rector/TypeAnalyzerTrait.php
@@ -84,6 +84,16 @@ trait TypeAnalyzerTrait
         return $this->nodeTypeAnalyzer->isStringyType($node);
     }
 
+    protected function isIntegerType(Node $node): bool
+    {
+        return $this->nodeTypeAnalyzer->isIntType($node);
+    }
+
+    protected function isFloatType(Node $node): bool
+    {
+        return $this->nodeTypeAnalyzer->isFloatType($node);
+    }
+
     protected function getStaticType(Node $node): ?Type
     {
         return $this->nodeTypeAnalyzer->getNodeStaticType($node);
@@ -92,6 +102,11 @@ trait TypeAnalyzerTrait
     protected function isNullableType(Node $node): bool
     {
         return $this->nodeTypeAnalyzer->isNullableType($node);
+    }
+
+    protected function isNullableObjectType(Node $node): bool
+    {
+        return $this->nodeTypeAnalyzer->isNullableObjectType($node);
     }
 
     protected function isNullType(Node $node): bool

--- a/src/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/src/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -81,7 +81,7 @@ abstract class AbstractRectorTestCase extends TestCase
 
     protected function provideConfig(): string
     {
-        if ($this->getRectorClass()) { // use local if not overloaded
+        if ($this->getRectorClass() !== '') { // use local if not overloaded
             $hash = Strings::substring(
                 md5($this->getRectorClass() . Json::encode($this->getRectorConfiguration())),
                 0,

--- a/tests/Rector/Property/PropertyToMethodRector/PropertyToMethodRectorTest.php
+++ b/tests/Rector/Property/PropertyToMethodRector/PropertyToMethodRectorTest.php
@@ -24,14 +24,20 @@ final class PropertyToMethodRectorTest extends AbstractRectorTestCase
     protected function getRectorConfiguration(): array
     {
         return [
-            Translator::class => ['locale' => [
-                'get' => 'getLocale',
-                'set' => 'setLocale',
-            ]],
-            'Rector\Tests\Rector\Property\PropertyToMethodRector\Fixture\SomeClassWithParameters' => ['parameter' => ['get' => [
-                'method' => 'getConfig',
-                'arguments' => ['parameter'],
-            ]]],
+            Translator::class => [
+                'locale' => [
+                    'get' => 'getLocale',
+                    'set' => 'setLocale',
+                ],
+            ],
+            'Rector\Tests\Rector\Property\PropertyToMethodRector\Fixture\SomeClassWithParameters' => [
+                'parameter' => [
+                    'get' => [
+                        'method' => 'getConfig',
+                        'arguments' => ['parameter'],
+                    ],
+                ],
+            ],
         ];
     }
 }


### PR DESCRIPTION
Closes #961 

### Includes

- [x] count support
- [x] array support
- [x] string support
- [x] integer support
- [x] float support
- [x] elseif support
- [x] null|Object support
- [x] ternary support

### Related 

- https://www.reddit.com/r/PHP/comments/aqk01p/is_there_a_situation_in_which_if_countarray_0
- https://github.com/phpstan/phpstan-strict-rules/blob/1ec1d04221dca0c2f4ce7abb73c17b276bfce206/src/Rules/BooleansInConditions/BooleanInIfConditionRule.php


Changes lousy bools like `(!non-bool)` or `(non-bool)` to direct ones:

```diff
-if (!count($stringTokens)) {
+if (count($stringTokens) === 0) {
```


```diff
-if (! $items) {
+if ($items === []) {
```
