### PR TITLE
[CakePHP]FIx rule for cakephp37

### DIFF
--- a/config/level/cakephp/cakephp37.yaml
+++ b/config/level/cakephp/cakephp37.yaml
@@ -80,4 +80,4 @@ services:
                 set: 'setClassName'
                 get: 'getClassName'
 
-    Rector\CakePHP\Rector\Name\ChangeSnakedFixtureNameToCamel: ~
+    Rector\CakePHP\Rector\Name\ChangeSnakedFixtureNameToCamelRector: ~


### PR DESCRIPTION
Sorry, I made a mistake! 🙇 
In #1252, I added incorrect service name.
Lacking  of `~Rector` suffix, `--level  cakephp37` is  interrupted.