### PR TITLE
[PHPUnit] Add RemoveExpectAnyFromMockRector

### DIFF
--- a/config/level/phpunit/phpunit-code-quality.yaml
+++ b/config/level/phpunit/phpunit-code-quality.yaml
@@ -1,0 +1,2 @@
+services:
+    Rector\PHPUnit\Rector\MethodCall\RemoveExpectAnyFromMockRector: ~

--- a/packages/PHPUnit/src/Rector/MethodCall/RemoveExpectAnyFromMockRector.php
+++ b/packages/PHPUnit/src/Rector/MethodCall/RemoveExpectAnyFromMockRector.php
@@ -1,0 +1,94 @@
+<?php declare(strict_types=1);
+
+namespace Rector\PHPUnit\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use Rector\Rector\AbstractPHPUnitRector;
+use Rector\RectorDefinition\CodeSample;
+use Rector\RectorDefinition\RectorDefinition;
+
+/**
+ * @see https://github.com/symfony/symfony/pull/30813/files#r270879504
+ */
+final class RemoveExpectAnyFromMockRector extends AbstractPHPUnitRector
+{
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Remove `expect($this->any())` from mocks as it has no added value', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+use PHPUnit\Framework\TestCase;
+
+class SomeClass extends TestCase
+{
+    public function test()
+    {
+        $translator = $this->getMock('SomeClass');
+        $translator->expects($this->any())
+            ->method('trans')
+            ->willReturn('translated max {{ max }}!');
+    }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+use PHPUnit\Framework\TestCase;
+
+class SomeClass extends TestCase
+{
+    public function test()
+    {
+        $translator = $this->getMock('SomeClass');
+        $translator->method('trans')
+            ->willReturn('translated max {{ max }}!');
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    /**
+     * @param MethodCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isInTestClass($node)) {
+            return null;
+        }
+
+        if (! $this->isName($node, 'expects')) {
+            return null;
+        }
+
+        if (count($node->args) !== 1) {
+            return null;
+        }
+
+        $onlyArgument = $node->args[0]->value;
+
+        // @todo add match sequence method, ref https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/be664e0c9f3cca94d0bbefa06a731848144e4a22/src/Tokenizer/Tokens.php#L776
+        if (! $onlyArgument instanceof Node\Expr\MethodCall) {
+            return null;
+        }
+
+        if (! $this->isName($onlyArgument->var, 'this')) {
+            return null;
+        }
+
+        if (! $this->isName($onlyArgument, 'any')) {
+            return null;
+        }
+
+        return $node->var;
+    }
+}

--- a/packages/PHPUnit/tests/Rector/MethodCall/RemoveExpectAnyFromMockRector/Fixture/fixture.php.inc
+++ b/packages/PHPUnit/tests/Rector/MethodCall/RemoveExpectAnyFromMockRector/Fixture/fixture.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\MethodCall\RemoveExpectAnyFromMockRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+class SomeClass extends TestCase
+{
+    public function test()
+    {
+        $translator = $this->createMock('SomeClass');
+        $translator->expects($this->any())
+            ->method('trans')
+            ->willReturn('translated max {{ max }}!');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\MethodCall\RemoveExpectAnyFromMockRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+class SomeClass extends TestCase
+{
+    public function test()
+    {
+        $translator = $this->createMock('SomeClass');
+        $translator
+            ->method('trans')
+            ->willReturn('translated max {{ max }}!');
+    }
+}
+
+?>

--- a/packages/PHPUnit/tests/Rector/MethodCall/RemoveExpectAnyFromMockRector/Fixture/keep.php.inc
+++ b/packages/PHPUnit/tests/Rector/MethodCall/RemoveExpectAnyFromMockRector/Fixture/keep.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\MethodCall\RemoveExpectAnyFromMockRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+class Keep extends TestCase
+{
+    public function test()
+    {
+        $translator = $this->createMock('Keep');
+        $translator->expects($this->once())
+            ->method('trans')
+            ->willReturn('translated max {{ max }}!');
+    }
+}

--- a/packages/PHPUnit/tests/Rector/MethodCall/RemoveExpectAnyFromMockRector/RemoveExpectAnyFromMockRectorTest.php
+++ b/packages/PHPUnit/tests/Rector/MethodCall/RemoveExpectAnyFromMockRector/RemoveExpectAnyFromMockRectorTest.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\Rector\MethodCall\RemoveExpectAnyFromMockRector;
+
+use Rector\PHPUnit\Rector\MethodCall\RemoveExpectAnyFromMockRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RemoveExpectAnyFromMockRectorTest extends AbstractRectorTestCase
+{
+    public function test(): void
+    {
+        $this->doTestFiles([__DIR__ . '/Fixture/fixture.php.inc']);
+    }
+
+    protected function getRectorClass(): string
+    {
+        return RemoveExpectAnyFromMockRector::class;
+    }
+}


### PR DESCRIPTION
Closes #1298


```diff
use PHPUnit\Framework\TestCase;
class SomeClass extends TestCase
{
    public function test()
    {
        $translator = $this->getMock('SomeClass');
-       $translator->expects($this->any())
+       $translator
            ->method('trans')
            ->willReturn('translated max {{ max }}!');
    }
}
```