### PR TITLE
Fix GetAndSetToMethodCallRector in class itself

### DIFF
--- a/src/PhpParser/Node/Manipulator/PropertyFetchManipulator.php
+++ b/src/PhpParser/Node/Manipulator/PropertyFetchManipulator.php
@@ -40,6 +40,15 @@ final class PropertyFetchManipulator
         $this->nameResolver = $nameResolver;
     }
 
+    public function isPropertyToSelf(PropertyFetch $propertyFetch): bool
+    {
+        if (! $propertyFetch->var instanceof Node\Expr\Variable) {
+            return false;
+        }
+
+        return $propertyFetch->var->name === 'this';
+    }
+
     public function isMagicOnType(Node $node, string $type): bool
     {
         if (! $node instanceof PropertyFetch) {

--- a/src/Rector/MagicDisclosure/GetAndSetToMethodCallRector.php
+++ b/src/Rector/MagicDisclosure/GetAndSetToMethodCallRector.php
@@ -111,6 +111,10 @@ CODE_SAMPLE
                 continue;
             }
 
+            if ($this->propertyFetchManipulator->isPropertyToSelf($propertyFetchNode)) {
+                continue;
+            }
+
             if (! $this->propertyFetchManipulator->isMagicOnType($propertyFetchNode, $type)) {
                 continue;
             }
@@ -133,6 +137,10 @@ CODE_SAMPLE
 
         foreach ($this->typeToMethodCalls as $type => $transformation) {
             if (! $this->isType($propertyFetchNode, $type)) {
+                continue;
+            }
+
+            if ($this->propertyFetchManipulator->isPropertyToSelf($propertyFetchNode)) {
                 continue;
             }
 

--- a/tests/Rector/MagicDisclosure/GetAndSetToMethodCallRector/Fixture/fixture3.php.inc
+++ b/tests/Rector/MagicDisclosure/GetAndSetToMethodCallRector/Fixture/fixture3.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+class Enlight_View_Default
+{
+    protected $engine;
+
+    public function __construct($engine)
+    {
+        $this->engine = $engine;
+    }
+}
+?>
+-----
+<?php
+
+class Enlight_View_Default
+{
+    protected $engine;
+
+    public function __construct($engine)
+    {
+        $this->engine = $engine;
+    }
+}
+?>

--- a/tests/Rector/MagicDisclosure/GetAndSetToMethodCallRector/Fixture/fixture3.php.inc
+++ b/tests/Rector/MagicDisclosure/GetAndSetToMethodCallRector/Fixture/fixture3.php.inc
@@ -10,3 +10,4 @@ class Enlight_View_Default
     }
 }
 ?>
+-----

--- a/tests/Rector/MagicDisclosure/GetAndSetToMethodCallRector/Fixture/fixture3.php.inc
+++ b/tests/Rector/MagicDisclosure/GetAndSetToMethodCallRector/Fixture/fixture3.php.inc
@@ -9,5 +9,3 @@ class Enlight_View_Default
         $this->engine = $engine;
     }
 }
-?>
------

--- a/tests/Rector/MagicDisclosure/GetAndSetToMethodCallRector/Fixture/fixture3.php.inc
+++ b/tests/Rector/MagicDisclosure/GetAndSetToMethodCallRector/Fixture/fixture3.php.inc
@@ -10,16 +10,3 @@ class Enlight_View_Default
     }
 }
 ?>
------
-<?php
-
-class Enlight_View_Default
-{
-    protected $engine;
-
-    public function __construct($engine)
-    {
-        $this->engine = $engine;
-    }
-}
-?>

--- a/tests/Rector/MagicDisclosure/GetAndSetToMethodCallRector/GetAndSetToMethodCallRectorTest.php
+++ b/tests/Rector/MagicDisclosure/GetAndSetToMethodCallRector/GetAndSetToMethodCallRectorTest.php
@@ -10,7 +10,7 @@ final class GetAndSetToMethodCallRectorTest extends AbstractRectorTestCase
 {
     public function test(): void
     {
-        $this->doTestFiles([__DIR__ . '/Fixture/fixture.php.inc', __DIR__ . '/Fixture/fixture2.php.inc']);
+        $this->doTestFiles([__DIR__ . '/Fixture/fixture.php.inc', __DIR__ . '/Fixture/fixture2.php.inc', __DIR__ . '/Fixture/fixture3.php.inc']);
     }
 
     protected function getRectorClass(): string
@@ -23,9 +23,15 @@ final class GetAndSetToMethodCallRectorTest extends AbstractRectorTestCase
      */
     protected function getRectorConfiguration(): array
     {
-        return [SomeContainer::class => [
-            'get' => 'getService',
-            'set' => 'addService',
-        ]];
+        return [
+            SomeContainer::class => [
+                'get' => 'getService',
+                'set' => 'addService',
+            ],
+            'Enlight_View_Default' => [
+                'get' => 'getService',
+                'set' => 'addService',
+            ]
+        ];
     }
 }


### PR DESCRIPTION
**Before the Fix**

Before
```php
class Enlight_View_Default
{
    protected $engine;
    public function __construct($engine)
    {
        $this->engine = $engine;
    }
}
```

After
```php
class Enlight_View_Default
{
    protected $engine;
    public function __construct($engine)
    {
        $this->addService('engine', $engine);
    }
}
```