### PR TITLE
[Nette] Add nette-utils-code-quality level

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,12 +126,6 @@ vendor/bin/rector process src --level symfony40 --dry-run
 vendor/bin/rector process src --level symfony40
 ```
 
-Tip: To process just specific subdirectories, you can use [fnmatch](http://php.net/manual/en/function.fnmatch.php) pattern:
-
-```bash
-vendor/bin/rector process "src/Symfony/Component/*/Tests" --level phpunit60 --dry-run
-```
-
 ### B. Custom Sets
 
 1. Create `rector.yaml` with desired Rectors:

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,8 @@
             "Rector\\Laravel\\": "packages/Laravel/src",
             "Rector\\PhpSpecToPHPUnit\\": "packages/PhpSpecToPHPUnit/src",
             "Rector\\Shopware\\": "packages/Shopware/src",
-            "Rector\\NetteTesterToPHPUnit\\": "packages/NetteTesterToPHPUnit/src"
+            "Rector\\NetteTesterToPHPUnit\\": "packages/NetteTesterToPHPUnit/src",
+            "Rector\\Nette\\": "packages/Nette/src"
         }
     },
     "autoload-dev": {
@@ -92,7 +93,8 @@
             "Rector\\PhpSpecToPHPUnit\\Tests\\": "packages/PhpSpecToPHPUnit/tests",
             "Rector\\PHPStanExtensions\\": "utils/PHPStanExtensions/src",
             "Rector\\Shopware\\Tests\\": "packages/Shopware/tests",
-            "Rector\\NetteTesterToPHPUnit\\Tests\\": "packages/NetteTesterToPHPUnit/tests"
+            "Rector\\NetteTesterToPHPUnit\\Tests\\": "packages/NetteTesterToPHPUnit/tests",
+            "Rector\\Nette\\Tests\\": "packages/Nette/tests"
         },
         "classmap": [
             "packages/Symfony/tests/Rector/FrameworkBundle/AbstractToConstructorInjectionRectorSource",

--- a/config/level/nette/nette-utils-code-quality.yaml
+++ b/config/level/nette/nette-utils-code-quality.yaml
@@ -13,3 +13,5 @@ services:
     # strings
     Rector\Nette\Rector\NotIdentical\StrposToStringsContainsRector: ~
     Rector\Nette\Rector\FuncCall\SubstrStrlenFunctionToNetteUtilsStringsRector: ~
+    Rector\Nette\Rector\Identical\StartsWithFunctionToNetteUtilsStringsRector: ~
+    Rector\Nette\Rector\Identical\EndsWithFunctionToNetteUtilsStringsRector: ~

--- a/config/level/nette/nette-utils-code-quality.yaml
+++ b/config/level/nette/nette-utils-code-quality.yaml
@@ -1,3 +1,4 @@
+# @see https://www.tomasvotruba.cz/blog/2018/07/30/hidden-gems-of-php-packages-nette-utils/
 services:
     Rector\Rector\Function_\FunctionToStaticCallRector:
         # filesystem
@@ -10,3 +11,4 @@ services:
         json_encode: ['Nette\Utils\Json', 'encode']
 
         # strings
+    Rector\Nette\Rector\NotIdentical\StrposToStringsContainsRector: ~

--- a/config/level/nette/nette-utils-code-quality.yaml
+++ b/config/level/nette/nette-utils-code-quality.yaml
@@ -1,0 +1,12 @@
+services:
+    Rector\Rector\Function_\FunctionToStaticCallRector:
+        # filesystem
+        file_get_contents: ['Nette\Utils\FileSystem', 'read']
+        unlink: ['Nette\Utils\FileSystem', 'delete']
+        rmdir: ['Nette\Utils\FileSystem', 'delete']
+
+        # json
+        json_decode: ['Nette\Utils\Json', 'decode']
+        json_encode: ['Nette\Utils\Json', 'encode']
+
+        # strings

--- a/config/level/nette/nette-utils-code-quality.yaml
+++ b/config/level/nette/nette-utils-code-quality.yaml
@@ -10,5 +10,6 @@ services:
         json_decode: ['Nette\Utils\Json', 'decode']
         json_encode: ['Nette\Utils\Json', 'encode']
 
-        # strings
+    # strings
     Rector\Nette\Rector\NotIdentical\StrposToStringsContainsRector: ~
+    Rector\Nette\Rector\FuncCall\SubstrStrlenFunctionToNetteUtilsStringsRector: ~

--- a/packages/Nette/src/Rector/FuncCall/SubstrStrlenFunctionToNetteUtilsStringsRector.php
+++ b/packages/Nette/src/Rector/FuncCall/SubstrStrlenFunctionToNetteUtilsStringsRector.php
@@ -63,10 +63,7 @@ CODE_SAMPLE
     {
         foreach ($this->functionToStaticMethod as $function => $staticMethod) {
             if ($this->isName($node, $function)) {
-                $staticCall = $this->createStaticCall('Nette\Utils\Strings', $staticMethod);
-                $staticCall->args = $node->args;
-
-                return $staticCall;
+                return $this->createStaticCall('Nette\Utils\Strings', $staticMethod, $node->args);
             }
         }
 

--- a/packages/Nette/src/Rector/FuncCall/SubstrStrlenFunctionToNetteUtilsStringsRector.php
+++ b/packages/Nette/src/Rector/FuncCall/SubstrStrlenFunctionToNetteUtilsStringsRector.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Nette\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use Rector\Rector\AbstractRector;
+use Rector\RectorDefinition\CodeSample;
+use Rector\RectorDefinition\RectorDefinition;
+
+/**
+ * @see https://github.com/nette/utils/blob/master/src/Utils/Strings.php
+ */
+final class SubstrStrlenFunctionToNetteUtilsStringsRector extends AbstractRector
+{
+    /**
+     * @var string[]
+     */
+    private $functionToStaticMethod = [
+        'substr' => 'substring',
+        'strlen' => 'length',
+    ];
+
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Use Nette\Utils\Strings over bare string-functions', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run()
+    {
+        return substr($value, 0, 3);
+    }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run()
+    {
+        return \Nette\Utils\Strings::substring($value, 0, 3);
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    /**
+     * @param FuncCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        foreach ($this->functionToStaticMethod as $function => $staticMethod) {
+            if ($this->isName($node, $function)) {
+                $staticCall = $this->createStaticCall('Nette\Utils\Strings', $staticMethod);
+                $staticCall->args = $node->args;
+
+                return $staticCall;
+            }
+        }
+
+        return null;
+    }
+}

--- a/packages/Nette/src/Rector/Identical/EndsWithFunctionToNetteUtilsStringsRector.php
+++ b/packages/Nette/src/Rector/Identical/EndsWithFunctionToNetteUtilsStringsRector.php
@@ -1,0 +1,129 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Nette\Rector\Identical;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\BinaryOp\Identical;
+use PhpParser\Node\Expr\BinaryOp\NotIdentical;
+use Rector\Rector\AbstractRector;
+use Rector\RectorDefinition\CodeSample;
+use Rector\RectorDefinition\RectorDefinition;
+
+/**
+ * @see https://github.com/nette/utils/blob/master/src/Utils/Strings.php
+ */
+final class EndsWithFunctionToNetteUtilsStringsRector extends AbstractRector
+{
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Use Nette\Utils\Strings over bare string-functions', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function end($needle)
+    {
+        $content = 'Hi, my name is Tom';
+
+        $yes = substr($content, -strlen($needle)) === $needle;
+        $no = $needle !== substr($content, -strlen($needle));
+    }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function end($needle)
+    {
+        $content = 'Hi, my name is Tom';
+
+        $yes = \Nette\Utils\Strings::endsWith($content, $needle);
+        $no = !\Nette\Utils\Strings::endsWith($content, $needle);
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [Identical::class, NotIdentical::class];
+    }
+
+    /**
+     * @param Identical|NotIdentical $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $contentAndNeedle = null;
+
+        if ($node->left instanceof Node\Expr\Variable) {
+            $contentAndNeedle = $this->matchContentAndNeedleOfSubstrOfVariableLength($node->right, $node->left);
+        }
+
+        if ($node->right instanceof Node\Expr\Variable) {
+            $contentAndNeedle = $this->matchContentAndNeedleOfSubstrOfVariableLength($node->left, $node->right);
+        }
+
+        if ($contentAndNeedle === null) {
+            return null;
+        }
+
+        [$contentNode, $needleNode] = $contentAndNeedle;
+
+        // starts with
+        $startsWithStaticCall = $this->createStaticCall('Nette\Utils\Strings', 'endsWith', [
+            new Node\Arg($contentNode),
+            new Node\Arg($needleNode),
+        ]);
+
+        if ($node instanceof Node\Expr\BinaryOp\NotIdentical) {
+            return new Node\Expr\BooleanNot($startsWithStaticCall);
+        }
+
+        return $startsWithStaticCall;
+    }
+
+    /**
+     * @return Node\Expr[]|null
+     */
+    private function matchContentAndNeedleOfSubstrOfVariableLength(Node $node, Node\Expr\Variable $variable): ?array
+    {
+        if (! $node instanceof Node\Expr\FuncCall) {
+            return null;
+        }
+
+        if (! $this->isName($node, 'substr')) {
+            return null;
+        }
+
+        if (! $node->args[1]->value instanceof Node\Expr\UnaryMinus) {
+            return null;
+        }
+
+        /** @var Node\Expr\UnaryMinus $unaryMinus */
+        $unaryMinus = $node->args[1]->value;
+
+        if (! $unaryMinus->expr instanceof Node\Expr\FuncCall) {
+            return null;
+        }
+
+        if (! $this->isName($unaryMinus->expr, 'strlen')) {
+            return null;
+        }
+
+        /** @var Node\Expr\FuncCall $strlenFuncCall */
+        $strlenFuncCall = $unaryMinus->expr;
+
+        if ($this->areNodesEqual($strlenFuncCall->args[0]->value, $variable)) {
+            return [$node->args[0]->value, $strlenFuncCall->args[0]->value];
+        }
+
+        return null;
+    }
+}

--- a/packages/Nette/src/Rector/Identical/StartsWithFunctionToNetteUtilsStringsRector.php
+++ b/packages/Nette/src/Rector/Identical/StartsWithFunctionToNetteUtilsStringsRector.php
@@ -1,0 +1,128 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Nette\Rector\Identical;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\BinaryOp\Identical;
+use PhpParser\Node\Expr\BinaryOp\NotIdentical;
+use Rector\Rector\AbstractRector;
+use Rector\RectorDefinition\CodeSample;
+use Rector\RectorDefinition\RectorDefinition;
+
+/**
+ * @see https://github.com/nette/utils/blob/master/src/Utils/Strings.php
+ */
+final class StartsWithFunctionToNetteUtilsStringsRector extends AbstractRector
+{
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Use Nette\Utils\Strings over bare string-functions', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function start($needle)
+    {
+        $content = 'Hi, my name is Tom';
+
+        $yes = substr($content, 0, strlen($needle)) === $needle;
+        $no = $needle !== substr($content, 0, strlen($needle));
+    }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function start($needle)
+    {
+        $content = 'Hi, my name is Tom';
+
+        $yes = \Nette\Utils\Strings::startwith($content, $needle);
+        $no = !\Nette\Utils\Strings::startwith($content, $needle);
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [Identical::class, NotIdentical::class];
+    }
+
+    /**
+     * @param Identical|NotIdentical $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $contentAndNeedle = null;
+
+        if ($node->left instanceof Node\Expr\Variable) {
+            $contentAndNeedle = $this->matchContentAndNeedleOfSubstrOfVariableLength($node->right, $node->left);
+        }
+
+        if ($node->right instanceof Node\Expr\Variable) {
+            $contentAndNeedle = $this->matchContentAndNeedleOfSubstrOfVariableLength($node->left, $node->right);
+        }
+
+        if ($contentAndNeedle === null) {
+            return null;
+        }
+
+        [$contentNode, $needleNode] = $contentAndNeedle;
+
+        // starts with
+        $startsWithStaticCall = $this->createStaticCall('Nette\Utils\Strings', 'startsWith', [
+            new Node\Arg($contentNode),
+            new Node\Arg($needleNode),
+        ]);
+
+        if ($node instanceof Node\Expr\BinaryOp\NotIdentical) {
+            return new Node\Expr\BooleanNot($startsWithStaticCall);
+        }
+
+        return $startsWithStaticCall;
+    }
+
+    /**
+     * @return Node\Expr[]|null
+     */
+    private function matchContentAndNeedleOfSubstrOfVariableLength(Node $node, Node\Expr\Variable $variable): ?array
+    {
+        if (! $node instanceof Node\Expr\FuncCall) {
+            return null;
+        }
+
+        if (! $this->isName($node, 'substr')) {
+            return null;
+        }
+        if (! $this->isValue($node->args[1]->value, 0)) {
+            return null;
+        }
+
+        if (! isset($node->args[2])) {
+            return null;
+        }
+
+        if (! $node->args[2]->value instanceof Node\Expr\FuncCall) {
+            return null;
+        }
+
+        if (! $this->isName($node->args[2]->value, 'strlen')) {
+            return null;
+        }
+
+        /** @var Node\Expr\FuncCall $strlenFuncCall */
+        $strlenFuncCall = $node->args[2]->value;
+        if ($this->areNodesEqual($strlenFuncCall->args[0]->value, $variable)) {
+            return [$node->args[0]->value, $strlenFuncCall->args[0]->value];
+        }
+
+        return null;
+    }
+}

--- a/packages/Nette/src/Rector/NotIdentical/StrposToStringsContainsRector.php
+++ b/packages/Nette/src/Rector/NotIdentical/StrposToStringsContainsRector.php
@@ -1,0 +1,102 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Nette\Rector\NotIdentical;
+
+use PhpParser\Node;
+use Rector\Rector\AbstractRector;
+use Rector\RectorDefinition\CodeSample;
+use Rector\RectorDefinition\RectorDefinition;
+
+/**
+ * @see https://3v4l.org/CubLi
+ * @see https://github.com/nette/utils/blob/bd961f49b211997202bda1d0fbc410905be370d4/src/Utils/Strings.php#L81
+ */
+final class StrposToStringsContainsRector extends AbstractRector
+{
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Use Nette\Utils\Strings over bare string-functions', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run()
+    {
+        $name = 'Hi, my name is Tom';
+        return strpos($name, 'Hi') !== false;
+    }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run()
+    {
+        $name = 'Hi, my name is Tom';
+        return \Nette\Utils\Strings::contains($name, 'Hi');
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [Node\Expr\BinaryOp\NotIdentical::class, Node\Expr\BinaryOp\Identical::class];
+    }
+
+    /**
+     * @param Node\Expr\BinaryOp\NotIdentical|Node\Expr\BinaryOp\Identical $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $strpos = $this->matchStrposInComparisonToFalse($node);
+        if ($strpos === null) {
+            return null;
+        }
+
+        if (isset($strpos->args[2]) && ! $this->isValue($strpos->args[2]->value, 0)) {
+            return null;
+        }
+
+        $containsStaticCall = new Node\Expr\StaticCall(new Node\Name\FullyQualified('Nette\Utils\Strings'), 'contains');
+        $containsStaticCall->args[0] = $strpos->args[0];
+        $containsStaticCall->args[1] = $strpos->args[1];
+
+        if ($node instanceof Node\Expr\BinaryOp\Identical) {
+            return new Node\Expr\BooleanNot($containsStaticCall);
+        }
+
+        return $containsStaticCall;
+    }
+
+    private function matchStrposInComparisonToFalse(Node\Expr\BinaryOp $binaryOp): ?Node\Expr\FuncCall
+    {
+        if ($this->isFalse($binaryOp->left)) {
+            if (! $binaryOp->right instanceof Node\Expr\FuncCall) {
+                return null;
+            }
+
+            if ($this->isName($binaryOp->right, 'strpos')) {
+                return $binaryOp->right;
+            }
+        }
+
+        if ($this->isFalse($binaryOp->right)) {
+            if (! $binaryOp->left instanceof Node\Expr\FuncCall) {
+                return null;
+            }
+
+            if ($this->isName($binaryOp->left, 'strpos')) {
+                return $binaryOp->left;
+            }
+        }
+
+        return null;
+    }
+}

--- a/packages/Nette/tests/Rector/FuncCall/SubstrStrlenFunctionToNetteUtilsStringsRector/Fixture/strlen.php.inc
+++ b/packages/Nette/tests/Rector/FuncCall/SubstrStrlenFunctionToNetteUtilsStringsRector/Fixture/strlen.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Nette\Tests\Rector\FuncCall\SubstrStrlenFunctionToNetteUtilsStringsRector\Fixture;
+
+class Strlen
+{
+    public function run($value)
+    {
+        return strlen($value);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Nette\Tests\Rector\FuncCall\SubstrStrlenFunctionToNetteUtilsStringsRector\Fixture;
+
+class Strlen
+{
+    public function run($value)
+    {
+        return \Nette\Utils\Strings::length($value);
+    }
+}
+
+?>

--- a/packages/Nette/tests/Rector/FuncCall/SubstrStrlenFunctionToNetteUtilsStringsRector/Fixture/substr.php.inc
+++ b/packages/Nette/tests/Rector/FuncCall/SubstrStrlenFunctionToNetteUtilsStringsRector/Fixture/substr.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Nette\Tests\Rector\FuncCall\SubstrStrlenFunctionToNetteUtilsStringsRector\Fixture;
+
+class SomeClass
+{
+    public function run()
+    {
+        return substr($value, 0, 3);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Nette\Tests\Rector\FuncCall\SubstrStrlenFunctionToNetteUtilsStringsRector\Fixture;
+
+class SomeClass
+{
+    public function run()
+    {
+        return \Nette\Utils\Strings::substring($value, 0, 3);
+    }
+}
+
+?>

--- a/packages/Nette/tests/Rector/FuncCall/SubstrStrlenFunctionToNetteUtilsStringsRector/SubstrStrlenFunctionToNetteUtilsStringsRectorTest.php
+++ b/packages/Nette/tests/Rector/FuncCall/SubstrStrlenFunctionToNetteUtilsStringsRector/SubstrStrlenFunctionToNetteUtilsStringsRectorTest.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Nette\Tests\Rector\FuncCall\SubstrStrlenFunctionToNetteUtilsStringsRector;
+
+use Rector\Nette\Rector\FuncCall\SubstrStrlenFunctionToNetteUtilsStringsRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class SubstrStrlenFunctionToNetteUtilsStringsRectorTest extends AbstractRectorTestCase
+{
+    public function test(): void
+    {
+        $this->doTestFiles([__DIR__ . '/Fixture/substr.php.inc', __DIR__ . '/Fixture/strlen.php.inc']);
+    }
+
+    protected function getRectorClass(): string
+    {
+        return SubstrStrlenFunctionToNetteUtilsStringsRector::class;
+    }
+}

--- a/packages/Nette/tests/Rector/Identical/EndsWithFunctionToNetteUtilsStringsRector/EndsWithFunctionToNetteUtilsStringsRectorTest.php
+++ b/packages/Nette/tests/Rector/Identical/EndsWithFunctionToNetteUtilsStringsRector/EndsWithFunctionToNetteUtilsStringsRectorTest.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Nette\Tests\Rector\Identical\EndsWithFunctionToNetteUtilsStringsRector;
+
+use Rector\Nette\Rector\Identical\EndsWithFunctionToNetteUtilsStringsRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class EndsWithFunctionToNetteUtilsStringsRectorTest extends AbstractRectorTestCase
+{
+    public function test(): void
+    {
+        $this->doTestFiles([__DIR__ . '/Fixture/fixture.php.inc']);
+    }
+
+    protected function getRectorClass(): string
+    {
+        return EndsWithFunctionToNetteUtilsStringsRector::class;
+    }
+}

--- a/packages/Nette/tests/Rector/Identical/EndsWithFunctionToNetteUtilsStringsRector/Fixture/fixture.php.inc
+++ b/packages/Nette/tests/Rector/Identical/EndsWithFunctionToNetteUtilsStringsRector/Fixture/fixture.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Nette\Tests\Rector\Identical\EndsWithFunctionToNetteUtilsStringsRector\Fixture;
+
+class SomeClass
+{
+    public function end($needle)
+    {
+        $content = 'Hi, my name is Tom';
+
+        $yes = substr($content, -strlen($needle)) === $needle;
+        $no = $needle !== substr($content, -strlen($needle));
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Nette\Tests\Rector\Identical\EndsWithFunctionToNetteUtilsStringsRector\Fixture;
+
+class SomeClass
+{
+    public function end($needle)
+    {
+        $content = 'Hi, my name is Tom';
+
+        $yes = \Nette\Utils\Strings::endsWith($content, $needle);
+        $no = !\Nette\Utils\Strings::endsWith($content, $needle);
+    }
+}
+
+?>

--- a/packages/Nette/tests/Rector/Identical/StartsWithFunctionToNetteUtilsStringsRector/Fixture/fixture.php.inc
+++ b/packages/Nette/tests/Rector/Identical/StartsWithFunctionToNetteUtilsStringsRector/Fixture/fixture.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Nette\Tests\Rector\Identical\StartsWithFunctionToNetteUtilsStringsRector\Fixture;
+
+class SomeClass
+{
+    public function start($needle)
+    {
+        $content = 'Hi, my name is Tom';
+
+        $yes = substr($content, 0, strlen($needle)) === $needle;
+        $no = $needle !== substr($content, 0, strlen($needle));
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Nette\Tests\Rector\Identical\StartsWithFunctionToNetteUtilsStringsRector\Fixture;
+
+class SomeClass
+{
+    public function start($needle)
+    {
+        $content = 'Hi, my name is Tom';
+
+        $yes = \Nette\Utils\Strings::startsWith($content, $needle);
+        $no = !\Nette\Utils\Strings::startsWith($content, $needle);
+    }
+}
+
+?>

--- a/packages/Nette/tests/Rector/Identical/StartsWithFunctionToNetteUtilsStringsRector/StartsWithFunctionToNetteUtilsStringsRectorTest.php
+++ b/packages/Nette/tests/Rector/Identical/StartsWithFunctionToNetteUtilsStringsRector/StartsWithFunctionToNetteUtilsStringsRectorTest.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Nette\Tests\Rector\Identical\StartsWithFunctionToNetteUtilsStringsRector;
+
+use Rector\Nette\Rector\Identical\StartsWithFunctionToNetteUtilsStringsRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class StartsWithFunctionToNetteUtilsStringsRectorTest extends AbstractRectorTestCase
+{
+    public function test(): void
+    {
+        $this->doTestFiles([__DIR__ . '/Fixture/fixture.php.inc']);
+    }
+
+    protected function getRectorClass(): string
+    {
+        return StartsWithFunctionToNetteUtilsStringsRector::class;
+    }
+}

--- a/packages/Nette/tests/Rector/NotIdentical/StrposToStringsContainsRector/Fixture/fixture.php.inc
+++ b/packages/Nette/tests/Rector/NotIdentical/StrposToStringsContainsRector/Fixture/fixture.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Nette\Tests\Rector\NotIdentical\StrposToStringsContainsRector\Fixture;
+
+class SomeClass
+{
+    public function run()
+    {
+        $name = 'Hi, my name is Tom';
+
+        $again = FALSE !== strpos($name, 'Hi');
+        $nope = FALSE === strpos($name, 'Hi');
+
+        $andAgain = FALSE !== strpos($name, 'Hi', 0);
+
+        return strpos($name, 'Hi') !== false;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Nette\Tests\Rector\NotIdentical\StrposToStringsContainsRector\Fixture;
+
+class SomeClass
+{
+    public function run()
+    {
+        $name = 'Hi, my name is Tom';
+
+        $again = \Nette\Utils\Strings::contains($name, 'Hi');
+        $nope = !\Nette\Utils\Strings::contains($name, 'Hi');
+
+        $andAgain = \Nette\Utils\Strings::contains($name, 'Hi');
+
+        return \Nette\Utils\Strings::contains($name, 'Hi');
+    }
+}
+
+?>

--- a/packages/Nette/tests/Rector/NotIdentical/StrposToStringsContainsRector/Fixture/keep.php.inc
+++ b/packages/Nette/tests/Rector/NotIdentical/StrposToStringsContainsRector/Fixture/keep.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Nette\Tests\Rector\NotIdentical\StrposToStringsContainsRector\Fixture;
+
+class Keep
+{
+    public function run()
+    {
+        $name = 'Hi my name is Tom';
+        $again = FALSE !== strpos($name, 'Hi', 2);
+    }
+}

--- a/packages/Nette/tests/Rector/NotIdentical/StrposToStringsContainsRector/StrposToStringsContainsRectorTest.php
+++ b/packages/Nette/tests/Rector/NotIdentical/StrposToStringsContainsRector/StrposToStringsContainsRectorTest.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Nette\Tests\Rector\NotIdentical\StrposToStringsContainsRector;
+
+use Rector\Nette\Rector\NotIdentical\StrposToStringsContainsRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class StrposToStringsContainsRectorTest extends AbstractRectorTestCase
+{
+    public function test(): void
+    {
+        $this->doTestFiles([__DIR__ . '/Fixture/fixture.php.inc', __DIR__ . '/Fixture/keep.php.inc']);
+    }
+
+    protected function getRectorClass(): string
+    {
+        return StrposToStringsContainsRector::class;
+    }
+}

--- a/packages/NetteToSymfony/src/Rector/Class_/NetteControlToSymfonyControllerRector.php
+++ b/packages/NetteToSymfony/src/Rector/Class_/NetteControlToSymfonyControllerRector.php
@@ -11,7 +11,6 @@ use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
-use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\String_;
@@ -146,7 +145,7 @@ CODE_SAMPLE
 
         $this->collectTemplateFileNameAndVariables($classMethod);
 
-        $thisRenderMethod = new MethodCall(new Variable('this'), 'render');
+        $thisRenderMethod = $this->createMethodCall('this', 'render');
 
         if ($this->templateFileExpr !== null) {
             $thisRenderMethod->args[0] = new Arg($this->templateFileExpr);

--- a/packages/NetteToSymfony/src/Rector/Class_/NetteFormToSymfonyFormRector.php
+++ b/packages/NetteToSymfony/src/Rector/Class_/NetteFormToSymfonyFormRector.php
@@ -8,7 +8,6 @@ use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
-use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Scalar\String_;
 use Rector\NodeTypeResolver\Node\Attribute;
@@ -155,7 +154,7 @@ CODE_SAMPLE
             return null;
         }
 
-        return new MethodCall(new Variable('this'), 'createFormBuilder');
+        return $this->createMethodCall('this', 'createFormBuilder');
     }
 
     private function addChoiceTypeOptions(string $method, Array_ $optionsArray): void

--- a/packages/Php/src/Rector/MethodCall/PreferThisOrSelfMethodCallRector.php
+++ b/packages/Php/src/Rector/MethodCall/PreferThisOrSelfMethodCallRector.php
@@ -6,7 +6,6 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Name;
 use Rector\Exception\Rector\InvalidRectorConfigurationException;
 use Rector\Rector\AbstractRector;
 use Rector\RectorDefinition\ConfiguredCodeSample;
@@ -129,7 +128,12 @@ CODE_SAMPLE
             return null;
         }
 
-        return new StaticCall(new Name('self'), $node->name);
+        $name = $this->getName($node->name);
+        if ($name === null) {
+            return null;
+        }
+
+        return $this->createStaticCall('self', $name);
     }
 
     /**

--- a/packages/Php/src/Rector/MethodCall/PreferThisOrSelfMethodCallRector.php
+++ b/packages/Php/src/Rector/MethodCall/PreferThisOrSelfMethodCallRector.php
@@ -5,7 +5,6 @@ namespace Rector\Php\Rector\MethodCall;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
-use PhpParser\Node\Expr\Variable;
 use Rector\Exception\Rector\InvalidRectorConfigurationException;
 use Rector\Rector\AbstractRector;
 use Rector\RectorDefinition\ConfiguredCodeSample;
@@ -149,6 +148,11 @@ CODE_SAMPLE
             return null;
         }
 
-        return new MethodCall(new Variable('this'), $node->name);
+        $name = $this->getName($node->name);
+        if ($name === null) {
+            return null;
+        }
+
+        return $this->createMethodCall('this', $name);
     }
 }

--- a/packages/Php/src/Rector/MethodCall/ThisCallOnStaticMethodToStaticCallRector.php
+++ b/packages/Php/src/Rector/MethodCall/ThisCallOnStaticMethodToStaticCallRector.php
@@ -4,8 +4,6 @@ namespace Rector\Php\Rector\MethodCall;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Expr\StaticCall;
-use PhpParser\Node\Name;
 use Rector\NodeTypeResolver\Application\FunctionLikeNodeCollector;
 use Rector\NodeTypeResolver\Node\Attribute;
 use Rector\Rector\AbstractRector;
@@ -99,6 +97,6 @@ CODE_SAMPLE
             return null;
         }
 
-        return new StaticCall(new Name('self'), $methodName);
+        return $this->createStaticCall('self', $methodName);
     }
 }

--- a/packages/PhpSpecToPHPUnit/src/Rector/MethodCall/PhpSpecMocksToPHPUnitMocksRector.php
+++ b/packages/PhpSpecToPHPUnit/src/Rector/MethodCall/PhpSpecMocksToPHPUnitMocksRector.php
@@ -157,7 +157,7 @@ final class PhpSpecMocksToPHPUnitMocksRector extends AbstractPhpSpecToPHPUnitRec
             $expectedArg = $methodCall->var->args[0]->value ?? null;
 
             $methodCall->var->name = new Identifier('expects');
-            $thisOnceMethodCall = new MethodCall(new Variable('this'), new Identifier('atLeastOnce'));
+            $thisOnceMethodCall = $this->createMethodCall('this', 'atLeastOnce');
             $methodCall->var->args = [new Arg($thisOnceMethodCall)];
 
             $methodCall->name = new Identifier('method');
@@ -189,7 +189,7 @@ final class PhpSpecMocksToPHPUnitMocksRector extends AbstractPhpSpecToPHPUnitRec
                 }
             }
         } else {
-            $newExpr = new MethodCall(new Variable('this'), 'equalTo');
+            $newExpr = $this->createMethodCall('this', 'equalTo');
             $newExpr->args = [new Arg($expr)];
             $expr = $newExpr;
         }
@@ -201,7 +201,7 @@ final class PhpSpecMocksToPHPUnitMocksRector extends AbstractPhpSpecToPHPUnitRec
 
     private function createNewMockVariableAssign(Param $param, Name $name): Expression
     {
-        $methodCall = new MethodCall(new Variable('this'), 'createMock');
+        $methodCall = $this->createMethodCall('this', 'createMock');
         $methodCall->args[] = new Arg(new ClassConstFetch($name, 'class'));
 
         $assign = new Assign($param->var, $methodCall);
@@ -223,7 +223,7 @@ final class PhpSpecMocksToPHPUnitMocksRector extends AbstractPhpSpecToPHPUnitRec
 
         $propertyFetch = new PropertyFetch(new Variable('this'), $variable);
 
-        $methodCall = new MethodCall(new Variable('this'), 'createMock');
+        $methodCall = $this->createMethodCall('this', 'createMock');
         $methodCall->args[] = new Arg(new ClassConstFetch($name, 'class'));
 
         $assign = new Assign($propertyFetch, $methodCall);
@@ -237,6 +237,6 @@ final class PhpSpecMocksToPHPUnitMocksRector extends AbstractPhpSpecToPHPUnitRec
 
         $name = $this->typeAnalyzer->isPhpReservedType($type) ? 'isType' : 'isInstanceOf';
 
-        return new MethodCall(new Variable('this'), $name, $staticCall->args);
+        return $this->createMethodCall('this', $name, $staticCall->args);
     }
 }

--- a/packages/PhpSpecToPHPUnit/src/Rector/MethodCall/PhpSpecPromisesToPHPUnitAssertRector.php
+++ b/packages/PhpSpecToPHPUnit/src/Rector/MethodCall/PhpSpecPromisesToPHPUnitAssertRector.php
@@ -263,7 +263,7 @@ final class PhpSpecPromisesToPHPUnitAssertRector extends AbstractPhpSpecToPHPUni
         if ($this->isName($methodCall, 'beConstructedThrough')) {
             // static method
             $methodName = $this->getValue($methodCall->args[0]->value);
-            $staticCall = new StaticCall(new FullyQualified($this->testedClass), $methodName);
+            $staticCall = $this->createStaticCall($this->testedClass, $methodName);
 
             $this->moveConstructorArguments($methodCall, $staticCall);
 

--- a/packages/PhpSpecToPHPUnit/src/Rector/MethodCall/PhpSpecPromisesToPHPUnitAssertRector.php
+++ b/packages/PhpSpecToPHPUnit/src/Rector/MethodCall/PhpSpecPromisesToPHPUnitAssertRector.php
@@ -221,7 +221,7 @@ final class PhpSpecPromisesToPHPUnitAssertRector extends AbstractPhpSpecToPHPUni
             $name = $this->resolveBoolMethodName($name, $expected);
         }
 
-        $assetMethodCall = new MethodCall(new Variable('this'), new Identifier($name));
+        $assetMethodCall = $this->createMethodCall('this', $name);
 
         if (! $this->isBoolAssert && $expected) {
             $assetMethodCall->args[] = new Arg($this->thisToTestedObjectPropertyFetch($expected));
@@ -305,7 +305,7 @@ final class PhpSpecPromisesToPHPUnitAssertRector extends AbstractPhpSpecToPHPUni
             }
 
             // 1. assign callable to variable
-            $thisGetMatchers = new MethodCall(new Variable('this'), 'getMatchers');
+            $thisGetMatchers = $this->createMethodCall('this', 'getMatchers');
             $arrayDimFetch = new ArrayDimFetch($thisGetMatchers, new String_($matcherKey));
             $matcherCallableVariable = new Variable('matcherCallable');
             $assign = new Assign($matcherCallableVariable, $arrayDimFetch);

--- a/packages/Silverstripe/src/Rector/ConstantToStaticCallRector.php
+++ b/packages/Silverstripe/src/Rector/ConstantToStaticCallRector.php
@@ -6,8 +6,6 @@ use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\ConstFetch;
-use PhpParser\Node\Expr\StaticCall;
-use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\String_;
 use Rector\Rector\AbstractRector;
 use Rector\RectorDefinition\CodeSample;
@@ -44,9 +42,6 @@ final class ConstantToStaticCallRector extends AbstractRector
             return null;
         }
 
-        $staticCallNode = new StaticCall(new FullyQualified('Environment'), 'getEnv');
-        $staticCallNode->args[] = new Arg(new String_($constantName));
-
-        return $staticCallNode;
+        return $this->createStaticCall('Environment', 'getEnv', [new Arg(new String_($constantName))]);
     }
 }

--- a/packages/Silverstripe/src/Rector/DefineConstantToStaticCallRector.php
+++ b/packages/Silverstripe/src/Rector/DefineConstantToStaticCallRector.php
@@ -5,8 +5,6 @@ namespace Rector\Silverstripe\Rector;
 use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
-use PhpParser\Node\Expr\StaticCall;
-use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\String_;
 use Rector\Rector\AbstractRector;
 use Rector\RectorDefinition\CodeSample;
@@ -51,9 +49,6 @@ final class DefineConstantToStaticCallRector extends AbstractRector
             return null;
         }
 
-        $staticCallNode = new StaticCall(new FullyQualified('Environment'), 'getEnv');
-        $staticCallNode->args = $node->args;
-
-        return $staticCallNode;
+        return $this->createStaticCall('Environment', 'getEnv', $node->args);
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -144,4 +144,5 @@ parameters:
         - '#Method Rector\\NodeTypeResolver\\NodeVisitor\\(.*?)\:\:enterNode\(\) should return int\|PhpParser\\Node\|void\|null but return statement is missing#'
         - '#Negated boolean expression is always true#'
         - '#Strict comparison using \=\=\= between PhpParser\\Node and null will always evaluate to false#'
-
+        - '#In method "Rector\\FileSystemRector\\Rector\\AbstractFileSystemRector\:\:createStaticCall", parameter \$args type is "array"\. Please provide a @param annotation to further specify the type of the array\. For instance\: @param int\[\] \$args\. More info\: http\://bit\.ly/typehintarray#'
+        - '#In method "Rector\\Rector\\AbstractRector\:\:createStaticCall", parameter \$args type is "array"\. Please provide a @param annotation to further specify the type of the array\. For instance\: @param int\[\] \$args\. More info\: http\://bit\.ly/typehintarray#'

--- a/src/Rector/Function_/FunctionToStaticCallRector.php
+++ b/src/Rector/Function_/FunctionToStaticCallRector.php
@@ -4,8 +4,6 @@ namespace Rector\Rector\Function_;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
-use PhpParser\Node\Expr\StaticCall;
-use PhpParser\Node\Name\FullyQualified;
 use Rector\Rector\AbstractRector;
 use Rector\RectorDefinition\ConfiguredCodeSample;
 use Rector\RectorDefinition\RectorDefinition;
@@ -58,7 +56,7 @@ final class FunctionToStaticCallRector extends AbstractRector
 
             [$className, $methodName] = $staticCall;
 
-            return new StaticCall(new FullyQualified($className), $methodName, $node->args);
+            return $this->createStaticCall($className, $methodName, $node->args);
         }
 
         return null;

--- a/src/Rector/New_/NewToStaticCallRector.php
+++ b/src/Rector/New_/NewToStaticCallRector.php
@@ -4,8 +4,6 @@ namespace Rector\Rector\New_;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\New_;
-use PhpParser\Node\Expr\StaticCall;
-use PhpParser\Node\Name\FullyQualified;
 use Rector\Rector\AbstractRector;
 use Rector\RectorDefinition\ConfiguredCodeSample;
 use Rector\RectorDefinition\RectorDefinition;
@@ -74,9 +72,7 @@ CODE_SAMPLE
                 continue;
             }
 
-            $className = new FullyQualified($staticCall[0]);
-
-            return new StaticCall($className, $staticCall[1], $node->args);
+            return $this->createStaticCall($staticCall[0], $staticCall[1], $node->args);
         }
 
         return $node;

--- a/src/Rector/NodeFactoryTrait.php
+++ b/src/Rector/NodeFactoryTrait.php
@@ -34,9 +34,18 @@ trait NodeFactoryTrait
         $this->nodeFactory = $nodeFactory;
     }
 
-    protected function createStaticCall(string $class, string $method): Expr\StaticCall
+    /**
+     * @param Arg[] $args
+     */
+    protected function createStaticCall(string $class, string $method, array $args = []): Expr\StaticCall
     {
-        return new Node\Expr\StaticCall(new Node\Name\FullyQualified($class), $method);
+        if (in_array($class, ['self', 'parent', 'static'], true)) {
+            $class = new Name($class);
+        } else {
+            $class = new Name\FullyQualified($class);
+        }
+
+        return new Node\Expr\StaticCall($class, $method, $args);
     }
 
     protected function createClassConstant(string $class, string $constant): ClassConstFetch

--- a/src/Rector/NodeFactoryTrait.php
+++ b/src/Rector/NodeFactoryTrait.php
@@ -34,7 +34,12 @@ trait NodeFactoryTrait
         $this->nodeFactory = $nodeFactory;
     }
 
-    public function createClassConstant(string $class, string $constant): ClassConstFetch
+    protected function createStaticCall(string $class, string $method): Expr\StaticCall
+    {
+        return new Node\Expr\StaticCall(new Node\Name\FullyQualified($class), $method);
+    }
+
+    protected function createClassConstant(string $class, string $constant): ClassConstFetch
     {
         return $this->nodeFactory->createClassConstant($class, $constant);
     }


### PR DESCRIPTION
Closes #1276 

See [Hidden Gems of PHP Packages: Nette\Utils](https://www.tomasvotruba.cz/blog/2018/07/30/hidden-gems-of-php-packages-nette-utils/)

## Example

```diff
-file_get_contents($file);
+Nette\Utils\FileSystem::read($file);

-json_encode($json);
+Nette\Utils\Json::encode($json);

-strpos($content, 'hi') !=== false
+Nette\Utils\Strings::contains($content, 'hi);
```