### PR TITLE
[PHPUnit] Add ReplaceAssertArraySubsetRector

### DIFF
--- a/config/level/phpunit/phpunit80.yaml
+++ b/config/level/phpunit/phpunit80.yaml
@@ -22,3 +22,4 @@ services:
             tearDown: 'void'
             tearDownAfterClass: 'void'
             onNotSuccessfulTest: 'void'
+    Rector\PHPUnit\Rector\MethodCall\ReplaceAssertArraySubsetRector: ~

--- a/packages/PHPUnit/src/Rector/MethodCall/ReplaceAssertArraySubsetRector.php
+++ b/packages/PHPUnit/src/Rector/MethodCall/ReplaceAssertArraySubsetRector.php
@@ -1,0 +1,193 @@
+<?php declare(strict_types=1);
+
+namespace Rector\PHPUnit\Rector\MethodCall;
+
+use PhpParser\BuilderHelpers;
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayDimFetch;
+use PhpParser\Node\Expr\BinaryOp\Identical;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name;
+use Rector\Rector\AbstractPHPUnitRector;
+use Rector\RectorDefinition\CodeSample;
+use Rector\RectorDefinition\RectorDefinition;
+
+/**
+ * @see https://github.com/sebastianbergmann/phpunit/issues/3494
+ * @see https://github.com/sebastianbergmann/phpunit/issues/3495
+ */
+final class ReplaceAssertArraySubsetRector extends AbstractPHPUnitRector
+{
+    /**
+     * @var Expr[]
+     */
+    private $expectedKeys = [];
+
+    /**
+     * @var Expr[]
+     */
+    private $expectedValuesByKeys = [];
+
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Replace deprecated "assertArraySubset()" method with alternative methods', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+class SomeTest extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $checkedArray = [];
+
+        $this->assertArraySubset([
+           'cache_directory' => 'new_value',
+        ], $checkedArray);
+    }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+class SomeTest extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $checkedArray = [];
+
+        $this->assertArrayHasKey('cache_directory', $checkedArray);
+        $this->assertSame('new_value', $checkedArray['cache_directory']);
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class, StaticCall::class];
+    }
+
+    /**
+     * @param MethodCall|StaticCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isAssertMethod($node, 'assertArraySubset')) {
+            return null;
+        }
+
+        $this->reset();
+
+        $expectedArray = $this->matchArray($node->args[0]->value);
+        if ($expectedArray === null) {
+            return null;
+        }
+
+        $this->collectExpectedKeysAndValues($expectedArray);
+
+        if ($this->expectedKeys === []) {
+            // no keys → intersect!
+            $arrayIntersect = new FuncCall(new Name('array_intersect'));
+            $arrayIntersect->args[] = new Arg($expectedArray);
+            $arrayIntersect->args[] = $node->args[1];
+
+            $identical = new Identical($arrayIntersect, $expectedArray);
+
+            $assertTrue = $this->createCallWithName($node, 'assertTrue');
+            $assertTrue->args[] = new Arg($identical);
+
+            $this->addNodeAfterNode($assertTrue, $node);
+        } else {
+            $this->addKeyAsserts($node);
+            $this->addValueAsserts($node);
+        }
+
+        $this->removeNode($node);
+
+        return null;
+    }
+
+    /**
+     * @param MethodCall|StaticCall $node
+     */
+    private function addKeyAsserts(Node $node): void
+    {
+        foreach ($this->expectedKeys as $expectedKey) {
+            $assertArrayHasKey = $this->createCallWithName($node, 'assertArrayHasKey');
+            $assertArrayHasKey->args[0] = new Arg($expectedKey);
+            $assertArrayHasKey->args[1] = $node->args[1];
+
+            $this->addNodeAfterNode($assertArrayHasKey, $node);
+        }
+    }
+
+    /**
+     * @param MethodCall|StaticCall $node
+     */
+    private function addValueAsserts(Node $node): void
+    {
+        foreach ($this->expectedValuesByKeys as $key => $expectedValue) {
+            $assertSame = $this->createCallWithName($node, 'assertSame');
+            $assertSame->args[0] = new Arg($expectedValue);
+
+            $arrayDimFetch = new ArrayDimFetch($node->args[1]->value, BuilderHelpers::normalizeValue($key));
+            $assertSame->args[1] = new Arg($arrayDimFetch);
+
+            $this->addNodeAfterNode($assertSame, $node);
+        }
+    }
+
+    /**
+     * @param StaticCall|MethodCall $node
+     * @return StaticCall|MethodCall
+     */
+    private function createCallWithName(Node $node, string $name): Node
+    {
+        return $node instanceof MethodCall ? new MethodCall($node->var, $name) : new StaticCall($node->class, $name);
+    }
+
+    private function collectExpectedKeysAndValues(Array_ $expectedArray): void
+    {
+        foreach ($expectedArray->items as $arrayItem) {
+            if ($arrayItem->key === null) {
+                continue;
+            }
+
+            $this->expectedKeys[] = $arrayItem->key;
+
+            $key = $this->getValue($arrayItem->key);
+            $this->expectedValuesByKeys[$key] = $arrayItem->value;
+        }
+    }
+
+    private function reset(): void
+    {
+        $this->expectedKeys = [];
+        $this->expectedValuesByKeys = [];
+    }
+
+    private function matchArray(Expr $expr): ?Array_
+    {
+        if ($expr instanceof Array_) {
+            return $expr;
+        }
+
+        $value = $this->getValue($expr);
+
+        // nothing we can do
+        if ($value === null || ! is_array($value)) {
+            return null;
+        }
+
+        // use specific array instead
+        return BuilderHelpers::normalizeValue($value);
+    }
+}

