### PR TITLE
[CodingStyle] Add ConsistentPregDelimiterRector

### DIFF
--- a/config/level/coding-style/coding-style.yaml
+++ b/config/level/coding-style/coding-style.yaml
@@ -17,3 +17,4 @@ services:
 
     # 'ClassName' → ClassName::class
     Rector\Php\Rector\String_\StringClassNameToClassConstantRector: ~
+    Rector\CodingStyle\Rector\FuncCall\ConsistentPregDelimiterRector: ~

--- a/packages/CodingStyle/src/Rector/FuncCall/ConsistentPregDelimiterRector.php
+++ b/packages/CodingStyle/src/Rector/FuncCall/ConsistentPregDelimiterRector.php
@@ -1,0 +1,158 @@
+<?php declare(strict_types=1);
+
+namespace Rector\CodingStyle\Rector\FuncCall;
+
+use Nette\Utils\Strings;
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Scalar\String_;
+use Rector\Rector\AbstractRector;
+use Rector\RectorDefinition\CodeSample;
+use Rector\RectorDefinition\RectorDefinition;
+
+final class ConsistentPregDelimiterRector extends AbstractRector
+{
+    /**
+     * @var string
+     *
+     * For modifiers see https://www.php.net/manual/en/reference.pcre.pattern.modifiers.php
+     */
+    private const INNER_PATTERN_PATTERN = '#(?<content>.*?)(?<close>[imsxeADSUXJu]*)$#';
+
+    /**
+     * All with pattern as 1st argument
+     * @var int[]
+     */
+    private const FUNCTIONS_WITH_REGEX_PATTERN = [
+        'preg_match' => 0,
+        'preg_replace_callback_array' => 0,
+        'preg_replace_callback' => 0,
+        'preg_replace' => 0,
+        'preg_match_all' => 0,
+        'preg_split' => 0,
+        'preg_grep' => 0,
+    ];
+
+    /**
+     * All with pattern as 2st argument
+     * @var int[][]
+     */
+    private const STATIC_METHODS_WITH_REGEX_PATTERN = [
+        'Nette\Utils\Strings' => [
+            'match' => 1,
+            'matchAll' => 1,
+            'replace' => 1,
+            'split' => 1,
+        ],
+    ];
+
+    /**
+     * @var string
+     */
+    private $delimiter;
+
+    public function __construct(string $delimiter = '#')
+    {
+        $this->delimiter = $delimiter;
+    }
+
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Replace PREG delimiter with configured one', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run()
+    {
+        preg_match('~value~', $value);
+        preg_match_all('~value~im', $value);
+    }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run()
+    {
+        preg_match('#value#', $value);
+        preg_match_all('#value#im', $value);
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class, StaticCall::class];
+    }
+
+    /**
+     * @param FuncCall|StaticCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($node instanceof FuncCall) {
+            return $this->refactorFuncCall($node);
+        }
+
+        foreach (self::STATIC_METHODS_WITH_REGEX_PATTERN as $type => $methodsToPositions) {
+            if (! $this->isType($node, $type)) {
+                continue;
+            }
+
+            foreach ($methodsToPositions as $method => $position) {
+                if (! $this->isName($node->name, $method)) {
+                    continue;
+                }
+
+                $this->refactorArgument($node->args[$position]);
+            }
+        }
+
+        return $node;
+    }
+
+    private function refactorArgument(Arg $arg): void
+    {
+        if (! $arg->value instanceof String_) {
+            return;
+        }
+
+        $value = $arg->value->value;
+
+        $arg->value->value = Strings::replace($value, self::INNER_PATTERN_PATTERN, function (array $match): string {
+            $innerPattern = $match['content'];
+            if (strlen($innerPattern) > 2) {
+                // change delimiter
+                if ($innerPattern[0] === $innerPattern[strlen($innerPattern) - 1]) {
+                    $innerPattern[0] = $this->delimiter;
+                    $innerPattern[strlen($innerPattern) - 1] = $this->delimiter;
+                }
+            }
+
+            return $innerPattern . $match['close'];
+        });
+    }
+
+    private function refactorFuncCall(FuncCall $funcCall): FuncCall
+    {
+        foreach (self::FUNCTIONS_WITH_REGEX_PATTERN as $function => $position) {
+            if (! $this->isName($funcCall, $function)) {
+                continue;
+            }
+
+            $this->refactorArgument($funcCall->args[$position]);
+        }
+
+        return $funcCall;
+    }
+}

--- a/packages/CodingStyle/tests/Rector/FuncCall/ConsistentPregDelimiterRector/ConsistentPregDelimiterRectorTest.php
+++ b/packages/CodingStyle/tests/Rector/FuncCall/ConsistentPregDelimiterRector/ConsistentPregDelimiterRectorTest.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Rector\CodingStyle\Tests\Rector\FuncCall\ConsistentPregDelimiterRector;
+
+use Rector\CodingStyle\Rector\FuncCall\ConsistentPregDelimiterRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ConsistentPregDelimiterRectorTest extends AbstractRectorTestCase
+{
+    public function test(): void
+    {
+        $this->doTestFiles([
+            __DIR__ . '/Fixture/fixture.php.inc',
+            __DIR__ . '/Fixture/static_call.php.inc',
+            __DIR__ . '/Fixture/skip_concat.php.inc',
+        ]);
+    }
+
+    protected function getRectorClass(): string
+    {
+        return ConsistentPregDelimiterRector::class;
+    }
+}

--- a/packages/CodingStyle/tests/Rector/FuncCall/ConsistentPregDelimiterRector/Fixture/fixture.php.inc
+++ b/packages/CodingStyle/tests/Rector/FuncCall/ConsistentPregDelimiterRector/Fixture/fixture.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\CodingStyle\Tests\Rector\FuncCall\ConsistentPregDelimiterRector\Fixture;
+
+class SomeClass
+{
+    public function run()
+    {
+        preg_match('~value~', $value);
+        preg_match_all('~value~im', $value);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CodingStyle\Tests\Rector\FuncCall\ConsistentPregDelimiterRector\Fixture;
+
+class SomeClass
+{
+    public function run()
+    {
+        preg_match('#value#', $value);
+        preg_match_all('#value#im', $value);
+    }
+}
+
+?>

--- a/packages/CodingStyle/tests/Rector/FuncCall/ConsistentPregDelimiterRector/Fixture/skip_concat.php.inc
+++ b/packages/CodingStyle/tests/Rector/FuncCall/ConsistentPregDelimiterRector/Fixture/skip_concat.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\CodingStyle\Tests\Rector\FuncCall\ConsistentPregDelimiterRector\Fixture;
+
+use Nette\Utils\Strings;
+
+class SkipConcat
+{
+    public function run($file)
+    {
+        Strings::replace($file, '#' . preg_quote(getcwd() . '/') . '#');
+    }
+}

--- a/packages/CodingStyle/tests/Rector/FuncCall/ConsistentPregDelimiterRector/Fixture/static_call.php.inc
+++ b/packages/CodingStyle/tests/Rector/FuncCall/ConsistentPregDelimiterRector/Fixture/static_call.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\CodingStyle\Tests\Rector\FuncCall\ConsistentPregDelimiterRector\Fixture;
+
+use Nette\Utils\Strings;
+
+class StaticCall
+{
+    public function run($value)
+    {
+        Strings::match($value, '/value/');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CodingStyle\Tests\Rector\FuncCall\ConsistentPregDelimiterRector\Fixture;
+
+use Nette\Utils\Strings;
+
+class StaticCall
+{
+    public function run($value)
+    {
+        Strings::match($value, '#value#');
+    }
+}
+
+?>


### PR DESCRIPTION
Ref #1466

- Configurable :wrench: 

```yaml
services:
    Rector\CodingStyle\Rector\FuncCall\ConsistentPregDelimiterRector:
        delimiter: '_' # "#" by default

```

Inspired by https://github.com/Symplify/CodingStandard/blob/master/src/Fixer/ControlStructure/PregDelimiterFixer.php