### PR TITLE
[CakePHP] Add Fixture importing name style rector(for 3.7)

### DIFF
--- a/config/level/cakephp/cakephp37.yaml
+++ b/config/level/cakephp/cakephp37.yaml
@@ -79,3 +79,5 @@ services:
             className:
                 set: 'setClassName'
                 get: 'getClassName'
+
+    Rector\CakePHP\Rector\Name\ChangeSnakedFixtureNameToCamel: ~

--- a/packages/CakePHP/src/Rector/Name/ChangeSnakedFixtureNameToCamelRector.php
+++ b/packages/CakePHP/src/Rector/Name/ChangeSnakedFixtureNameToCamelRector.php
@@ -10,6 +10,9 @@ use Rector\Rector\AbstractRector;
 use Rector\RectorDefinition\CodeSample;
 use Rector\RectorDefinition\RectorDefinition;
 
+/**
+ * @see https://book.cakephp.org/3.0/en/appendices/3-7-migration-guide.html
+ */
 final class ChangeSnakedFixtureNameToCamelRector extends AbstractRector
 {
     public function getDefinition(): RectorDefinition

--- a/packages/CakePHP/src/Rector/Name/ChangeSnakedFixtureNameToCamelRector.php
+++ b/packages/CakePHP/src/Rector/Name/ChangeSnakedFixtureNameToCamelRector.php
@@ -1,0 +1,95 @@
+<?php declare(strict_types=1);
+
+namespace Rector\CakePHP\Rector\Name;
+
+use PhpParser\Node;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Property;
+use Rector\NodeTypeResolver\Node\Attribute;
+use Rector\Rector\AbstractRector;
+use Rector\RectorDefinition\CodeSample;
+use Rector\RectorDefinition\RectorDefinition;
+
+final class ChangeSnakedFixtureNameToCamelRector extends AbstractRector
+{
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Changes $fixtues style from snake_case to CamelCase.', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+class SomeTest
+{
+    protected $fixtures = [
+        'app.posts',
+        'app.users',
+        'some_plugin.posts/special_posts',
+    ];
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+class SomeTest
+{
+    protected $fixtures = [
+        'app.Posts',
+        'app.Users',
+        'some_plugin.Posts/SpeectialPosts',
+    ];
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getNodeTypes(): array
+    {
+        return [Property::class];
+    }
+
+    /**
+     * @param Property $node
+     * @return Node|null
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $classNode = $node->getAttribute(Attribute::CLASS_NODE);
+        if ($classNode === null) {
+            return null;
+        }
+        if (! $this->isName($node, 'fixtures')) {
+            return null;
+        }
+
+        foreach ($node->props as $i => $prop) {
+            if (! isset($prop->default->items)) {
+                continue;
+            }
+            foreach ($prop->default->items as $j => $item) {
+                $node->props[$i]->default->items[$j]->value = $this->renameFixtureName($item->value);
+            }
+        }
+
+        return $node;
+    }
+
+    /**
+     * @param String_ $name
+     * @return String_
+     */
+    private function renameFixtureName(String_ $name): String_
+    {
+        [$prefix, $table] = explode('.', $name->value);
+        $table = array_map(
+            function ($token) {
+                $tokens = explode('_', $token);
+
+                return implode(array_map('ucfirst', $tokens));
+            },
+            explode('/', $table)
+        );
+        $table = implode('/', $table);
+
+        return new String_("{$prefix}.{$table}", $name->getAttributes());
+    }
+}

--- a/packages/CakePHP/tests/Rector/Name/ChangeSnakedFixtureNameToCamel/ChangeSnakedFixtureNameToCamelTest.php
+++ b/packages/CakePHP/tests/Rector/Name/ChangeSnakedFixtureNameToCamel/ChangeSnakedFixtureNameToCamelTest.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Rector\CakePHP\Tests\Rector\Name\ChangeSnakedFixtureNameToCamel;
+
+use Rector\CakePHP\Rector\Name\ChangeSnakedFixtureNameToCamelRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ChangeSnakedFixtureNameToCamelTest extends AbstractRectorTestCase
+{
+    public function test(): void
+    {
+        $this->doTestFiles([__DIR__ . '/Fixture/fixture.php.inc']);
+    }
+
+    protected function getRectorClass(): string
+    {
+        return ChangeSnakedFixtureNameToCamelRector::class;
+    }
+}

--- a/packages/CakePHP/tests/Rector/Name/ChangeSnakedFixtureNameToCamel/Fixture/fixture.php.inc
+++ b/packages/CakePHP/tests/Rector/Name/ChangeSnakedFixtureNameToCamel/Fixture/fixture.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\FixtureImport\SnakeToCamelRector;
+
+class ClassImportingFixturesWithSnakeCasedName
+{
+    protected $fixtures = [
+        'app.users',
+        'other_app.tags',
+        'plugin.posts',
+        'plugin.messages/deleted_messages',
+    ];
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\FixtureImport\SnakeToCamelRector;
+
+class ClassImportingFixturesWithSnakeCasedName
+{
+    protected $fixtures = [
+        'app.Users',
+        'other_app.Tags',
+        'plugin.Posts',
+        'plugin.Messages/DeletedMessages',
+    ];
+}
+
+?>


### PR DESCRIPTION
Since CakePHP 3.7,  declaring `TestCase::$fixtures`  in underscored has been deprecated.
Now, it should be declared in SnakeCase.

I think rector is the perfect solution for saving cakephp-er from such a boring work "check and renaming ALL `$fixtures = []` VARS in exists test file" 😄 

---

> Using underscored fixtures names in TestCase::$fixtures is deprecated. Use CamelCased names instead. For e.g. app.FooBar, plugin.MyPlugin.FooBar.
[(migration guide)](https://book.cakephp.org/3.0/en/appendices/3-7-migration-guide.html)

also see: https://github.com/cakephp/cakephp/pull/12560/files#diff-00c99fa549dd6a8e04203fff9bcc684aR196