### PR TITLE
[DeadCode] Anonymous class implementing an interface doesn't respect interface signature

### DIFF
--- a/packages/DeadCode/tests/Rector/ClassMethod/RemoveUnusedParameterRector/Fixture/anonymous_classes.php.inc
+++ b/packages/DeadCode/tests/Rector/ClassMethod/RemoveUnusedParameterRector/Fixture/anonymous_classes.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\DeadCode\Tests\Rector\ClassMethod\RemoveUnusedParameterRector\FixtureInterface {
+
+    interface Foo
+    {
+        public function bar($value1);
+    }
+
+}
+
+namespace Rector\DeadCode\Tests\Rector\ClassMethod\RemoveUnusedParameterRector\Fixture {
+
+    use Rector\DeadCode\Tests\Rector\ClassMethod\RemoveUnusedParameterRector\FixtureInterface\Foo;
+
+    class Baz
+    {
+        public function test()
+        {
+            $class = new class implements Foo
+            {
+                public function bar($value1)
+                {
+                }
+            };
+        }
+    }
+}

--- a/packages/DeadCode/tests/Rector/ClassMethod/RemoveUnusedParameterRector/RemoveUnusedParameterRectorTest.php
+++ b/packages/DeadCode/tests/Rector/ClassMethod/RemoveUnusedParameterRector/RemoveUnusedParameterRectorTest.php
@@ -16,6 +16,7 @@ final class RemoveUnusedParameterRectorTest extends AbstractRectorTestCase
             __DIR__ . '/Fixture/in_between_parameter.php.inc',
             __DIR__ . '/Fixture/compact.php.inc',
             __DIR__ . '/Fixture/keep_magic_methods_param.php.inc',
+            __DIR__ . '/Fixture/anonymous_classes.php.inc',
         ]);
     }
 

--- a/packages/NodeTypeResolver/src/NodeVisitor/ClassAndMethodNodeVisitor.php
+++ b/packages/NodeTypeResolver/src/NodeVisitor/ClassAndMethodNodeVisitor.php
@@ -52,7 +52,10 @@ final class ClassAndMethodNodeVisitor extends NodeVisitorAbstract
      */
     public function enterNode(Node $node)
     {
-        if ($node instanceof Class_ && $this->isClassAnonymous($node)) {
+        if (
+            ($node instanceof Class_ && $this->isClassAnonymous($node)) ||
+            ($node instanceof ClassMethod && ($parentNode = $node->getAttribute(AttributeKey::PARENT_NODE)) instanceof Class_ && $this->isClassAnonymous($parentNode))
+        ) {
             return null;
         }
 


### PR DESCRIPTION
I found this while running the dead code level on a code base. I don't have a fix for it yet, but thought I'd open a PR so long with a failing test case while I investigate further (and maybe get some pointers to the right solution)

When instantiating an anonymous class that implements an interface, and the methods in the class is empty, then all the parameters in the method signature is removed. The signature that comes from the interface isn't respected. When running the test case in the PR, I get the following failure:

```diff
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
         {
             $class = new class implements Foo
             {
-                public function bar($value1)
+                public function bar()
                 {
                 }
             };\n
```

but I expect the test to pass, since the function `bar` matches the signature in the interface it implements.

The strange thing, though, is that in the `RemoveUnusedParameterRector` class, the line `$classNode = $node->getAttribute(AttributeKey::CLASS_NODE);` returns the current class node, and not the anonymous class node. So I think the issue might lie when traversing the nodes, and not with the actual rector class. I'm still digging through everything, but any nudge in the right direction would be appreciated.