### PR TITLE
[CodeQuality] Simplify Regex patterns

### DIFF
--- a/config/level/code-quality/code-quality.yaml
+++ b/config/level/code-quality/code-quality.yaml
@@ -28,3 +28,4 @@ services:
     Rector\CodeQuality\Rector\Equal\UseIdenticalOverEqualWithSameTypeRector: ~
     Rector\CodeQuality\Rector\Ternary\SimplifyDuplicatedTernaryRector: ~
     Rector\CodeQuality\Rector\Identical\SimplifyBoolIdenticalTrueRector: ~
+    Rector\CodeQuality\Rector\FuncCall\SimplifyRegexPatternRector: ~

--- a/docs/AllRectorsOverview.md
+++ b/docs/AllRectorsOverview.md
@@ -1,4 +1,4 @@
-# All 243 Rectors Overview
+# All 258 Rectors Overview
 
 - [Projects](#projects)
 - [General](#general)
@@ -50,6 +50,27 @@ Changes combined set/get `value()` to specific `getValue()` or `setValue(x)`.
 -$object->config(['key' => 'value']);
 +$object->setConfig('key', 'value');
 +$object->setConfig(['key' => 'value']);
+```
+
+<br>
+
+### `ChangeSnakedFixtureNameToCamelRector`
+
+- class: `Rector\CakePHP\Rector\Name\ChangeSnakedFixtureNameToCamelRector`
+
+Changes $fixtues style from snake_case to CamelCase.
+
+```diff
+ class SomeTest
+ {
+     protected $fixtures = [
+-        'app.posts',
+-        'app.users',
+-        'some_plugin.posts/special_posts',
++        'app.Posts',
++        'app.Users',
++        'some_plugin.Posts/SpeectialPosts',
+     ];
 ```
 
 <br>
@@ -353,6 +374,25 @@ Simplify strpos(strtolower(), "...") calls
 ```diff
 -strpos(strtolower($var), "...")"
 +stripos($var, "...")"
+```
+
+<br>
+
+### `SimplifyRegexPatternRector`
+
+- class: `Rector\CodeQuality\Rector\FuncCall\SimplifyRegexPatternRector`
+
+Simplify regex pattern to known ranges
+
+```diff
+ class SomeClass
+ {
+     public function run($value)
+     {
+-        preg_match('#[a-zA-Z0-9+]#', $value);
++        preg_match('#[\w\d+]#', $value);
+     }
+ }
 ```
 
 <br>
@@ -847,8 +887,8 @@ Remove duplicated key in defined arrays.
 
 ```diff
  $item = [
-     1 => 'A',
--    1 => 'A'
+-    1 => 'A',
+     1 => 'B'
  ];
 ```
 
@@ -968,6 +1008,34 @@ Remove initial assigns of overridden values
 
 <br>
 
+### `RemoveDeadIfForeachForRector`
+
+- class: `Rector\DeadCode\Rector\For_\RemoveDeadIfForeachForRector`
+
+Remove if, foreach and for that does not do anything
+
+```diff
+ class SomeClass
+ {
+     public function run($someObject)
+     {
+         $value = 5;
+-        if ($value) {
+-        }
+-
+         if ($someObject->run()) {
+-        }
+-
+-        foreach ($values as $value) {
+         }
+
+         return $value;
+     }
+ }
+```
+
+<br>
+
 ### `RemoveUnusedPrivatePropertyRector`
 
 - class: `Rector\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector`
@@ -1029,6 +1097,30 @@ Remove dead code after return statement
      {
           return $a;
 -         $a++;
+     }
+ }
+```
+
+<br>
+
+### `RemoveDeadReturnRector`
+
+- class: `Rector\DeadCode\Rector\FunctionLike\RemoveDeadReturnRector`
+
+Remove last return in the functions, since does not do anything
+
+```diff
+ class SomeClass
+ {
+     public function run()
+     {
+         $shallWeDoThis = true;
+
+         if ($shallWeDoThis) {
+             return;
+         }
+-
+-        return;
      }
  }
 ```
@@ -1339,6 +1431,32 @@ Replace mysql_pconnect() with mysqli_connect() with host p: prefix
 
 ## NetteTesterToPHPUnit
 
+### `NetteAssertToPHPUnitAssertRector`
+
+- class: `Rector\NetteTesterToPHPUnit\Rector\StaticCall\NetteAssertToPHPUnitAssertRector`
+
+Migrate Nette/Assert calls to PHPUnit
+
+```diff
+ use Tester\Assert;
+
+ function someStaticFunctions()
+ {
+-    Assert::true(10 == 5);
++    \PHPUnit\Framework\Assert::assertTrue(10 == 5);
+ }
+```
+
+<br>
+
+### `RenameTesterTestToPHPUnitToTestFileRector`
+
+- class: `Rector\NetteTesterToPHPUnit\Rector\RenameTesterTestToPHPUnitToTestFileRector`
+
+Rename "*.phpt" file to "*Test.php" file
+
+<br>
+
 ### `NetteTesterClassToPHPUnitClassRector`
 
 - class: `Rector\NetteTesterToPHPUnit\Rector\Class_\NetteTesterClassToPHPUnitClassRector`
@@ -1356,19 +1474,14 @@ Migrate Nette Tester test case to PHPUnit
 -class ExtensionTest extends TestCase
 +class ExtensionTest extends \PHPUnit\Framework\TestCase
  {
--    public function setUp()
-+    protected function setUp()
-     {
-     }
-
      public function testFunctionality()
      {
 -        Assert::true($default instanceof Kdyby\Doctrine\EntityManager);
 -        Assert::true(5);
 -        Assert::same($container->getService('kdyby.doctrine.default.entityManager'), $default);
-+        self::assertInstanceOf(\Kdyby\Doctrine\EntityManager::cllass, $default);
-+        self::assertTrue(5);
-+        self::same($container->getService('kdyby.doctrine.default.entityManager'), $default);
++        $this->assertInstanceOf(\Kdyby\Doctrine\EntityManager::cllass, $default);
++        $this->assertTrue(5);
++        $this->same($container->getService('kdyby.doctrine.default.entityManager'), $default);
      }
 -}
 -
@@ -1495,6 +1608,65 @@ Adds %% to placeholder name of trans() method if missing
 -            ['name' => $name]
 +            ['%name%' => $name]
          );
+     }
+ }
+```
+
+<br>
+
+### `NetteControlToSymfonyControllerRector`
+
+- class: `Rector\NetteToSymfony\Rector\Class_\NetteControlToSymfonyControllerRector`
+
+Migrate Nette Component to Symfony Controller
+
+```diff
+ use Nette\Application\UI\Control;
+
+-class SomeControl extends Control
++class SomeController extends \Symfony\Bundle\FrameworkBundle\Controller\AbstractController
+ {
+-    public function render()
+-    {
+-        $this->template->param = 'some value';
+-        $this->template->render(__DIR__ . '/poll.latte');
+-    }
++     public function some()
++     {
++         $this->render(__DIR__ . '/poll.latte', ['param' => 'some value']);
++     }
+ }
+```
+
+<br>
+
+### `NetteFormToSymfonyFormRector`
+
+- class: `Rector\NetteToSymfony\Rector\Class_\NetteFormToSymfonyFormRector`
+
+Migrate Nette\Forms in Presenter to Symfony
+
+```diff
+ use Nette\Application\UI;
+
+ class SomePresenter extends UI\Presenter
+ {
+     public function someAction()
+     {
+-        $form = new UI\Form;
+-        $form->addText('name', 'Name:');
+-        $form->addPassword('password', 'Password:');
+-        $form->addSubmit('login', 'Sign up');
++        $form = $this->createFormBuilder();
++        $form->add('name', \Symfony\Component\Form\Extension\Core\Type\TextType::class, [
++            'label' => 'Name:'
++        ]);
++        $form->add('password', \Symfony\Component\Form\Extension\Core\Type\PasswordType::class, [
++            'label' => 'Password:'
++        ]);
++        $form->add('login', \Symfony\Component\Form\Extension\Core\Type\SubmitType::class, [
++            'label' => 'Sign up'
++        ]);
      }
  }
 ```
@@ -1881,11 +2053,11 @@ Turns instanceof comparisons to their method name alternatives in PHPUnit TestCa
 
 ```diff
 -$this->assertTrue($foo instanceof Foo, "message");
