### PR TITLE
[CodingStyle] Add SplitStringClassConstantToClassConstFetchRector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "composer/xdebug-handler": "^1.3",
         "jean85/pretty-package-versions": "^1.2",
         "nette/robot-loader": "^3.1",
-        "nette/utils": "^2.5 || ^3.0",
+        "nette/utils": "^2.5|^3.0",
         "nikic/php-parser": "^4.2.1",
         "phpstan/phpstan": "0.11.5",
         "sebastian/diff": "^3.0",

--- a/config/level/coding-style/coding-style.yaml
+++ b/config/level/coding-style/coding-style.yaml
@@ -12,3 +12,4 @@ services:
     # Rector\CodingStyle\Rector\ClassMethod\ReturnArrayClassMethodToYieldRector: ~
     Rector\CodingStyle\Rector\String_\SymplifyQuoteEscapeRector: ~
     Rector\CodingStyle\Rector\ClassConst\SplitGroupedConstantsAndPropertiesRector: ~
+    Rector\CodingStyle\Rector\String_\SplitStringClassConstantToClassConstFetchRector: ~

--- a/packages/CodingStyle/src/Rector/String_/SplitStringClassConstantToClassConstFetchRector.php
+++ b/packages/CodingStyle/src/Rector/String_/SplitStringClassConstantToClassConstFetchRector.php
@@ -1,0 +1,79 @@
+<?php declare(strict_types=1);
+
+namespace Rector\CodingStyle\Rector\String_;
+
+use Nette\Utils\Strings;
+use PhpParser\Node;
+use PhpParser\Node\Scalar\String_;
+use Rector\Rector\AbstractRector;
+use Rector\RectorDefinition\CodeSample;
+use Rector\RectorDefinition\RectorDefinition;
+
+final class SplitStringClassConstantToClassConstFetchRector extends AbstractRector
+{
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Separate class constant in a string to class constant fetch and string', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    const HI = true;
+}
+
+class AnotherClass
+{
+    public function get()
+    {
+        return 'SomeClass::HI';
+    }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    const HI = true;
+}
+
+class AnotherClass
+{
+    public function get()
+    {
+        return SomeClass::class . '::HI';
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [String_::class];
+    }
+
+    /**
+     * @param String_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (substr_count($node->value, '::') !== 1) {
+            return null;
+        }
+
+        // a possible constant reference
+        [$possibleClass, $secondPart] = Strings::split($node->value, '#::#');
+
+        if (! class_exists($possibleClass)) {
+            return null;
+        }
+
+        $classConstFetch = new Node\Expr\ClassConstFetch(new Node\Name\FullyQualified($possibleClass), 'class');
+
+        return new Node\Expr\BinaryOp\Concat($classConstFetch, new Node\Scalar\String_('::' . $secondPart));
+    }
+}

--- a/packages/CodingStyle/tests/Rector/String_/SplitStringClassConstantToClassConstFetchRector/Fixture/fixture.php.inc
+++ b/packages/CodingStyle/tests/Rector/String_/SplitStringClassConstantToClassConstFetchRector/Fixture/fixture.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\CodingStyle\Tests\Rector\String_\SplitStringClassConstantToClassConstFetchRector\Fixture;
+
+class SomeClass
+{
+    const HI = true;
+}
+
+class AnotherClass
+{
+    public function get()
+    {
+        return 'Rector\CodingStyle\Tests\Rector\String_\SplitStringClassConstantToClassConstFetchRector\Fixture\SomeClass::HI';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CodingStyle\Tests\Rector\String_\SplitStringClassConstantToClassConstFetchRector\Fixture;
+
+class SomeClass
+{
+    const HI = true;
+}
+
+class AnotherClass
+{
+    public function get()
+    {
+        return \Rector\CodingStyle\Tests\Rector\String_\SplitStringClassConstantToClassConstFetchRector\Fixture\SomeClass::class . '::HI';
+    }
+}
+
+?>

--- a/packages/CodingStyle/tests/Rector/String_/SplitStringClassConstantToClassConstFetchRector/SplitStringClassConstantToClassConstFetchRectorTest.php
+++ b/packages/CodingStyle/tests/Rector/String_/SplitStringClassConstantToClassConstFetchRector/SplitStringClassConstantToClassConstFetchRectorTest.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Rector\CodingStyle\Tests\Rector\String_\SplitStringClassConstantToClassConstFetchRector;
+
+use Rector\CodingStyle\Rector\String_\SplitStringClassConstantToClassConstFetchRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class SplitStringClassConstantToClassConstFetchRectorTest extends AbstractRectorTestCase
+{
+    public function test(): void
+    {
+        $this->doTestFiles([__DIR__ . '/Fixture/fixture.php.inc']);
+    }
+
+    protected function getRectorClass(): string
+    {
+        return SplitStringClassConstantToClassConstFetchRector::class;
+    }
+}


### PR DESCRIPTION
```diff
class SomeClass
{
    const HI = true;
}

class AnotherClass
{
    public function get()
    {
-       return 'SomeClass::HI';
+       return SomeClass::class . '::HI';
    }
}