### PR TITLE
[Laravel] Add request() to injection

### DIFF
--- a/packages/Laravel/src/Rector/StaticCall/RequestStaticValidateToInjectRector.php
+++ b/packages/Laravel/src/Rector/StaticCall/RequestStaticValidateToInjectRector.php
@@ -3,9 +3,12 @@
 namespace Rector\Laravel\Rector\StaticCall;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt\Class_;
+use Rector\NodeTypeResolver\Node\Attribute;
 use Rector\PhpParser\Node\Manipulator\ClassMethodManipulator;
 use Rector\Rector\AbstractRector;
 use Rector\RectorDefinition\CodeSample;
@@ -67,19 +70,15 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [StaticCall::class];
+        return [StaticCall::class, FuncCall::class];
     }
 
     /**
-     * @param StaticCall $node
+     * @param StaticCall|FuncCall $node
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isType($node, $this->requestClass)) {
-            return null;
-        }
-
-        if (! $this->isName($node, 'validate')) {
+        if ($this->shouldSkip($node)) {
             return null;
         }
 
@@ -91,6 +90,31 @@ CODE_SAMPLE
 
         $variable = new Variable($requestName);
 
+        if ($node instanceof FuncCall) {
+            return $variable;
+        }
+
         return new MethodCall($variable, $node->name, $node->args);
+    }
+
+    /**
+     * @param StaticCall|FuncCall $node
+     */
+    private function shouldSkip(Node $node): bool
+    {
+        if ($node instanceof StaticCall) {
+            return ! $this->isType($node, $this->requestClass);
+        }
+
+        if ($node instanceof FuncCall) {
+            $class = $node->getAttribute(Attribute::CLASS_NODE);
+            if (! $class instanceof Class_) {
+                return true;
+            }
+
+            return ! $this->isName($node, 'request');
+        }
+
+        return true;
     }
 }

--- a/packages/Laravel/src/Rector/StaticCall/RequestStaticValidateToInjectRector.php
+++ b/packages/Laravel/src/Rector/StaticCall/RequestStaticValidateToInjectRector.php
@@ -90,11 +90,16 @@ CODE_SAMPLE
 
         $variable = new Variable($requestName);
 
+        $methodName = $node->name;
         if ($node instanceof FuncCall) {
-            return $variable;
+            if (count($node->args) === 0) {
+                return $variable;
+            }
+
+            $methodName = 'input';
         }
 
-        return new MethodCall($variable, $node->name, $node->args);
+        return new MethodCall($variable, $methodName, $node->args);
     }
 
     /**

--- a/packages/Laravel/src/Rector/StaticCall/RequestStaticValidateToInjectRector.php
+++ b/packages/Laravel/src/Rector/StaticCall/RequestStaticValidateToInjectRector.php
@@ -25,9 +25,9 @@ final class RequestStaticValidateToInjectRector extends AbstractRector
     private $classMethodManipulator;
 
     /**
-     * @var string
+     * @var string[]
      */