-+$this->assertFalse($foo instanceof Foo, "message");
++$this->assertInstanceOf("Foo", $foo, "message");
 ```
 
 ```diff
--$this->assertInstanceOf("Foo", $foo, "message");
+-$this->assertFalse($foo instanceof Foo, "message");
 +$this->assertNotInstanceOf("Foo", $foo, "message");
 ```
 
@@ -1953,6 +2125,68 @@ Turns getMock*() methods to createMock()
 ```diff
 -$this->getMockWithoutInvokingTheOriginalConstructor("Class");
 +$this->createMock("Class");
+```
+
+<br>
+
+### `TestListenerToHooksRector`
+
+- class: `Rector\PHPUnit\Rector\Class_\TestListenerToHooksRector`
+
+Refactor "*TestListener.php" to particular "*Hook.php" files
+
+```diff
+ namespace App\Tests;
+
+-use PHPUnit\Framework\TestListener;
+-
+-final class BeforeListHook implements TestListener
++final class BeforeListHook implements \PHPUnit\Runner\BeforeTestHook, \PHPUnit\Runner\AfterTestHook
+ {
+-    public function addError(Test $test, \Throwable $t, float $time): void
++    public function executeBeforeTest(Test $test): void
+     {
+-    }
+-
+-    public function addWarning(Test $test, Warning $e, float $time): void
+-    {
+-    }
+-
+-    public function addFailure(Test $test, AssertionFailedError $e, float $time): void
+-    {
+-    }
+-
+-    public function addIncompleteTest(Test $test, \Throwable $t, float $time): void
+-    {
+-    }
+-
+-    public function addRiskyTest(Test $test, \Throwable $t, float $time): void
+-    {
+-    }
+-
+-    public function addSkippedTest(Test $test, \Throwable $t, float $time): void
+-    {
+-    }
+-
+-    public function startTestSuite(TestSuite $suite): void
+-    {
+-    }
+-
+-    public function endTestSuite(TestSuite $suite): void
+-    {
+-    }
+-
+-    public function startTest(Test $test): void
+-    {
+         echo 'start test!';
+     }
+
+-    public function endTest(Test $test, float $time): void
++    public function executeAfterTest(Test $test, float $time): void
+     {
+         echo $time;
+     }
+ }
 ```
 
 <br>
@@ -2372,7 +2606,7 @@ Changes rand, srand and getrandmax by new md_* alternatives.
 
 - class: `Rector\Php\Rector\FuncCall\PregReplaceEModifierRector`
 
-The /e modifier is no longer supported, use preg_replace_callback instead
+The /e modifier is no longer supported, use preg_replace_callback instead 
 
 ```diff
  class SomeClass
