### PR TITLE
Preserve file permissions when updating a file

### DIFF
--- a/src/PhpParser/Printer/FormatPerservingPrinter.php
+++ b/src/PhpParser/Printer/FormatPerservingPrinter.php
@@ -28,7 +28,7 @@ final class FormatPerservingPrinter
     {
         $newContent = $this->printToString($newStmts, $oldStmts, $oldTokens);
 
-        FileSystem::write($fileInfo->getRealPath(), $newContent);
+        FileSystem::write($fileInfo->getRealPath(), $newContent, $fileInfo->getPerms());
 
         return $newContent;
     }

--- a/tests/PhpParser/Printer/FormatPerservingPrinterTest.php
+++ b/tests/PhpParser/Printer/FormatPerservingPrinterTest.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Tests\PhpParser\Printer;
+
+use Nette\Utils\FileSystem;
+use Rector\HttpKernel\RectorKernel;
+use Rector\PhpParser\Printer\FormatPerservingPrinter;
+use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
+use Symplify\PackageBuilder\Tests\AbstractKernelTestCase;
+
+final class FormatPerservingPrinterTest extends AbstractKernelTestCase
+{
+    /**
+     * @var FormatPerservingPrinter
+     */
+    private $formatPerservingPrinter;
+
+    protected function setUp(): void
+    {
+        $this->bootKernel(RectorKernel::class);
+        $this->formatPerservingPrinter = self::$container->get(FormatPerservingPrinter::class);
+    }
+
+    protected function tearDown(): void
+    {
+        FileSystem::delete(__DIR__ . '/Fixture');
+    }
+
+    public function testFileModeIsPreserved(): void
+    {
+        mkdir(__DIR__ . '/Fixture');
+        touch(__DIR__ . '/Fixture/file.php');
+        $expectedFilemod = 0755;
+        chmod(__DIR__ . '/Fixture/file.php', $expectedFilemod);
+
+        $fileInfo = new SmartFileInfo(__DIR__ . '/Fixture/file.php');
+
+        $this->formatPerservingPrinter->printToFile($fileInfo, [], [], []);
+
+        $this->assertSame($expectedFilemod, fileperms(__DIR__ . '/Fixture/file.php') & 0777);
+    }
+}


### PR DESCRIPTION
The change of permissions is not explicitely requested by the user
and is not shown in the dry-run. It makes Rector harder to use when
the sources of a project has some executable scripts.