### PR TITLE
Change type hint for resolveClassConstFetch to mixed

### DIFF
--- a/src/PhpParser/Node/Value/ValueResolver.php
+++ b/src/PhpParser/Node/Value/ValueResolver.php
@@ -2,7 +2,6 @@
 
 namespace Rector\PhpParser\Node\Value;
 
-use PhpParser\ConstExprEvaluationException;
 use PhpParser\ConstExprEvaluator;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ClassConstFetch;
@@ -95,8 +94,6 @@ final class ValueResolver
 
     /**
      * @return mixed
-     * @throws ShouldNotHappenException
-     * @throws ConstExprEvaluationException
      */
     private function resolveClassConstFetch(ClassConstFetch $classConstFetch)
     {

--- a/src/PhpParser/Node/Value/ValueResolver.php
+++ b/src/PhpParser/Node/Value/ValueResolver.php
@@ -2,6 +2,7 @@
 
 namespace Rector\PhpParser\Node\Value;
 
+use PhpParser\ConstExprEvaluationException;
 use PhpParser\ConstExprEvaluator;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ClassConstFetch;
@@ -93,11 +94,9 @@ final class ValueResolver
     }
 
     /**
-     * @param ClassConstFetch $classConstFetch
-     *
      * @return mixed
      * @throws ShouldNotHappenException
-     * @throws \PhpParser\ConstExprEvaluationException
+     * @throws ConstExprEvaluationException
      */
     private function resolveClassConstFetch(ClassConstFetch $classConstFetch)
     {

--- a/src/PhpParser/Node/Value/ValueResolver.php
+++ b/src/PhpParser/Node/Value/ValueResolver.php
@@ -50,7 +50,7 @@ final class ValueResolver
             return $this->constExprEvaluator;
         }
 
-        $this->constExprEvaluator = new ConstExprEvaluator(function (Expr $expr): ?string {
+        $this->constExprEvaluator = new ConstExprEvaluator(function (Expr $expr) {
             if ($expr instanceof Dir) {
                 // __DIR__
                 return $this->resolveDirConstant($expr);
@@ -92,7 +92,14 @@ final class ValueResolver
         return $fileInfo->getPathname();
     }
 
-    private function resolveClassConstFetch(ClassConstFetch $classConstFetch): string
+    /**
+     * @param ClassConstFetch $classConstFetch
+     *
+     * @return mixed
+     * @throws ShouldNotHappenException
+     * @throws \PhpParser\ConstExprEvaluationException
+     */
+    private function resolveClassConstFetch(ClassConstFetch $classConstFetch)
     {
         $class = $this->nameResolver->resolve($classConstFetch->class);
         $constant = $this->nameResolver->resolve($classConstFetch->name);


### PR DESCRIPTION
Rector throws an exception when it has to inspect a constant with an integer value. See: #1127.

Signed-off-by: Kevin R <22906111+cgkkevinr@users.noreply.github.com>