@@ -2653,8 +2887,8 @@ Adds JSON_THROW_ON_ERROR to json_encode() and json_decode() to throw JsonExcepti
 ```diff
 -json_encode($content);
 -json_decode($json);
-+json_encode($content, JSON_THROW_ON_ERROR
-+json_decode($json, null, null, JSON_THROW_ON_ERROR););
++json_encode($content, JSON_THROW_ON_ERROR);
++json_decode($json, null, null, JSON_THROW_ON_ERROR);
 ```
 
 <br>
@@ -2969,7 +3203,7 @@ list() assigns variables in reverse order - relevant in array assign
 
 ```diff
 -list($a[], $a[]) = [1, 2];
-+list($a[], $a[]) = array_reverse([1, 2])];
++list($a[], $a[]) = array_reverse([1, 2]);
 ```
 
 <br>
@@ -3112,6 +3346,142 @@ Turns use property to method and `$node->alias` to last name in UseAlias Node of
 
 ## PhpSpecToPHPUnit
 
+### `PhpSpecMethodToPHPUnitMethodRector`
+
+- class: `Rector\PhpSpecToPHPUnit\Rector\ClassMethod\PhpSpecMethodToPHPUnitMethodRector`
+
+Migrate PhpSpec behavior to PHPUnit test
+
+```diff
+ namespace spec\SomeNamespaceForThisTest;
+
+-use PhpSpec\ObjectBehavior;
+-
+ class OrderSpec extends ObjectBehavior
+ {
+-    public function let(OrderFactory $factory, ShippingMethod $shippingMethod)
++    /**
++     * @var \SomeNamespaceForThisTest\Order
++     */
++    private $order;
++    protected function setUp()
+     {
+-        $factory->createShippingMethodFor(Argument::any())->shouldBeCalled()->willReturn($shippingMethod);
++        /** @var OrderFactory|\PHPUnit\Framework\MockObject\MockObject $factory */
++        $factory = $this->createMock(OrderFactory::class);
++
++        /** @var ShippingMethod|\PHPUnit\Framework\MockObject\MockObject $shippingMethod */
++        $shippingMethod = $this->createMock(ShippingMethod::class);
++
++        $factory->expects($this->once())->method('createShippingMethodFor')->willReturn($shippingMethod);
+     }
+ }
+```
+
+<br>
+
+### `MockVariableToPropertyFetchRector`
+
+- class: `Rector\PhpSpecToPHPUnit\Rector\ClassMethod\MockVariableToPropertyFetchRector`
+
+Migrate PhpSpec behavior to PHPUnit test
+
+```diff
+ namespace spec\SomeNamespaceForThisTest;
+
+-use PhpSpec\ObjectBehavior;
+-
+ class OrderSpec extends ObjectBehavior
+ {
+-    public function let(OrderFactory $factory, ShippingMethod $shippingMethod)
++    /**
++     * @var \SomeNamespaceForThisTest\Order
++     */
++    private $order;
++    protected function setUp()
+     {
+-        $factory->createShippingMethodFor(Argument::any())->shouldBeCalled()->willReturn($shippingMethod);
++        /** @var OrderFactory|\PHPUnit\Framework\MockObject\MockObject $factory */
++        $factory = $this->createMock(OrderFactory::class);
++
++        /** @var ShippingMethod|\PHPUnit\Framework\MockObject\MockObject $shippingMethod */
++        $shippingMethod = $this->createMock(ShippingMethod::class);
++
++        $factory->expects($this->once())->method('createShippingMethodFor')->willReturn($shippingMethod);
+     }
+ }
+```
+
+<br>
+
+### `PhpSpecMocksToPHPUnitMocksRector`
+
+- class: `Rector\PhpSpecToPHPUnit\Rector\MethodCall\PhpSpecMocksToPHPUnitMocksRector`
+
+Migrate PhpSpec behavior to PHPUnit test
+
+```diff
+ namespace spec\SomeNamespaceForThisTest;
+
+-use PhpSpec\ObjectBehavior;
+-
+ class OrderSpec extends ObjectBehavior
+ {
+-    public function let(OrderFactory $factory, ShippingMethod $shippingMethod)
++    /**
++     * @var \SomeNamespaceForThisTest\Order
++     */
++    private $order;
++    protected function setUp()
+     {
+-        $factory->createShippingMethodFor(Argument::any())->shouldBeCalled()->willReturn($shippingMethod);
++        /** @var OrderFactory|\PHPUnit\Framework\MockObject\MockObject $factory */
++        $factory = $this->createMock(OrderFactory::class);
++
++        /** @var ShippingMethod|\PHPUnit\Framework\MockObject\MockObject $shippingMethod */
++        $shippingMethod = $this->createMock(ShippingMethod::class);
++
++        $factory->expects($this->once())->method('createShippingMethodFor')->willReturn($shippingMethod);
+     }
+ }
+```
+
+<br>
+
+### `PhpSpecPromisesToPHPUnitAssertRector`
+
+- class: `Rector\PhpSpecToPHPUnit\Rector\MethodCall\PhpSpecPromisesToPHPUnitAssertRector`
+
+Migrate PhpSpec behavior to PHPUnit test
+
+```diff
+ namespace spec\SomeNamespaceForThisTest;
+
+-use PhpSpec\ObjectBehavior;
+-
+ class OrderSpec extends ObjectBehavior
+ {
+-    public function let(OrderFactory $factory, ShippingMethod $shippingMethod)
++    /**
++     * @var \SomeNamespaceForThisTest\Order
++     */
++    private $order;
++    protected function setUp()
+     {
+-        $factory->createShippingMethodFor(Argument::any())->shouldBeCalled()->willReturn($shippingMethod);
++        /** @var OrderFactory|\PHPUnit\Framework\MockObject\MockObject $factory */
++        $factory = $this->createMock(OrderFactory::class);
++
++        /** @var ShippingMethod|\PHPUnit\Framework\MockObject\MockObject $shippingMethod */
++        $shippingMethod = $this->createMock(ShippingMethod::class);
++
++        $factory->expects($this->once())->method('createShippingMethodFor')->willReturn($shippingMethod);
+     }
+ }
+```
+
+<br>
+
 ### `RenameSpecFileToTestFileRector`
 
 - class: `Rector\PhpSpecToPHPUnit\Rector\RenameSpecFileToTestFileRector`