--- a/packages/PHPUnit/tests/Rector/MethodCall/ReplaceAssertArraySubsetRector/Fixture/fixture.php.inc
+++ b/packages/PHPUnit/tests/Rector/MethodCall/ReplaceAssertArraySubsetRector/Fixture/fixture.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\MethodCall\ReplaceAssertArraySubsetRector\Fixture;
+
+class SomeTest extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $checkedArray = [];
+
+        $this->assertArraySubset([
+           'cache_directory' => 'new_value',
+        ], $checkedArray);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\MethodCall\ReplaceAssertArraySubsetRector\Fixture;
+
+class SomeTest extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $checkedArray = [];
+        $this->assertArrayHasKey('cache_directory', $checkedArray);
+        $this->assertSame('new_value', $checkedArray['cache_directory']);
+    }
+}
+
+?>

--- a/packages/PHPUnit/tests/Rector/MethodCall/ReplaceAssertArraySubsetRector/Fixture/issue_2069.php.inc
+++ b/packages/PHPUnit/tests/Rector/MethodCall/ReplaceAssertArraySubsetRector/Fixture/issue_2069.php.inc
@@ -1,0 +1,46 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\MethodCall\ReplaceAssertArraySubsetRector\Fixture;
+
+class Issue2069 extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $result = ['Hello' => 'a', 'World!' => 'b'];
+        $this->assertArraySubset(['World!' => 'b', 'Hello' => 'a'], $result);
+    }
+
+    public function shouldWorkToo()
+    {
+        $result = ['a', 'b', 'c', 'd'];
+        $this->assertArraySubset(['b', 'c'], $result);
+        $this->assertArraySubset(['a', 'c', 'b'], $result);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\MethodCall\ReplaceAssertArraySubsetRector\Fixture;
+
+class Issue2069 extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $result = ['Hello' => 'a', 'World!' => 'b'];
+        $this->assertArrayHasKey('World!', $result);
+        $this->assertArrayHasKey('Hello', $result);
+        $this->assertSame('b', $result['World!']);
+        $this->assertSame('a', $result['Hello']);
+    }
+
+    public function shouldWorkToo()
+    {
+        $result = ['a', 'b', 'c', 'd'];
+        $this->assertTrue(array_intersect(['b', 'c'], $result) === ['b', 'c']);
+        $this->assertTrue(array_intersect(['a', 'c', 'b'], $result) === ['a', 'c', 'b']);
+    }
+}
+
+?>

--- a/packages/PHPUnit/tests/Rector/MethodCall/ReplaceAssertArraySubsetRector/Fixture/issue_2237.php.inc
+++ b/packages/PHPUnit/tests/Rector/MethodCall/ReplaceAssertArraySubsetRector/Fixture/issue_2237.php.inc
@@ -1,0 +1,57 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\MethodCall\ReplaceAssertArraySubsetRector\Fixture;
+
+class Issue2237 extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $result = [
+            'a' => 'item a',
+            'b' => 'item k', // wrong value
+            'c' => [
+                // 'd' not present
+                'g' => 'item g',
+            ],
+        ];
+
+        $this->assertArraySubset([
+            'a' => 'item a',
+            'b' => 'item b',
+            'c' => [
+                'd' => 'item d',
+            ],
+        ], $result);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\MethodCall\ReplaceAssertArraySubsetRector\Fixture;
+
+class Issue2237 extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $result = [
+            'a' => 'item a',
+            'b' => 'item k', // wrong value
+            'c' => [
+                // 'd' not present
+                'g' => 'item g',
+            ],
+        ];
+        $this->assertArrayHasKey('a', $result);
+        $this->assertArrayHasKey('b', $result);
+        $this->assertArrayHasKey('c', $result);
+        $this->assertSame('item a', $result['a']);
+        $this->assertSame('item b', $result['b']);
+        $this->assertSame([
+            'd' => 'item d',
+        ], $result['c']);
+    }
+}
+
+?>

