### PR TITLE
[SOLID] Add AbstractChildlessUnusedClassesRector

### DIFF
--- a/config/level/solid/solid.yaml
+++ b/config/level/solid/solid.yaml
@@ -2,3 +2,4 @@ services:
     Rector\SOLID\Rector\Class_\FinalizeClassesWithoutChildrenRector: ~
 
     Rector\SOLID\Rector\ClassConst\PrivatizeLocalClassConstantRector: ~
+    Rector\SOLID\Rector\Class_\AbstractChildlessUnusedClassesRector: ~

--- a/docs/AllRectorsOverview.md
+++ b/docs/AllRectorsOverview.md
@@ -1,4 +1,4 @@
-# All 291 Rectors Overview
+# All 298 Rectors Overview
 
 - [Projects](#projects)
 - [General](#general)
@@ -770,6 +770,26 @@ Joins concat of 2 strings
 
 ## CodingStyle
 
+### `SplitDoubleAssignRector`
+
+- class: `Rector\CodingStyle\Rector\Assign\SplitDoubleAssignRector`
+
+Split multiple inline assigns to each own lines default value, to prevent undefined array issues
+
+```diff
+ class SomeClass
+ {
+     public function run()
+     {
+-        $one = $two = 1;
++        $one = 1;
++        $two = 1;
+     }
+ }
+```
+
+<br>
+
 ### `ReturnArrayClassMethodToYieldRector`
 
 - class: `Rector\CodingStyle\Rector\ClassMethod\ReturnArrayClassMethodToYieldRector`
@@ -820,6 +840,30 @@ services:
      {
 -        yield 'event' => 'callback';
 +        return ['event' => 'callback'];
+     }
+ }
+```
+
+<br>
+
+### `CatchExceptionNameMatchingTypeRector`
+
+- class: `Rector\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector`
+
+Type and name of catch exception should match
+
+```diff
+ class SomeClass
+ {
+     public function run()
+     {
+         try {
+             // ...
+-        } catch (SomeException $typoException) {
+-            $typoException->getMessage();
++        } catch (SomeException $someException) {
++            $someException->getMessage();
+         }
      }
  }
 ```
@@ -892,6 +936,31 @@ Import fully qualified names to use statements
 
 <br>
 
+### `ArrayPropertyDefaultValueRector`
+
+- class: `Rector\CodingStyle\Rector\Property\ArrayPropertyDefaultValueRector`
+
+Array property should have default value, to prevent undefined array issues
+
+```diff
+ class SomeClass
+ {
+     /**
+      * @var int[]
+      */
+-    private $items;
++    private $items = [];
+
+     public function run()
+     {
+         foreach ($items as $item) {
+         }
+     }
+ }
+```
+
+<br>
+
 ### `RemoveUnusedAliasRector`
 
 - class: `Rector\CodingStyle\Rector\Use_\RemoveUnusedAliasRector`
@@ -905,6 +974,25 @@ Removes unused use aliases
 -class SomeClass extends BaseKernel
 +class SomeClass extends Kernel
  {
+ }
+```
+
+<br>
+
+### `FollowRequireByDirRector`
+
+- class: `Rector\CodingStyle\Rector\Include_\FollowRequireByDirRector`
+
+include/require should be followed by absolute path
+
+```diff
+ class SomeClass
+ {
+     public function run()
+     {
+-        require 'autoload.php';
++        require __DIR__ . '/autoload.php';
+     }
  }
 ```
 
@@ -944,6 +1032,27 @@ Changes redundant anonymous bool functions to simple calls
 -    return is_dir($path);
 -});
 +array_filter($paths, "is_dir");
+```
+
+<br>
+
+### `ConsistentPregDelimiterRector`
+
+- class: `Rector\CodingStyle\Rector\FuncCall\ConsistentPregDelimiterRector`
+
+Replace PREG delimiter with configured one
+
+```diff
+ class SomeClass
+ {
+     public function run()
+     {
+-        preg_match('~value~', $value);
+-        preg_match_all('~value~im', $value);
++        preg_match('#value#', $value);
++        preg_match_all('#value#im', $value);
+     }
+ }
 ```
 
 <br>
@@ -990,6 +1099,24 @@ Separate constant and properties to own lines
 +     * @var string
 +     */
 +    public $isIsThough;
+ }
+```
+
+<br>
+
+### `VarConstantCommentRector`
+
+- class: `Rector\CodingStyle\Rector\ClassConst\VarConstantCommentRector`
+
+Constant should have a @var comment with type
+
+```diff
+ class SomeClass
+ {
++    /**
++     * @var string
++     */
+     const HI = 'hi';
  }
 ```
 