@@ -3120,33 +3490,68 @@ Rename "*Spec.php" file to "*Test.php" file
 
 <br>
 
+### `AddMockPropertiesRector`
+
+- class: `Rector\PhpSpecToPHPUnit\Rector\Class_\AddMockPropertiesRector`
+
+Migrate PhpSpec behavior to PHPUnit test
+
+```diff
+ namespace spec\SomeNamespaceForThisTest;
+
+-use PhpSpec\ObjectBehavior;
+-
+ class OrderSpec extends ObjectBehavior
+ {
+-    public function let(OrderFactory $factory, ShippingMethod $shippingMethod)
++    /**
++     * @var \SomeNamespaceForThisTest\Order
++     */
++    private $order;
++    protected function setUp()
+     {
+-        $factory->createShippingMethodFor(Argument::any())->shouldBeCalled()->willReturn($shippingMethod);
++        /** @var OrderFactory|\PHPUnit\Framework\MockObject\MockObject $factory */
++        $factory = $this->createMock(OrderFactory::class);
++
++        /** @var ShippingMethod|\PHPUnit\Framework\MockObject\MockObject $shippingMethod */
++        $shippingMethod = $this->createMock(ShippingMethod::class);
++
++        $factory->expects($this->once())->method('createShippingMethodFor')->willReturn($shippingMethod);
+     }
+ }
+```
+
+<br>
+
 ### `PhpSpecClassToPHPUnitClassRector`
 
 - class: `Rector\PhpSpecToPHPUnit\Rector\Class_\PhpSpecClassToPHPUnitClassRector`
 