-    private $requestClass = 'Illuminate\Http\Request';
+    private $requestTypes = ['Illuminate\Http\Request', 'Request'];
 
     public function __construct(ClassMethodManipulator $classMethodManipulator)
     {
@@ -84,13 +84,13 @@ CODE_SAMPLE
 
         $requestName = $this->classMethodManipulator->addMethodParameterIfMissing(
             $node,
-            $this->requestClass,
+            'Illuminate\Http\Request',
             ['request', 'httpRequest']
         );
 
         $variable = new Variable($requestName);
 
-        $methodName = $node->name;
+        $methodName = $this->getName($node->name);
         if ($node instanceof FuncCall) {
             if (count($node->args) === 0) {
                 return $variable;
@@ -108,7 +108,7 @@ CODE_SAMPLE
     private function shouldSkip(Node $node): bool
     {
         if ($node instanceof StaticCall) {
-            return ! $this->isType($node, $this->requestClass);
+            return ! $this->isTypes($node, $this->requestTypes);
         }
 
         if ($node instanceof FuncCall) {

--- a/packages/Laravel/tests/Rector/StaticCall/RequestStaticValidateToInjectRector/Fixture/function.php.inc
+++ b/packages/Laravel/tests/Rector/StaticCall/RequestStaticValidateToInjectRector/Fixture/function.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Laravel\Tests\Rector\StaticCall\RequestStaticValidateToInjectRector\Fixture;
+
+class SomeFunction
+{
+    public function store()
+    {
+        $validatedData = request()->get('foo');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Laravel\Tests\Rector\StaticCall\RequestStaticValidateToInjectRector\Fixture;
+
+class SomeFunction
+{
+    public function store(\Illuminate\Http\Request $request)
+    {
+        $validatedData = $request->get('foo');
+    }
+}
+
+?>

--- a/packages/Laravel/tests/Rector/StaticCall/RequestStaticValidateToInjectRector/Fixture/function2.php.inc
+++ b/packages/Laravel/tests/Rector/StaticCall/RequestStaticValidateToInjectRector/Fixture/function2.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Laravel\Tests\Rector\StaticCall\RequestStaticValidateToInjectRector\Fixture;
+
+class SomeFunction2
+{
+    public function store()
+    {
+        $validatedData = request('foo');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Laravel\Tests\Rector\StaticCall\RequestStaticValidateToInjectRector\Fixture;
+
+class SomeFunction2
+{
+    public function store(\Illuminate\Http\Request $request)
+    {
+        $validatedData = $request->input('foo');
+    }
+}
+
+?>

--- a/packages/Laravel/tests/Rector/StaticCall/RequestStaticValidateToInjectRector/RequestStaticValidateToInjectRectorTest.php
+++ b/packages/Laravel/tests/Rector/StaticCall/RequestStaticValidateToInjectRector/RequestStaticValidateToInjectRectorTest.php
@@ -9,7 +9,7 @@ final class RequestStaticValidateToInjectRectorTest extends AbstractRectorTestCa
 {
     public function test(): void
     {
-        $this->doTestFiles([__DIR__ . '/Fixture/fixture.php.inc', __DIR__ . '/Fixture/fixture-alias.php.inc']);
+        $this->doTestFiles([__DIR__ . '/Fixture/fixture.php.inc', __DIR__ . '/Fixture/fixture-alias.php.inc', __DIR__ . '/Fixture/function.php.inc']);
     }
 
     protected function getRectorClass(): string

--- a/packages/Laravel/tests/Rector/StaticCall/RequestStaticValidateToInjectRector/RequestStaticValidateToInjectRectorTest.php
+++ b/packages/Laravel/tests/Rector/StaticCall/RequestStaticValidateToInjectRector/RequestStaticValidateToInjectRectorTest.php
@@ -9,7 +9,12 @@ final class RequestStaticValidateToInjectRectorTest extends AbstractRectorTestCa
 {
     public function test(): void
     {
-        $this->doTestFiles([__DIR__ . '/Fixture/fixture.php.inc', __DIR__ . '/Fixture/fixture-alias.php.inc', __DIR__ . '/Fixture/function.php.inc']);
+        $this->doTestFiles([
+            __DIR__ . '/Fixture/fixture.php.inc',
+            __DIR__ . '/Fixture/fixture-alias.php.inc',
+            __DIR__ . '/Fixture/function.php.inc',
+            __DIR__ . '/Fixture/function2.php.inc',
+        ]);
     }
 
     protected function getRectorClass(): string


### PR DESCRIPTION
## Before

```php
<?php

namespace App\Http\Controllers;

class WelcomeController extends Controller
{
    public function index()
    {
        return view('welcome', [
            'foo' => request()->get('foo'),
        ]);
    }
}
```

## After

```php
<?php

namespace App\Http\Controllers;

use Illuminate\Http\Request;

class WelcomeController extends Controller
{
    public function index(Request $request)
    {
        return view('welcome', [
            'foo' => $request->get('foo'),
        ]);
    }
}
```


cc @azdanov :)