### PR TITLE
Add annotation replacement to phpunit80

### DIFF
--- a/config/level/phpunit/phpunit80.yaml
+++ b/config/level/phpunit/phpunit80.yaml
@@ -13,6 +13,10 @@ services:
         'PHPUnit_Framework_MockObject_MockObject': 'PHPUnit\Framework\MockObject\MockObject'
     Rector\PHPUnit\Rector\MethodCall\AssertEqualsParameterToSpecificMethodsTypeRector: ~
 
+    Rector\Rector\Annotation\AnnotationReplacerRector:
+        PHPUnit\Framework\TestCase:
+            scenario: 'test'
+
     Rector\Rector\ClassMethod\AddReturnTypeDeclarationRector:
         PHPUnit\Framework\TestCase:
             setUpBeforeClass: 'void'


### PR DESCRIPTION
The annotation replacement is part of the phpunit70 process but the
'expectedException*' annotations are an actual BC-break in PHPUnit 8.0.

I copied the annotation replacement configuration from `phpunit70.yml` over to `phpunit80.yml`