### PR TITLE
allow Nette 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "composer/xdebug-handler": "^1.3",
         "jean85/pretty-package-versions": "^1.2",
         "nette/robot-loader": "^3.1",
-        "nette/utils": "^2.5",
+        "nette/utils": "^2.5 || ^3.0",
         "nikic/php-parser": "^4.2.1",
         "phpstan/phpstan": "0.11.5",
         "sebastian/diff": "^3.0",

--- a/src/NodeContainer/ParsedNodesByType.php
+++ b/src/NodeContainer/ParsedNodesByType.php
@@ -89,7 +89,7 @@ final class ParsedNodesByType
     }
 
     /**
-     * @return Class_
+     * @return Class_[]
      */
     public function getClasses(): array
     {


### PR DESCRIPTION
I wanted to test this tool, but I require Nette 3.0. 

By the way, Is it normal that your PHPUnit coverage tests require more than 25 minutes on travis ci?