### PR TITLE
Add working directory option

### DIFF
--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -111,7 +111,7 @@ final class ProcessCommand extends AbstractCommand
         );
         $this->addOption(
             Option::OPTION_DRY_RUN,
-            'd',
+            'n',
             InputOption::VALUE_NONE,
             'See diff of changes, do not save them to files.'
         );

--- a/src/Rector/Psr4/MultipleClassFileToPsr4ClassesRector.php
+++ b/src/Rector/Psr4/MultipleClassFileToPsr4ClassesRector.php
@@ -168,10 +168,10 @@ CODE_SAMPLE
         }
     }
 
-    private function createClassLikeFileDestination(ClassLike $classLikeNode, SmartFileInfo $smartFileInfo): string
+    private function createClassLikeFileDestination(ClassLike $classLike, SmartFileInfo $smartFileInfo): string
     {
         $currentDirectory = dirname($smartFileInfo->getRealPath());
 
-        return $currentDirectory . DIRECTORY_SEPARATOR . (string) $classLikeNode->name . '.php';
+        return $currentDirectory . DIRECTORY_SEPARATOR . (string) $classLike->name . '.php';
     }
 }

--- a/tests/Rector/Psr4/MultipleClassFileToPsr4ClassesRector/MultipleClassFileToPsr4ClassesRectorTest.php
+++ b/tests/Rector/Psr4/MultipleClassFileToPsr4ClassesRector/MultipleClassFileToPsr4ClassesRectorTest.php
@@ -101,6 +101,7 @@ final class MultipleClassFileToPsr4ClassesRectorTest extends AbstractKernelTestC
             ],
         ];
     }
+
     public function provideClassLike(): Iterator
     {
         yield [


### PR DESCRIPTION
New command-line utility option:

   -d, --working-dir=WORKING-DIR

If specified, use the given directory as working directory.

Follows same syntax as Composer (quick port from there).