### PR TITLE
SensitiveConstantNameRector: ignore existing contants

### DIFF
--- a/packages/Php/src/Rector/ConstFetch/SensitiveConstantNameRector.php
+++ b/packages/Php/src/Rector/ConstFetch/SensitiveConstantNameRector.php
@@ -118,6 +118,10 @@ CODE_SAMPLE
         }
 
         $currentConstantName = (string) $node->name;
+        
+        if (\defined($currentConstantName)) {
+        	return null;
+        }
 
         // is uppercase, all good
         if ($currentConstantName === strtoupper($currentConstantName)) {


### PR DESCRIPTION
case-sensitivity test of `defined()`: https://3v4l.org/DA23r