-Migrate PhpSpec object behavior spec to PHPUnit test case
+Migrate PhpSpec behavior to PHPUnit test
 
 ```diff
--namespace spec\SomeNamespaceForThisTest;
-+namespace SomeNamespaceForThisTest;
+ namespace spec\SomeNamespaceForThisTest;
 
- use PhpSpec\ObjectBehavior;
-
--class CartSpec extends ObjectBehavior
-+class CartTest extends \PHPUnit\Framework\TestCase
+-use PhpSpec\ObjectBehavior;
+-
+ class OrderSpec extends ObjectBehavior
  {
--    public function let()
+-    public function let(OrderFactory $factory, ShippingMethod $shippingMethod)
++    /**
++     * @var \SomeNamespaceForThisTest\Order
++     */
++    private $order;
 +    protected function setUp()
      {
--        $this->beConstructedWith(5);
-+        $this->cart = new Cart(5);
-     }
-
--    public function it_returns_id()
-+    public function testReturnsId()
-     {
--        $this->id()->shouldReturn(5);
-+        $this->assertSame(5, $this->cart->id());
+-        $factory->createShippingMethodFor(Argument::any())->shouldBeCalled()->willReturn($shippingMethod);
++        /** @var OrderFactory|\PHPUnit\Framework\MockObject\MockObject $factory */
++        $factory = $this->createMock(OrderFactory::class);
++
++        /** @var ShippingMethod|\PHPUnit\Framework\MockObject\MockObject $shippingMethod */
++        $shippingMethod = $this->createMock(ShippingMethod::class);
++
++        $factory->expects($this->once())->method('createShippingMethodFor')->willReturn($shippingMethod);
      }
  }
 ```
@@ -3488,6 +3893,29 @@ Adds new `$format` argument in `VarDumperTestTrait->assertDumpEquals()` in Valid
 
 <br>
 
+### `ResponseStatusCodeRector`
+
+- class: `Rector\Symfony\Rector\BinaryOp\ResponseStatusCodeRector`
+
+Turns status code numbers to constants
+
+```diff
+ class SomeController
+ {
+     public function index()
+     {
+         $response = new \Symfony\Component\HttpFoundation\Response();
+-        $response->setStatusCode(200);
++        $response->setStatusCode(\Symfony\Component\HttpFoundation\Response::HTTP_OK);
+
+-        if ($response->getStatusCode() === 200) {}
++        if ($response->getStatusCode() === \Symfony\Component\HttpFoundation\Response::HTTP_OK) {}
+     }
+ }
+```
+
+<br>
+
 ### `GetParameterToConstructorInjectionRector`
 
 - class: `Rector\Symfony\Rector\FrameworkBundle\GetParameterToConstructorInjectionRector`
@@ -3677,8 +4105,7 @@ Changes Twig_Function_Method to Twig_SimpleFunction calls in TwigExtension.
          ];
      }
 
