### PR TITLE
Pin PHPStan version to 0.11.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "nette/robot-loader": "^3.1",
         "nette/utils": "^2.5",
         "nikic/php-parser": "^4.2.1",
-        "phpstan/phpstan": "^0.11",
+        "phpstan/phpstan": "0.11.2",
         "sebastian/diff": "^3.0",
         "symfony/console": "^3.4|^4.2",
         "symfony/dependency-injection": "^3.4|^4.2",


### PR DESCRIPTION
This pins the PHPStan version to 0.11.2 since the newer version breaks tests. 