### PR TITLE
add failing test for RemoveUnusedPrivateMethodRector

### DIFF
--- a/packages/DeadCode/src/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php
+++ b/packages/DeadCode/src/Rector/ClassMethod/RemoveUnusedPrivateMethodRector.php
@@ -70,6 +70,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($this->matchName($node, '#^__*#')) {
+            return null;
+        }
+
         $classMethodCalls = $this->classMethodManipulator->getAllClassMethodCall($node);
         if ($classMethodCalls === []) {
             $this->removeNode($node);

--- a/packages/DeadCode/tests/Rector/ClassMethod/RemoveUnusedPrivateMethodRector/Fixture/private_constructor.php.inc
+++ b/packages/DeadCode/tests/Rector/ClassMethod/RemoveUnusedPrivateMethodRector/Fixture/private_constructor.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\DeadCode\Tests\Rector\ClassMethod\RemoveUnusedPrivateMethodRector\Fixture;
+
+final class PrivateConstructor
+{
+    private function __construct()
+    {
+    }
+}

--- a/packages/DeadCode/tests/Rector/ClassMethod/RemoveUnusedPrivateMethodRector/RemoveUnusedPrivateMethodRectorTest.php
+++ b/packages/DeadCode/tests/Rector/ClassMethod/RemoveUnusedPrivateMethodRector/RemoveUnusedPrivateMethodRectorTest.php
@@ -13,6 +13,7 @@ final class RemoveUnusedPrivateMethodRectorTest extends AbstractRectorTestCase
             __DIR__ . '/Fixture/fixture.php.inc',
             __DIR__ . '/Fixture/static_method.php.inc',
             __DIR__ . '/Fixture/keep_anonymous.php.inc',
+            __DIR__ . '/Fixture/private_constructor.php.inc',
         ]);
     }
 


### PR DESCRIPTION
Here's a bug I found when running `dead-code` level on my project