### PR TITLE
add failing test for RemoveEmptyClassMethodRectorTest

### DIFF
--- a/packages/DeadCode/src/Rector/ClassMethod/RemoveEmptyClassMethodRector.php
+++ b/packages/DeadCode/src/Rector/ClassMethod/RemoveEmptyClassMethodRector.php
@@ -67,6 +67,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node->isAbstract()) {
+            return null;
+        }
+
         if ($this->classMethodManipulator->hasParentMethodOrInterfaceMethod($node)) {
             return null;
         }

--- a/packages/DeadCode/tests/Rector/ClassMethod/RemoveEmptyClassMethodRector/Fixture/keep_abstract_method.php.inc
+++ b/packages/DeadCode/tests/Rector/ClassMethod/RemoveEmptyClassMethodRector/Fixture/keep_abstract_method.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\DeadCode\Tests\Rector\ClassMethod\RemoveUnusedPrivateMethodRector\Fixture;
+
+abstract class AbtractClass
+{
+    abstract public function keep(): string;
+}

--- a/packages/DeadCode/tests/Rector/ClassMethod/RemoveEmptyClassMethodRector/RemoveEmptyClassMethodRectorTest.php
+++ b/packages/DeadCode/tests/Rector/ClassMethod/RemoveEmptyClassMethodRector/RemoveEmptyClassMethodRectorTest.php
@@ -13,6 +13,7 @@ final class RemoveEmptyClassMethodRectorTest extends AbstractRectorTestCase
             __DIR__ . '/Fixture/simple.php.inc',
             __DIR__ . '/Fixture/with_parent.php.inc',
             __DIR__ . '/Fixture/with_interface.php.inc',
+            __DIR__ . '/Fixture/keep_abstract_method.php.inc',
         ]);
     }
 


### PR DESCRIPTION
found when running `dead-code` on my project.