### PR TITLE
Warning message on PHP files consisting of only comments when zend.assertions enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ install:
     - composer update $COMPOSER_FLAGS
 
 before_script:
+    - phpenv config-add travis.php.ini
     # disable xdebug
     - if [[ $COVERAGE == "" ]]; then phpenv config-rm xdebug.ini || echo "xdebug not available"; fi
     # increase memory for tests

--- a/src/assert-warning.php
+++ b/src/assert-warning.php
@@ -1,0 +1,3 @@
+<?php
+
+// A file with a single comment like this throws an assert() warning.

--- a/travis.php.ini
+++ b/travis.php.ini
@@ -1,0 +1,1 @@
+zend.assertions = 1


### PR DESCRIPTION
When PHP's `zend.assertions` are enabled, there's a Warning when a file is encountered that *only* contains a comment. This is a failing test to demonstrate #1157.

File contents:

```php
<?php

// A single-line comment
```

Output:

```
PHP Warning:  assert(): assert($itemStartPos >= 0 && $itemEndPos >= 0) failed in
vendor/nikic/php-parser/lib/PhpParser/PrettyPrinterAbstract.php on line 753
```

See the Travis log for this PR for either the `DOG_FOOD` or `RUN_RECTOR` builds. [Direct link](https://travis-ci.org/rectorphp/rector/jobs/514208182#L674)

<img width="894" alt="Screen Shot 2019-04-01 at 11 29 03 AM" src="https://user-images.githubusercontent.com/271432/55339807-67bd2f00-5471-11e9-8851-d1d7cbe9bd53.png">