--- a/packages/PHPUnit/tests/Rector/MethodCall/ReplaceAssertArraySubsetRector/Fixture/variable.php.inc
+++ b/packages/PHPUnit/tests/Rector/MethodCall/ReplaceAssertArraySubsetRector/Fixture/variable.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\MethodCall\ReplaceAssertArraySubsetRector\Fixture;
+
+class VariableTest extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $checkedArray = [];
+        $expectedSubset = [
+            'cache_directory' => 'new_value',
+        ];
+
+        $this->assertArraySubset($expectedSubset, $checkedArray);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\MethodCall\ReplaceAssertArraySubsetRector\Fixture;
+
+class VariableTest extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $checkedArray = [];
+        $expectedSubset = [
+            'cache_directory' => 'new_value',
+        ];
+        $this->assertArrayHasKey('cache_directory', $checkedArray);
+        $this->assertSame('new_value', $checkedArray['cache_directory']);
+    }
+}
+
+?>

--- a/packages/PHPUnit/tests/Rector/MethodCall/ReplaceAssertArraySubsetRector/ReplaceAssertArraySubsetRectorTest.php
+++ b/packages/PHPUnit/tests/Rector/MethodCall/ReplaceAssertArraySubsetRector/ReplaceAssertArraySubsetRectorTest.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\Rector\MethodCall\ReplaceAssertArraySubsetRector;
+
+use Rector\PHPUnit\Rector\MethodCall\ReplaceAssertArraySubsetRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ReplaceAssertArraySubsetRectorTest extends AbstractRectorTestCase
+{
+    public function test(): void
+    {
+        $this->doTestFiles([
+            __DIR__ . '/Fixture/fixture.php.inc',
+            __DIR__ . '/Fixture/issue_2069.php.inc',
+            __DIR__ . '/Fixture/issue_2237.php.inc',
+            __DIR__ . '/Fixture/variable.php.inc',
+        ]);
+    }
+
+    protected function getRectorClass(): string
+    {
+        return ReplaceAssertArraySubsetRector::class;
+    }
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -141,3 +141,5 @@ parameters:
         - '#Parameter \#1 \$children of class PHPStan\\PhpDocParser\\Ast\\PhpDoc\\PhpDocNode constructor expects array<PHPStan\\PhpDocParser\\Ast\\PhpDoc\\PhpDocChildNode\>, array<int, PHPStan\\PhpDocParser\\Ast\\Node\> given#'
         # false positive
         - '#If condition is always false#'
+        - '#Call to an undefined method PHPStan\\Type\\Type\:\:getValue\(\)#'
+        - '#Method Rector\\PHPUnit\\Rector\\MethodCall\\ReplaceAssertArraySubsetRector\:\:matchArray\(\) should return PhpParser\\Node\\Expr\\Array_\|null but returns PhpParser\\Node\\Expr#'

--- a/src/Rector/AbstractPHPUnitRector.php
+++ b/src/Rector/AbstractPHPUnitRector.php
@@ -3,10 +3,25 @@
 namespace Rector\Rector;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
 use Rector\NodeTypeResolver\Node\Attribute;
 
 abstract class AbstractPHPUnitRector extends AbstractRector
 {
+    protected function isAssertMethod(Node $node, string $name): bool
+    {
+        if (! $this->isInTestClass($node)) {
+            return false;
+        }
+
+        if (! $node instanceof MethodCall && ! $node instanceof StaticCall) {
+            return false;
+        }
+
+        return $this->isName($node, $name);
+    }
+
     protected function isInTestClass(Node $node): bool
     {
         $classNode = $node->getAttribute(Attribute::CLASS_NODE);


### PR DESCRIPTION
Closes #1025 

Ref https://github.com/sebastianbergmann/phpunit/issues/3495

## Check and Cover Reported Cases

- [x] https://github.com/sebastianbergmann/phpunit/issues/2069
- [x] https://github.com/sebastianbergmann/phpunit/issues/2108
- [x] https://github.com/sebastianbergmann/phpunit/issues/2568
- [x] https://github.com/sebastianbergmann/phpunit/issues/3101
- [x] https://github.com/sebastianbergmann/phpunit/issues/3101
- [x] https://github.com/sebastianbergmann/phpunit/issues/3240
- [x] https://github.com/sebastianbergmann/phpunit/issues/3319


## Test me! 

As this can have many different uses out in the wild and not all can be converted manually, this needs thorought testing.

0. Install local rector dev

```
composer require rector/rector:@dev --dev
```

1. Create `rector.yaml` local config

```yaml
# rector.yaml
services:
    Rector\PHPUnit\Rector\MethodCall\ReplaceAssertArraySubsetRector: ~
```

2. Run Rector

```
vendor/bin/rector process src
```

3. Report anomalies