--    public function getFilters()
-+    public function getFilteres()
+     public function getFilters()
      {
          return [
 -            'is_mobile' => new Twig_Filter_Method($this, 'isMobile'),

--- a/docs/NodesOverview.md
+++ b/docs/NodesOverview.md
@@ -910,7 +910,7 @@ if (true) {
 
 ```php
 ?>
-<strong>feel</strong><?php
+<strong>feel</strong><?php 
 ```
 <br>
 

--- a/packages/CodeQuality/src/Rector/FuncCall/SimplifyRegexPatternRector.php
+++ b/packages/CodeQuality/src/Rector/FuncCall/SimplifyRegexPatternRector.php
@@ -5,7 +5,7 @@ namespace Rector\CodeQuality\Rector\FuncCall;
 use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
-use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Expr\StaticCall;
 use Rector\Php\Regex\RegexPatternArgumentManipulator;
 use Rector\Rector\AbstractRector;
 use Rector\RectorDefinition\CodeSample;
@@ -70,21 +70,24 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [FuncCall::class, Node\Expr\StaticCall::class];
+        return [FuncCall::class, StaticCall::class];
     }
 
     /**
-     * @param FuncCall|Node\Expr\StaticCall $node
+     * @param FuncCall|StaticCall $node
      */
     public function refactor(Node $node): ?Node
     {
-        $pattern = $this->regexPatternArgumentManipulator->matchCallArgumentWithRegexPattern($node);
-        if (! $pattern instanceof String_) {
-            return null;
-        }
+        $patterns = $this->regexPatternArgumentManipulator->matchCallArgumentWithRegexPattern($node);
 
-        foreach ($this->complexPatternToSimple as $complexPattern => $simple) {
-            $pattern->value = Strings::replace($pattern->value, '#' . preg_quote($complexPattern, '#') . '#', $simple);
+        foreach ($patterns as $pattern) {
+            foreach ($this->complexPatternToSimple as $complexPattern => $simple) {
+                $pattern->value = Strings::replace(
+                    $pattern->value,
+                    '#' . preg_quote($complexPattern, '#') . '#',
+                    $simple
+                );
+            }
         }
 
         return $node;

--- a/packages/CodeQuality/src/Rector/FuncCall/SimplifyRegexPatternRector.php
+++ b/packages/CodeQuality/src/Rector/FuncCall/SimplifyRegexPatternRector.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types=1);
+
+namespace Rector\CodeQuality\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Scalar\String_;
+use Rector\Rector\AbstractRector;
+use Rector\RectorDefinition\CodeSample;
+use Rector\RectorDefinition\RectorDefinition;
+
+/**
+ * @see http://php.net/manual/en/function.preg-match.php#105924
+ */
+final class SimplifyRegexPatternRector extends AbstractRector
+{
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Simplify regex pattern to known ranges', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run($value)
+    {
+        preg_match('#[a-zA-Z0-9+]#', $value);
+    }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run($value)
+    {
+        preg_match('#[\w\d+]#', $value);
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    /**
+     * @param FuncCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        // @todo detect "is regex wrapper" - func arg, Strings::match() etc.
+        if (! $this->isName($node, 'preg_match')) {
+            return null;
+        }
+
+        // only string patterns
+        $pattern = $node->args[0]->value;
+        if (! $pattern instanceof String_) {
+            return null;
+        }
+
+        // @todo simplify
+        dump($pattern->value);
+        die;
+
+        // change the node
+
+        return $node;
+    }
+}

--- a/packages/CodeQuality/src/Rector/FuncCall/SimplifyRegexPatternRector.php
+++ b/packages/CodeQuality/src/Rector/FuncCall/SimplifyRegexPatternRector.php
@@ -22,6 +22,9 @@ final class SimplifyRegexPatternRector extends AbstractRector
     private $complexPatternToSimple = [
         '[0-9]' => '\d',
         '[a-zA-Z0-9_]' => '\w',
+        '[A-Za-z0-9_]' => '\w',
+        '[0-9a-zA-Z_]' => '\w',
+        '[0-9A-Za-z_]' => '\w',
         '[\r\n\t\f\v ]' => '\s',
     ];
 
@@ -67,11 +70,11 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [FuncCall::class];
+        return [FuncCall::class, Node\Expr\StaticCall::class];
     }
 
     /**
-     * @param FuncCall $node
+     * @param FuncCall|Node\Expr\StaticCall $node
      */
     public function refactor(Node $node): ?Node
     {
@@ -81,7 +84,7 @@ CODE_SAMPLE
         }
 
         foreach ($this->complexPatternToSimple as $complexPattern => $simple) {
-            $pattern->value = Strings::replace($pattern->value, '#' . preg_quote($complexPattern) . '#', $simple);
+            $pattern->value = Strings::replace($pattern->value, '#' . preg_quote($complexPattern, '#') . '#', $simple);
         }
 
         return $node;

--- a/packages/CodeQuality/tests/Rector/FuncCall/SimplifyRegexPatternRector/Fixture/fixture.php.inc
+++ b/packages/CodeQuality/tests/Rector/FuncCall/SimplifyRegexPatternRector/Fixture/fixture.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\CodeQuality\Tests\Rector\FuncCall\SimplifyRegexPatternRector\Fixture;
+
+class SomeClass
+{
+    public function run($value)
+    {
+        preg_match('#[a-zA-Z0-9+]#', $value);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CodeQuality\Tests\Rector\FuncCall\SimplifyRegexPatternRector\Fixture;
+
+class SomeClass
+{
+    public function run($value)
+    {
+        preg_match('#[\w\d+]#', $value);
+    }
+}
+
+?>

--- a/packages/CodeQuality/tests/Rector/FuncCall/SimplifyRegexPatternRector/Fixture/fixture.php.inc
+++ b/packages/CodeQuality/tests/Rector/FuncCall/SimplifyRegexPatternRector/Fixture/fixture.php.inc
@@ -6,7 +6,7 @@ class SomeClass
 {
     public function run($value)
     {
-        preg_match('#[a-zA-Z0-9+]#', $value);
+        preg_match('#[0-9]#', $value);
     }
 }
 
@@ -20,7 +20,7 @@ class SomeClass
 {
     public function run($value)
     {
-        preg_match('#[\w\d+]#', $value);
+        preg_match('#\d#', $value);
     }
 }
 

--- a/packages/CodeQuality/tests/Rector/FuncCall/SimplifyRegexPatternRector/Fixture/pattern_in_constant.php.inc
+++ b/packages/CodeQuality/tests/Rector/FuncCall/SimplifyRegexPatternRector/Fixture/pattern_in_constant.php.inc
@@ -2,14 +2,13 @@
 
 namespace Rector\CodeQuality\Tests\Rector\FuncCall\SimplifyRegexPatternRector\Fixture;
 
-use Nette\Utils\Strings;
-
-class SomeClass
+class PatternInConstant
 {
+    const PATTERN = '#[0-9]#';
+
     public function run($value)
     {
-        preg_match('#[0-9]#', $value);
-        Strings::match($value, '#[A-Za-z0-9_]+#');
+        preg_match(self::PATTERN, $value);
     }
 }
 
@@ -19,14 +18,13 @@ class SomeClass
 
 namespace Rector\CodeQuality\Tests\Rector\FuncCall\SimplifyRegexPatternRector\Fixture;
 
-use Nette\Utils\Strings;
-
-class SomeClass
+class PatternInConstant
 {
+    const PATTERN = '#\d#';
+
     public function run($value)
     {
-        preg_match('#\d#', $value);
-        Strings::match($value, '#\w+#');
+        preg_match(self::PATTERN, $value);
     }
 }
 

--- a/packages/CodeQuality/tests/Rector/FuncCall/SimplifyRegexPatternRector/SimplifyRegexPatternRectorTest.php
+++ b/packages/CodeQuality/tests/Rector/FuncCall/SimplifyRegexPatternRector/SimplifyRegexPatternRectorTest.php
@@ -10,7 +10,7 @@ final class SimplifyRegexPatternRectorTest extends AbstractRectorTestCase
     public function test(): void
     {
         $this->doTestFiles([
-            //            __DIR__ . '/Fixture/fixture.php.inc',
+            __DIR__ . '/Fixture/fixture.php.inc',
             __DIR__ . '/Fixture/pattern_in_constant.php.inc',
         ]);
     }

--- a/packages/CodeQuality/tests/Rector/FuncCall/SimplifyRegexPatternRector/SimplifyRegexPatternRectorTest.php
+++ b/packages/CodeQuality/tests/Rector/FuncCall/SimplifyRegexPatternRector/SimplifyRegexPatternRectorTest.php
@@ -9,7 +9,10 @@ final class SimplifyRegexPatternRectorTest extends AbstractRectorTestCase
 {
     public function test(): void
     {
-        $this->doTestFiles([__DIR__ . '/Fixture/fixture.php.inc']);
+        $this->doTestFiles([
+            //            __DIR__ . '/Fixture/fixture.php.inc',
+            __DIR__ . '/Fixture/pattern_in_constant.php.inc',
+        ]);
     }
 
     protected function getRectorClass(): string

--- a/packages/CodeQuality/tests/Rector/FuncCall/SimplifyRegexPatternRector/SimplifyRegexPatternRectorTest.php
+++ b/packages/CodeQuality/tests/Rector/FuncCall/SimplifyRegexPatternRector/SimplifyRegexPatternRectorTest.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Rector\CodeQuality\Tests\Rector\FuncCall\SimplifyRegexPatternRector;
+
+use Rector\CodeQuality\Rector\FuncCall\SimplifyRegexPatternRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class SimplifyRegexPatternRectorTest extends AbstractRectorTestCase
+{
+    public function test(): void
+    {
+        $this->doTestFiles([__DIR__ . '/Fixture/fixture.php.inc']);
+    }
+
+    protected function getRectorClass(): string
+    {
+        return SimplifyRegexPatternRector::class;
+    }
+}

--- a/packages/PHPUnit/tests/Rector/Class_/TestListenerToHooksRector/Fixture/clear_it_all.php.inc
+++ b/packages/PHPUnit/tests/Rector/Class_/TestListenerToHooksRector/Fixture/clear_it_all.php.inc
@@ -63,7 +63,7 @@ use PHPUnit\Framework\TestListener;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Framework\Warning;
 
-final class SomeListener implements TestListener
+final class SomeListener
 {
 }
 

--- a/packages/Php/src/Rector/FuncCall/RegexDashEscapeRector.php
+++ b/packages/Php/src/Rector/FuncCall/RegexDashEscapeRector.php
@@ -36,31 +36,6 @@ final class RegexDashEscapeRector extends AbstractRector
     private const RIGHT_HAND_UNESCAPED_DASH_PATTERN = '#(?<!\[)-\\\\(w|s|d)#i';
 
     /**
-     * @var int[]
-     */
-    private $functionsWithPatternsToArgumentPosition = [
-        'preg_match' => 0,
-        'preg_replace_callback_array' => 0,
-        'preg_replace_callback' => 0,
-        'preg_replace' => 0,
-        'preg_match_all' => 0,
-        'preg_split' => 0,
-        'preg_grep' => 0,
-    ];
-
-    /**
-     * @var int[][]
-     */
-    private $staticMethodsWithPatternsToArgumentPosition = [
-        'Nette\Utils\Strings' => [
-            'match' => 1,
-            'matchAll' => 1,
-            'replace' => 1,
-            'split' => 1,
-        ],
-    ];
-
-    /**
      * @var ConstantNodeCollector
      */
     private $constantNodeCollector;

--- a/packages/Php/tests/Rector/FuncCall/RegexDashEscapeRector/RegexDashEscapeRectorTest.php
+++ b/packages/Php/tests/Rector/FuncCall/RegexDashEscapeRector/RegexDashEscapeRectorTest.php
@@ -12,9 +12,10 @@ final class RegexDashEscapeRectorTest extends AbstractRectorTestCase
         $this->doTestFiles([
             __DIR__ . '/Fixture/fixture.php.inc',
             __DIR__ . '/Fixture/method_call.php.inc',
+            __DIR__ . '/Fixture/const.php.inc',
+            // variables
             __DIR__ . '/Fixture/variable.php.inc',
             __DIR__ . '/Fixture/multiple_variables.php.inc',
-            __DIR__ . '/Fixture/const.php.inc',
         ]);
     }
 

--- a/src/Php/Regex/RegexPatternArgumentManipulator.php
+++ b/src/Php/Regex/RegexPatternArgumentManipulator.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Php\Regex;
+
+use Nette\Utils\Strings;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\StaticCall;
+use Rector\NodeTypeResolver\NodeTypeResolver;
+use Rector\PhpParser\Node\Resolver\NameResolver;
+
+final class RegexPatternArgumentManipulator
+{
+    /**
+     * @var int[]
+     */
+    private $functionsWithPatternsToArgumentPosition = [
+        'preg_match' => 0,
+        'preg_replace_callback_array' => 0,
+        'preg_replace_callback' => 0,
+        'preg_replace' => 0,
+        'preg_match_all' => 0,
+        'preg_split' => 0,
+        'preg_grep' => 0,
+    ];
+
+    /**
+     * @var int[][]
+     */
+    private $staticMethodsWithPatternsToArgumentPosition = [
+        Strings::class => [
+            'match' => 1,
+            'matchAll' => 1,
+            'replace' => 1,
+            'split' => 1,
+        ],
+    ];
+
+    /**
+     * @var NodeTypeResolver
+     */
+    private $nodeTypeResolver;
+
+    /**
+     * @var NameResolver
+     */
+    private $nameResolver;
+
+    public function __construct(NodeTypeResolver $nodeTypeResolver, NameResolver $nameResolver)
+    {
+        $this->nodeTypeResolver = $nodeTypeResolver;
+        $this->nameResolver = $nameResolver;
+    }
+
+    public function matchCallArgumentWithRegexPattern(Expr $expr): ?Expr
+    {
+        if ($expr instanceof FuncCall) {
+            return $this->processFuncCall($expr);
+        }
+
+        if ($expr instanceof StaticCall) {
+            return $this->processStaticCall($expr);
+        }
+
+        return null;
+    }
+
+    private function processFuncCall(FuncCall $funcCall): ?Expr
+    {
+        foreach ($this->functionsWithPatternsToArgumentPosition as $functionName => $argumentPosition) {
+            if (! $this->nameResolver->isName($funcCall, $functionName)) {
+                continue;
+            }
+
+            if (! isset($funcCall->args[$argumentPosition])) {
+                return null;
+            }
+
+            return $funcCall->args[$argumentPosition]->value;
+        }
+
+        return null;
+    }
+
+    private function processStaticCall(StaticCall $staticCall): ?Expr
+    {
+        foreach ($this->staticMethodsWithPatternsToArgumentPosition as $type => $methodNamesToArgumentPosition) {
+            if (! $this->nodeTypeResolver->isType($staticCall, $type)) {
+                continue;
+            }
+
+            foreach ($methodNamesToArgumentPosition as $methodName => $argumentPosition) {
+                if (! $this->nameResolver->isName($staticCall, $methodName)) {
+                    continue;
+                }
+
+                if (! isset($staticCall->args[$argumentPosition])) {
+                    return null;
+                }
+
+                return $staticCall->args[$argumentPosition]->value;
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Use `\d` and `\w` when it shortens the expression

```diff
-preg_match('#[0-9]+#', $value);
+preg_match('#\d+#', $value);
```


```diff
-Nette\Utils\Strings::match($value,'#[A-Za-z0-9_]+#');
+Nette\Utils\Strings::match($value,'#\w+#');
```