@@ -4244,6 +4371,30 @@ Finalize every class constant that is used only locally
      {
          return self::LOCAL_ONLY;
      }
+ }
+```
+
+<br>
+
+### `AbstractChildlessUnusedClassesRector`
+
+- class: `Rector\SOLID\Rector\Class_\AbstractChildlessUnusedClassesRector`
+
+Classes that have no children nor are used, should have abstract
+
+```diff
+ class SomeClass extends PossibleAbstractClass
+ {
+ }
+
+-class PossibleAbstractClass
++abstract class PossibleAbstractClass
+ {
+ }
+
+ function run()
+ {
+     return new SomeClass();
  }
 ```
 

--- a/docs/NodesOverview.md
+++ b/docs/NodesOverview.md
@@ -23,6 +23,13 @@ $someVariable[0]
 ```
 <br>
 
+#### `PhpParser\Node\Expr\ArrowFunction`
+
+```php
+fn() => 1
+```
+<br>
+
 #### `PhpParser\Node\Expr\Assign`
 
 ```php

--- a/packages/CodingStyle/src/Rector/Assign/SplitDoubleAssignRector.php
+++ b/packages/CodingStyle/src/Rector/Assign/SplitDoubleAssignRector.php
@@ -54,11 +54,11 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $node->expr instanceof Node\Expr\Assign) {
+        if (! $node->expr instanceof Assign) {
             return null;
         }
 
-        $newAssign = new Node\Expr\Assign($node->var, $node->expr->expr);
+        $newAssign = new Assign($node->var, $node->expr->expr);
 
         $this->addNodeAfterNode($node->expr, $node);
 

--- a/packages/CodingStyle/src/Rector/Catch_/CatchExceptionNameMatchingTypeRector.php
+++ b/packages/CodingStyle/src/Rector/Catch_/CatchExceptionNameMatchingTypeRector.php
@@ -3,6 +3,7 @@
 namespace Rector\CodingStyle\Rector\Catch_;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Catch_;
 use Rector\CodingStyle\Naming\ClassNaming;
 use Rector\PhpParser\NodeTraverser\CallableNodeTraverser;
@@ -100,16 +101,13 @@ CODE_SAMPLE
         return $node;
     }
 
-    private function renameVariableInStmts(
-        Node\Stmt\Catch_ $catch,
-        string $oldVariableName,
-        string $newVariableName
-    ): void {
+    private function renameVariableInStmts(Catch_ $catch, string $oldVariableName, string $newVariableName): void
+    {
         $this->callableNodeTraverser->traverseNodesWithCallable($catch->stmts, function (Node $node) use (
             $oldVariableName,
             $newVariableName
         ): void {
-            if (! $node instanceof Node\Expr\Variable) {
+            if (! $node instanceof Variable) {
                 return;
             }
 

--- a/packages/CodingStyle/src/Rector/Include_/FollowRequireByDirRector.php
+++ b/packages/CodingStyle/src/Rector/Include_/FollowRequireByDirRector.php
@@ -4,7 +4,9 @@ namespace Rector\CodingStyle\Rector\Include_;
 
 use Nette\Utils\Strings;
 use PhpParser\Node;
+use PhpParser\Node\Expr\BinaryOp\Concat;
 use PhpParser\Node\Expr\Include_;
+use PhpParser\Node\Scalar\MagicConst\Dir;
 use PhpParser\Node\Scalar\String_;
 use Rector\Rector\AbstractRector;
 use Rector\RectorDefinition\CodeSample;
@@ -65,7 +67,7 @@ CODE_SAMPLE
         $this->removeExtraDotSlash($includedPath);
         $this->prependSlashIfMissing($includedPath);
 
-        $node->expr = new Node\Expr\BinaryOp\Concat(new Node\Scalar\MagicConst\Dir(), $includedPath);
+        $node->expr = new Concat(new Dir(), $includedPath);
 
         return $node;
     }

--- a/packages/CodingStyle/src/Rector/Property/ArrayPropertyDefaultValueRector.php
+++ b/packages/CodingStyle/src/Rector/Property/ArrayPropertyDefaultValueRector.php
@@ -3,6 +3,8 @@
 namespace Rector\CodingStyle\Rector\Property;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\PropertyProperty;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PhpDoc\NodeAnalyzer\DocBlockManipulator;
@@ -78,7 +80,7 @@ CODE_SAMPLE
             return null;
         }
 
-        /** @var Node\Stmt\Property $parentNode */
+        /** @var Property $parentNode */
         $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
 
         $varTypeInfo = $this->docBlockManipulator->getVarTypeInfo($parentNode);
@@ -90,7 +92,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $node->default = new Node\Expr\Array_();
+        $node->default = new Array_();
 
         return $node;
     }

--- a/packages/NodeTypeResolver/src/PHPStan/Type/TypeToStringResolver.php
+++ b/packages/NodeTypeResolver/src/PHPStan/Type/TypeToStringResolver.php
@@ -54,7 +54,8 @@ final class TypeToStringResolver
 
         $arrayTypes = array_unique($arrayTypes);
 
-        return array_map(function (string $arrayType) {
+        /** @var string[] $arrayType */
+        return array_map(function (string $arrayType): string {
             return $arrayType . '[]';
         }, $arrayTypes);
     }

--- a/packages/SOLID/src/Rector/Class_/MakeUnusedClassesWithChildrenAbstractRector.php
+++ b/packages/SOLID/src/Rector/Class_/MakeUnusedClassesWithChildrenAbstractRector.php
@@ -1,0 +1,93 @@
+<?php declare(strict_types=1);
+
+namespace Rector\SOLID\Rector\Class_;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use Rector\NodeContainer\ParsedNodesByType;
+use Rector\Rector\AbstractRector;
+use Rector\RectorDefinition\CodeSample;
+use Rector\RectorDefinition\RectorDefinition;
+
+final class MakeUnusedClassesWithChildrenAbstractRector extends AbstractRector
+{
+    /**
+     * @var ParsedNodesByType
+     */
+    private $parsedNodesByType;
+
+    public function __construct(ParsedNodesByType $parsedNodesByType)
+    {
+        $this->parsedNodesByType = $parsedNodesByType;
+    }
+
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Classes that have no children nor are used, should have abstract', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+class SomeClass extends PossibleAbstractClass
+{
+}
+
+class PossibleAbstractClass
+{
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+class SomeClass extends PossibleAbstractClass
+{
+}
+
+abstract class PossibleAbstractClass
+{
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $className = $this->getName($node);
+        if ($className === null) {
+            return null;
+        }
+
+        // 1. is in static call?
+        if ($this->parsedNodesByType->findMethodCallsOnClass($className)) {
+            return null;
+        }
+
+        // 2. is in new?
+        if ($this->parsedNodesByType->findNewNodesByClass($className)) {
+            return null;
+        }
+
+        // 3. does it have any children
+        if (! $this->parsedNodesByType->findChildrenOfClass($className)) {
+            return null;
+        }
+
+        // is abstract!
+        if ($node->isAbstract()) {
+            return null;
+        }
+
+        $this->makeAbstract($node);
+
+        return $node;
+    }
+}

--- a/packages/SOLID/tests/Rector/Class_/MakeUnusedClassesWithChildrenAbstractRector/Fixture/fixture.php.inc
+++ b/packages/SOLID/tests/Rector/Class_/MakeUnusedClassesWithChildrenAbstractRector/Fixture/fixture.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\SOLID\Tests\Rector\Class_\MakeUnusedClassesWithChildrenAbstractRector\Fixture;
+
+class SomeClass extends PossibleAbstractClass
+{
+}
+
+class PossibleAbstractClass
+{
+}
+
+?>
+-----
+<?php
+
+namespace Rector\SOLID\Tests\Rector\Class_\MakeUnusedClassesWithChildrenAbstractRector\Fixture;
+
+class SomeClass extends PossibleAbstractClass
+{
+}
+
+abstract class PossibleAbstractClass
+{
+}
+
+?>

--- a/packages/SOLID/tests/Rector/Class_/MakeUnusedClassesWithChildrenAbstractRector/Fixture/skip_method_call.php.inc
+++ b/packages/SOLID/tests/Rector/Class_/MakeUnusedClassesWithChildrenAbstractRector/Fixture/skip_method_call.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\SOLID\Tests\Rector\Class_\MakeUnusedClassesWithChildrenAbstractRector\Fixture;
+
+class SkipMethodCall
+{
+    public static function run()
+    {
+
+    }
+}
+
+class ClassCalling
+{
+    public function go($skipMethodCall)
+    {
+        /** @var SkipMethodCall $skipMethodCall */
+        $skipMethodCall->run();
+    }
+}
+
+function localFunction()
+{
+    // just so the ClassCalling is not made abstract
+    $classCalling = new ClassCalling();
+}

--- a/packages/SOLID/tests/Rector/Class_/MakeUnusedClassesWithChildrenAbstractRector/Fixture/skip_new.php.inc
+++ b/packages/SOLID/tests/Rector/Class_/MakeUnusedClassesWithChildrenAbstractRector/Fixture/skip_new.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\SOLID\Tests\Rector\Class_\MakeUnusedClassesWithChildrenAbstractRector\Fixture;
+
+class SkipNew
+{
+}
+
+function runMePlease()
+{
+    return new SkipNew();
+}

--- a/packages/SOLID/tests/Rector/Class_/MakeUnusedClassesWithChildrenAbstractRector/Fixture/skip_static_call.php.inc
+++ b/packages/SOLID/tests/Rector/Class_/MakeUnusedClassesWithChildrenAbstractRector/Fixture/skip_static_call.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\SOLID\Tests\Rector\Class_\MakeUnusedClassesWithChildrenAbstractRector\Fixture;
+
+class SkipStaticCall
+{
+    public static function run()
+    {
+
+    }
+}
+
+function run()
+{
+    SkipStaticCall::run();
+}

--- a/packages/SOLID/tests/Rector/Class_/MakeUnusedClassesWithChildrenAbstractRector/MakeUnusedClassesWithChildrenAbstractRectorTest.php
+++ b/packages/SOLID/tests/Rector/Class_/MakeUnusedClassesWithChildrenAbstractRector/MakeUnusedClassesWithChildrenAbstractRectorTest.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Rector\SOLID\Tests\Rector\Class_\MakeUnusedClassesWithChildrenAbstractRector;
+
+use Rector\SOLID\Rector\Class_\MakeUnusedClassesWithChildrenAbstractRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class MakeUnusedClassesWithChildrenAbstractRectorTest extends AbstractRectorTestCase
+{
+    public function test(): void
+    {
+        $this->doTestFiles([
+            __DIR__ . '/Fixture/fixture.php.inc',
+            __DIR__ . '/Fixture/skip_new.php.inc',
+            __DIR__ . '/Fixture/skip_static_call.php.inc',
+        ]);
+    }
+
+    protected function getRectorClass(): string
+    {
+        return MakeUnusedClassesWithChildrenAbstractRector::class;
+    }
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -158,13 +158,6 @@ parameters:
         - '#Method Rector\\Collector\\CallableCollectorPopulator\:\:populate\(\) should return array<Closure\> but returns array<int\|string, callable\>#'
         - '#Access to an undefined property PhpParser\\Node\\Expr\:\:\$args#'
 
-        # waits on php-parser release
-        - '#ArrowFunction#'
-        - '#Parameter \#6 \$fixup \(int\|null\) of method Rector\\PhpParser\\Printer\\BetterStandardPrinter\:\:pArray\(\) should be compatible with parameter \$subNodeName \(string\) of method PhpParser\\PrettyPrinterAbstract\:\:pArray\(\)#'
-        - '#Parameter \#6 \$subNodeName of method PhpParser\\PrettyPrinterAbstract\:\:pArray\(\) expects string, int\|null given#'
-        - '#Parameter \#7 \$fixup of method PhpParser\\PrettyPrinterAbstract\:\:pArray\(\) expects int\|null, string\|null given#'
-        - '#Class PhpParser\\Node\\Expr\\ArrayItem constructor invoked with 5 parameters, 1\-4 required#'
-
         - '#Parameter \#2 \$name of method Rector\\Rector\\AbstractRector\:\:isName\(\) expects string, string\|null given#'
         # file always exists here
         - '#Cannot call method getRealPath\(\) on Symplify\\PackageBuilder\\FileSystem\\SmartFileInfo\|null#'
@@ -174,3 +167,6 @@ parameters:
         # known value
         - '#Parameter \#1 \$node of method Rector\\Rector\\AbstractRector\:\:getName\(\) expects PhpParser\\Node, PhpParser\\Node\\Identifier\|null given#'
         - '#Cannot cast array<string\>\|bool\|string\|null to string#'
+
+        - '#Parameter \#1 \$node of method Rector\\PhpParser\\Node\\Manipulator\\VisibilityManipulator\:\:makeAbstract\(\) expects PhpParser\\Node\\Stmt\\Class_\|PhpParser\\Node\\Stmt\\ClassMethod, PhpParser\\Node given#'
+

--- a/rector.yaml
+++ b/rector.yaml
@@ -15,4 +15,3 @@ parameters:
     php_version_features: '7.1'
 
 services:
-    Rector\CodingStyle\Rector\Namespace_\ImportFullyQualifiedNamesRector: ~

--- a/src/NodeContainer/ParsedNodesByType.php
+++ b/src/NodeContainer/ParsedNodesByType.php
@@ -413,6 +413,29 @@ final class ParsedNodesByType
         return $this->methodsCallsByTypeAndMethod[$className][$methodName] ?? [];
     }
 
+    /**
+     * @return MethodCall[]|StaticCall[]
+     */
+    public function findMethodCallsOnClass(string $className): array
+    {
+        return $this->methodsCallsByTypeAndMethod[$className] ?? [];
+    }
+
+    /**
+     * @return New_[]
+     */
+    public function findNewNodesByClass(string $className): array
+    {
+        $newNodesByClass = [];
+        foreach ($this->getNewNodes() as $newNode) {
+            if ($this->nameResolver->isName($newNode->class, $className)) {
+                $newNodesByClass[] = $newNode;
+            }
+        }
+
+        return $newNodesByClass;
+    }
+
     private function addClass(Class_ $classNode): void
     {
         if ($this->isClassAnonymous($classNode)) {

--- a/src/PhpParser/Node/Manipulator/PropertyManipulator.php
+++ b/src/PhpParser/Node/Manipulator/PropertyManipulator.php
@@ -63,7 +63,7 @@ final class PropertyManipulator
             }
 
             // is it the name match?
-            if ($this->nameResolver->resolve($node) !== $this->nameResolver->resolve($property)) {
+            if (! $this->nameResolver->areNamesEqual($node, $property)) {
                 return null;
             }
 

--- a/src/PhpParser/Node/Manipulator/VisibilityManipulator.php
+++ b/src/PhpParser/Node/Manipulator/VisibilityManipulator.php
@@ -14,7 +14,7 @@ final class VisibilityManipulator
     /**
      * @var string[]
      */
-    private $allowedNodeTypes = [ClassMethod::class, Property::class, ClassConst::class];
+    private $allowedNodeTypes = [ClassMethod::class, Property::class, ClassConst::class, Class_::class];
 
     /**
      * @param ClassMethod|Property|ClassConst $node
@@ -25,13 +25,21 @@ final class VisibilityManipulator
     }
 
     /**
+     * @param ClassMethod|Class_ $node
+     */
+    public function makeAbstract(Node $node): void
+    {
+        $this->addVisibilityFlag($node, 'abstract');
+    }
+
+    /**
      * @param ClassMethod|Property|ClassConst $node
      */
     public function replaceVisibilityFlag(Node $node, string $visibility): void
     {
         $visibility = strtolower($visibility);
 
-        if ($visibility !== 'static') {
+        if ($visibility !== 'static' && $visibility !== 'abstract') {
             $this->removeOriginalVisibilityFromFlags($node);
         }
 
@@ -66,7 +74,7 @@ final class VisibilityManipulator
     }
 
     /**
-     * @param ClassMethod|Property|ClassConst $node
+     * @param Class_|ClassMethod|Property|ClassConst $node
      */
     private function addVisibilityFlag(Node $node, string $visibility): void
     {
@@ -86,6 +94,10 @@ final class VisibilityManipulator
 
         if ($visibility === 'static') {
             $node->flags |= Class_::MODIFIER_STATIC;
+        }
+
+        if ($visibility === 'abstract') {
+            $node->flags |= Class_::MODIFIER_ABSTRACT;
         }
     }
 

--- a/src/Rector/VisibilityTrait.php
+++ b/src/Rector/VisibilityTrait.php
@@ -3,6 +3,7 @@
 namespace Rector\Rector;
 
 use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassConst;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Property;
@@ -49,6 +50,14 @@ trait VisibilityTrait
                 implode('", "', $allowedVisibilities)
             ));
         }
+    }
+
+    /**
+     * @param ClassMethod|Class_ $node
+     */
+    public function makeAbstract(Node $node): void
+    {
+        $this->visibilityManipulator->makeAbstract($node);
     }
 
     /**


### PR DESCRIPTION
Closes #1466

Classes that are never used, only inherited from, are `abstract`


```diff
class SomeClass extends PossibleAbstractClass
{
}

-class PossibleAbstractClass
+abstract class PossibleAbstractClass
{
}

function run()
{
    return new SomeClass();
}
```