### PR TITLE
Allow later versions of nette/utils

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "composer/xdebug-handler": "^1.3",
         "jean85/pretty-package-versions": "^1.2",
         "nette/robot-loader": "^3.1",
-        "nette/utils": "^2.5",
+        "nette/utils": "^2.5|^3.0",
         "nikic/php-parser": "^4.2.1",
         "phpstan/phpstan": "0.11.5",
         "sebastian/diff": "^3.0",


### PR DESCRIPTION
This should be a no brainer. Let's see if CI tests pass.