### PR TITLE
Add Show command to list loaded rectors

### DIFF
--- a/src/Console/Command/ShowCommand.php
+++ b/src/Console/Command/ShowCommand.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Console\Command;
+
+use Rector\Console\Shell;
+use Rector\Contract\Rector\RectorInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symplify\PackageBuilder\Console\Command\CommandNaming;
+
+final class ShowCommand extends AbstractCommand
+{
+    /**
+     * @var SymfonyStyle
+     */
+    private $symfonyStyle;
+
+    /**
+     * @var RectorInterface[]
+     */
+    private $rectors = [];
+
+    /**
+     * @param RectorInterface[] $rectors
+     */
+    public function __construct(SymfonyStyle $symfonyStyle, array $rectors)
+    {
+        $this->symfonyStyle = $symfonyStyle;
+        $this->rectors = $rectors;
+
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->setName(CommandNaming::classToName(self::class));
+        $this->setDescription('Show loaded Rectors');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $rectorClasses = array_map(function (RectorInterface $rector) {
+            return get_class($rector);
+        }, $this->rectors);
+
+        $this->symfonyStyle->listing($rectorClasses);
+        $this->symfonyStyle->success(sprintf('%d loaded Rectors', count($rectorClasses)));
+
+        return Shell::CODE_SUCCESS;
+    }
+}


### PR DESCRIPTION
If you ever get lost and you want to know, what rector services are loaded, just use:

```bash
vendor/bin/rector show
```

<br><br>

![demo](https://user-images.githubusercontent.com/924196/53165770-d639e200-35d3-11e9-8f9d-2ad4710b6d2b.gif)

