### PR TITLE
remove incorrect docs

### DIFF
--- a/packages/PHPUnit/src/Rector/MethodCall/SpecificAssertContainsRector.php
+++ b/packages/PHPUnit/src/Rector/MethodCall/SpecificAssertContainsRector.php
@@ -40,8 +40,6 @@ final class SomeTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertContains('foo', 'foo bar');
         $this->assertNotContains('foo', 'foo bar');
-        $this->assertContains('foo', ['foo', 'bar']);
-        $this->assertNotContains('foo', ['foo', 'bar']);
     }
 }
 CODE_SAMPLE
@@ -55,8 +53,6 @@ final class SomeTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertStringContains('foo', 'foo bar');
         $this->assertStringNotContains('foo', 'foo bar');
-        $this->assertIterableContains('foo', ['foo', 'bar']);
-        $this->assertIterableNotContains('foo', ['foo', 'bar']);
     }
 }
 CODE_SAMPLE


### PR DESCRIPTION
`assertIterableContains`/`assertIterableNotContains` were never implemented in phpunit.

https://github.com/rectorphp/rector/issues/1185#issuecomment-471768214