### PR TITLE
add JsonOutputFormatter

### DIFF
--- a/packages/ConsoleDiffer/src/DifferAndFormatter.php
+++ b/packages/ConsoleDiffer/src/DifferAndFormatter.php
@@ -23,13 +23,22 @@ final class DifferAndFormatter
         $this->diffConsoleFormatter = $diffConsoleFormatter;
     }
 
+    public function diff(string $old, string $new): string
+    {
+        if ($old === $new) {
+            return '';
+        }
+
+        return $this->differ->diff($old, $new);
+    }
+
     public function diffAndFormat(string $old, string $new): string
     {
         if ($old === $new) {
             return '';
         }
 
-        $diff = $this->differ->diff($old, $new);
+        $diff = $this->diff($old, $new);
 
         return $this->diffConsoleFormatter->format($diff);
     }

--- a/rector.yaml
+++ b/rector.yaml
@@ -17,4 +17,4 @@ parameters:
     php_version_features: '7.1'
 
 services:
-#    Rector\CodingStyle\Rector\Namespace_\ImportFullyQualifiedNamesRector: ~
+    Rector\CodingStyle\Rector\Namespace_\ImportFullyQualifiedNamesRector: ~

--- a/src/Application/ErrorAndDiffCollector.php
+++ b/src/Application/ErrorAndDiffCollector.php
@@ -83,6 +83,7 @@ final class ErrorAndDiffCollector
         // always keep the most recent diff
         $this->fileDiffs[$smartFileInfo->getRealPath()] = new FileDiff(
             $smartFileInfo->getRealPath(),
+            $this->differAndFormatter->diff($oldContent, $newContent),
             $this->differAndFormatter->diffAndFormat($oldContent, $newContent),
             $appliedRectors
         );

--- a/src/Application/RectorApplication.php
+++ b/src/Application/RectorApplication.php
@@ -116,7 +116,9 @@ final class RectorApplication
             });
         }
 
-        $this->symfonyStyle->newLine(2);
+        if ($this->configuration->showProgressBar()) {
+            $this->symfonyStyle->newLine(2);
+        }
 
         // 4. remove and add files
         $this->removedAndAddedFilesProcessor->run();

--- a/src/Application/RectorApplication.php
+++ b/src/Application/RectorApplication.php
@@ -90,7 +90,7 @@ final class RectorApplication
             return;
         }
 
-        if (! $this->symfonyStyle->isVerbose()) {
+        if (! $this->symfonyStyle->isVerbose() && $this->configuration->showProgressBar()) {
             // why 3? one for each cycle, so user sees some activity all the time
             $this->symfonyStyle->progressStart($fileCount * 3);
         }
@@ -172,7 +172,7 @@ final class RectorApplication
     {
         if ($this->symfonyStyle->isVerbose()) {
             $this->symfonyStyle->writeln($smartFileInfo->getRealPath());
-        } else {
+        } elseif ($this->configuration->showProgressBar()) {
             $this->symfonyStyle->progressAdvance();
         }
     }

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -78,8 +78,8 @@ final class Application extends SymfonyApplication
             $output->writeln($this->getLongVersion());
             $shouldFollowByNewline = true;
 
-            $configPath = $this->getConfigPath($input);
-            if (file_exists($configPath)) {
+            $configPath = $this->configuration->getConfigFilePath();
+            if ($configPath) {
                 $output->writeln('Config file: ' . realpath($configPath));
                 $shouldFollowByNewline = true;
             }

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -3,6 +3,8 @@
 namespace Rector\Console;
 
 use Jean85\PrettyVersions;
+use Rector\Configuration\Configuration;
+use Rector\Console\Output\JsonOutputFormatter;
 use Rector\ContributorTools\Command\DumpNodesCommand;
 use Rector\ContributorTools\Command\DumpRectorsCommand;
 use Rector\ContributorTools\Exception\Command\ContributorCommandInterface;
@@ -25,14 +27,20 @@ final class Application extends SymfonyApplication
     private const NAME = 'Rector';
 
     /**
+     * @var Configuration
+     */
+    private $configuration;
+
+    /**
      * @param Command[] $commands
      */
-    public function __construct(array $commands = [])
+    public function __construct(Configuration $configuration, array $commands = [])
     {
         parent::__construct(self::NAME, PrettyVersions::getVersion('rector/rector')->getPrettyVersion());
 
         $commands = $this->filterCommandsByScope($commands);
         $this->addCommands($commands);
+        $this->configuration = $configuration;
     }
 
     /**
@@ -45,6 +53,8 @@ final class Application extends SymfonyApplication
 
     public function doRun(InputInterface $input, OutputInterface $output): int
     {
+        $this->configuration->setConfigFilePathFromInput($input);
+
         $shouldFollowByNewline = false;
 
         // switch working dir
@@ -64,16 +74,15 @@ final class Application extends SymfonyApplication
             return parent::doRun($input, $output);
         }
 
-        if (! $this->isVersionPrintedElsewhere($input)) {
-            // always print name version to more debug info
+        if ($this->shouldPrintMetaInformation($input)) {
             $output->writeln($this->getLongVersion());
             $shouldFollowByNewline = true;
-        }
 
-        $configPath = $this->getConfigPath($input);
-        if (file_exists($configPath)) {
-            $output->writeln('Config file: ' . realpath($configPath));
-            $shouldFollowByNewline = true;
+            $configPath = $this->getConfigPath($input);
+            if (file_exists($configPath)) {
+                $output->writeln('Config file: ' . realpath($configPath));
+                $shouldFollowByNewline = true;
+            }
         }
 
         if ($shouldFollowByNewline) {
@@ -111,11 +120,6 @@ final class Application extends SymfonyApplication
         return array_values($filteredCommands);
     }
 
-    private function isVersionPrintedElsewhere(InputInterface $input): bool
-    {
-        return $input->hasParameterOption('--version') || $input->getFirstArgument() === null;
-    }
-
     private function getConfigPath(InputInterface $input): string
     {
         if ($input->getParameterOption('--config')) {
@@ -132,6 +136,19 @@ final class Application extends SymfonyApplication
         unset($options['quiet'], $options['no-interaction']);
 
         $inputDefinition->setOptions($options);
+    }
+
+    private function shouldPrintMetaInformation(InputInterface $input): bool
+    {
+        $hasNoArguments = $input->getFirstArgument() === null;
+        $hasVersionOption = $input->hasParameterOption('--version');
+
+        $hasJsonOutput = (
+            $input->getParameterOption('--output-format') === JsonOutputFormatter::NAME ||
+            $input->getParameterOption('-o') === JsonOutputFormatter::NAME
+        );
+
+        return ! ($hasVersionOption || $hasNoArguments || $hasJsonOutput);
     }
 
     private function addCustomOptions(InputDefinition $inputDefinition): void

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -153,9 +153,9 @@ final class ProcessCommand extends AbstractCommand
 
         $this->rectorApplication->runOnFileInfos($phpFileInfos);
 
+        // report diffs and errors
         $outputFormat = (string) $input->getOption(Option::OPTION_OUTPUT_FORMAT);
         $outputFormatter = $this->outputFormatterCollector->getByName($outputFormat);
-
         $outputFormatter->report($this->errorAndDiffCollector);
 
         // apply coding standard

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -164,10 +164,9 @@ final class ProcessCommand extends AbstractCommand
         $outputFormat = (string) $input->getOption(Option::OPTION_OUTPUT_FORMAT);
         $outputFormatter = $this->outputFormatterCollector->getByName($outputFormat);
 
-        $outputFormatter->reportFileDiffs($this->errorAndDiffCollector->getFileDiffs());
+        $outputFormatter->report($this->errorAndDiffCollector);
 
         if ($this->errorAndDiffCollector->getErrors() !== []) {
-            $outputFormatter->reportErrors($this->errorAndDiffCollector->getErrors());
             return Shell::CODE_ERROR;
         }
 
@@ -182,6 +181,7 @@ final class ProcessCommand extends AbstractCommand
             ) + $this->errorAndDiffCollector->getRemovedAndAddedFilesCount()
         ));
 
+        // inverse error code for CI dry-run
         if ($this->configuration->isDryRun() && count($this->errorAndDiffCollector->getFileDiffs())) {
             return Shell::CODE_ERROR;
         }

--- a/src/Console/Output/ConsoleOutputFormatter.php
+++ b/src/Console/Output/ConsoleOutputFormatter.php
@@ -49,7 +49,7 @@ final class ConsoleOutputFormatter implements OutputFormatterInterface
         foreach ($fileDiffs as $fileDiff) {
             $this->symfonyStyle->writeln(sprintf('<options=bold>%d) %s</>', ++$i, $fileDiff->getFile()));
             $this->symfonyStyle->newLine();
-            $this->symfonyStyle->writeln($fileDiff->getDiff());
+            $this->symfonyStyle->writeln($fileDiff->getDiffConsoleFormatted());
             $this->symfonyStyle->newLine();
 
             if ($fileDiff->getAppliedRectorClasses() !== []) {

--- a/src/Console/Output/ConsoleOutputFormatter.php
+++ b/src/Console/Output/ConsoleOutputFormatter.php
@@ -29,6 +29,15 @@ final class ConsoleOutputFormatter implements OutputFormatterInterface
     {
         $this->reportFileDiffs($errorAndDiffCollector->getFileDiffs());
         $this->reportErrors($errorAndDiffCollector->getErrors());
+
+        if ($errorAndDiffCollector->getErrors() !== []) {
+            return;
+        }
+
+        $this->symfonyStyle->success(sprintf(
+            'Rector is done! %d changed files',
+            count($errorAndDiffCollector->getFileDiffs()) + $errorAndDiffCollector->getRemovedAndAddedFilesCount()
+        ));
     }
 
     public function getName(): string

--- a/src/Console/Output/ConsoleOutputFormatter.php
+++ b/src/Console/Output/ConsoleOutputFormatter.php
@@ -3,6 +3,7 @@
 namespace Rector\Console\Output;
 
 use Rector\Application\Error;
+use Rector\Application\ErrorAndDiffCollector;
 use Rector\Contract\Console\Output\OutputFormatterInterface;
 use Rector\Reporting\FileDiff;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -24,6 +25,12 @@ final class ConsoleOutputFormatter implements OutputFormatterInterface
         $this->symfonyStyle = $symfonyStyle;
     }
 
+    public function report(ErrorAndDiffCollector $errorAndDiffCollector): void
+    {
+        $this->reportFileDiffs($errorAndDiffCollector->getFileDiffs());
+        $this->reportErrors($errorAndDiffCollector->getErrors());
+    }
+
     public function getName(): string
     {
         return self::NAME;
@@ -32,7 +39,7 @@ final class ConsoleOutputFormatter implements OutputFormatterInterface
     /**
      * @param FileDiff[] $fileDiffs
      */
-    public function reportFileDiffs(array $fileDiffs): void
+    private function reportFileDiffs(array $fileDiffs): void
     {
         if (count($fileDiffs) <= 0) {
             return;
@@ -64,7 +71,7 @@ final class ConsoleOutputFormatter implements OutputFormatterInterface
     /**
      * @param Error[] $errors
      */
-    public function reportErrors(array $errors): void
+    private function reportErrors(array $errors): void
     {
         foreach ($errors as $error) {
             $message = sprintf(

--- a/src/Console/Output/JsonOutputFormatter.php
+++ b/src/Console/Output/JsonOutputFormatter.php
@@ -4,32 +4,52 @@ namespace Rector\Console\Output;
 
 use Nette\Utils\Json;
 use Rector\Application\ErrorAndDiffCollector;
+use Rector\Configuration\Configuration;
 use Rector\Contract\Console\Output\OutputFormatterInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class JsonOutputFormatter implements OutputFormatterInterface
 {
     /**
+     * @var string
+     */
+    public const NAME = 'json';
+
+    /**
      * @var SymfonyStyle
      */
     private $symfonyStyle;
 
-    public function __construct(SymfonyStyle $symfonyStyle)
+    /**
+     * @var Configuration
+     */
+    private $configuration;
+
+    public function __construct(SymfonyStyle $symfonyStyle, Configuration $configuration)
     {
         $this->symfonyStyle = $symfonyStyle;
+        $this->configuration = $configuration;
     }
 
     public function getName(): string
     {
-        return 'json';
+        return self::NAME;
     }
 
     public function report(ErrorAndDiffCollector $errorAndDiffCollector): void
     {
         $fileDiffs = $errorAndDiffCollector->getFileDiffs();
 
-        $errorsArray = [];
-        $errorsArray['totals']['changed_files'] = count($fileDiffs);
+        $errorsArray = [
+            'meta' => [
+                'version' => $this->configuration->getPrettyVersion(),
+                'config' => $this->configuration->getConfigFilePath(),
+            ],
+            'totals' => [
+                'changed_files' => count($fileDiffs),
+                'removed_and_added_files_count' => $errorAndDiffCollector->getRemovedAndAddedFilesCount(),
+            ],
+        ];
 
         ksort($fileDiffs);
 

--- a/src/Console/Output/JsonOutputFormatter.php
+++ b/src/Console/Output/JsonOutputFormatter.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Console\Output;
+
+use Nette\Utils\Json;
+use Rector\Application\Error;
+use Rector\Contract\Console\Output\OutputFormatterInterface;
+use Rector\Reporting\FileDiff;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+final class JsonOutputFormatter implements OutputFormatterInterface
+{
+    /**
+     * @var SymfonyStyle
+     */
+    private $symfonyStyle;
+
+    public function __construct(SymfonyStyle $symfonyStyle)
+    {
+        $this->symfonyStyle = $symfonyStyle;
+    }
+
+    public function getName(): string
+    {
+        return 'json';
+    }
+
+    /**
+     * @param FileDiff[] $fileDiffs
+     */
+    public function reportFileDiffs(array $fileDiffs): void
+    {
+        $errorsArray = [];
+        $errorsArray['totals']['changed_files'] = count($fileDiffs);
+
+        ksort($fileDiffs);
+
+        foreach ($fileDiffs as $fileDiff) {
+            $errorsArray['file_diffs'][] = [
+                'file' => $fileDiff->getFile(),
+                'diff' => $fileDiff->getDiff(),
+                'applied_rectors' => $fileDiff->getAppliedRectorClasses(),
+            ];
+        }
+
+        $json = Json::encode($errorsArray, Json::PRETTY);
+
+        $this->symfonyStyle->writeln($json);
+    }
+
+    /**
+     * @param Error[] $errors
+     */
+    public function reportErrors(array $errors): void
+    {
+        $errorsArray = [];
+        $errorsArray['totals']['errors'] = count($errors);
+
+        foreach ($errors as $error) {
+            $errorData = [
+                'message' => $error->getMessage(),
+                'file' => $error->getFileInfo()->getPathname(),
+            ];
+
+            if ($error->getRectorClass()) {
+                $errorData['caused_by'] = $error->getRectorClass();
+            }
+
+            if ($error->getLine() !== null) {
+                $errorData['line'] = $error->getLine();
+            }
+
+            $errorsArray['errors'][] = $errorData;
+        }
+
+        $json = Json::encode($errorsArray, Json::PRETTY);
+
+        $this->symfonyStyle->writeln($json);
+    }
+}

--- a/src/Console/Output/JsonOutputFormatter.php
+++ b/src/Console/Output/JsonOutputFormatter.php
@@ -52,13 +52,15 @@ final class JsonOutputFormatter implements OutputFormatterInterface
         ];
 
         ksort($fileDiffs);
-
         foreach ($fileDiffs as $fileDiff) {
             $errorsArray['file_diffs'][] = [
                 'file' => $fileDiff->getFile(),
                 'diff' => $fileDiff->getDiff(),
                 'applied_rectors' => $fileDiff->getAppliedRectorClasses(),
             ];
+
+            // for Rector CI
+            $errorsArray['changed_files'][] = $fileDiff->getFile();
         }
 
         $errors = $errorAndDiffCollector->getErrors();

--- a/src/Console/Output/JsonOutputFormatter.php
+++ b/src/Console/Output/JsonOutputFormatter.php
@@ -3,9 +3,8 @@
 namespace Rector\Console\Output;
 
 use Nette\Utils\Json;
-use Rector\Application\Error;
+use Rector\Application\ErrorAndDiffCollector;
 use Rector\Contract\Console\Output\OutputFormatterInterface;
-use Rector\Reporting\FileDiff;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class JsonOutputFormatter implements OutputFormatterInterface
@@ -25,11 +24,10 @@ final class JsonOutputFormatter implements OutputFormatterInterface
         return 'json';
     }
 
-    /**
-     * @param FileDiff[] $fileDiffs
-     */
-    public function reportFileDiffs(array $fileDiffs): void
+    public function report(ErrorAndDiffCollector $errorAndDiffCollector): void
     {
+        $fileDiffs = $errorAndDiffCollector->getFileDiffs();
+
         $errorsArray = [];
         $errorsArray['totals']['changed_files'] = count($fileDiffs);
 
@@ -43,17 +41,7 @@ final class JsonOutputFormatter implements OutputFormatterInterface
             ];
         }
 
-        $json = Json::encode($errorsArray, Json::PRETTY);
-
-        $this->symfonyStyle->writeln($json);
-    }
-
-    /**
-     * @param Error[] $errors
-     */
-    public function reportErrors(array $errors): void
-    {
-        $errorsArray = [];
+        $errors = $errorAndDiffCollector->getErrors();
         $errorsArray['totals']['errors'] = count($errors);
 
         foreach ($errors as $error) {

--- a/src/Contract/Console/Output/OutputFormatterInterface.php
+++ b/src/Contract/Console/Output/OutputFormatterInterface.php
@@ -2,20 +2,11 @@
 
 namespace Rector\Contract\Console\Output;
 
-use Rector\Application\Error;
-use Rector\Reporting\FileDiff;
+use Rector\Application\ErrorAndDiffCollector;
 
 interface OutputFormatterInterface
 {
     public function getName(): string;
 
-    /**
-     * @param FileDiff[] $fileDiffs
-     */
-    public function reportFileDiffs(array $fileDiffs): void;
-
-    /**
-     * @param Error[] $errors
-     */
-    public function reportErrors(array $errors): void;
+    public function report(ErrorAndDiffCollector $errorAndDiffCollector): void;
 }

--- a/src/Reporting/FileDiff.php
+++ b/src/Reporting/FileDiff.php
@@ -20,18 +20,33 @@ final class FileDiff
     private $appliedRectorClasses = [];
 
     /**
+     * @var string
+     */
+    private $diffConsoleFormatted;
+
+    /**
      * @param string[] $appliedRectorClasses
      */
-    public function __construct(string $file, string $diff, array $appliedRectorClasses = [])
-    {
+    public function __construct(
+        string $file,
+        string $diff,
+        string $diffConsoleFormatted,
+        array $appliedRectorClasses = []
+    ) {
         $this->file = $file;
         $this->diff = $diff;
         $this->appliedRectorClasses = $appliedRectorClasses;
+        $this->diffConsoleFormatted = $diffConsoleFormatted;
     }
 
     public function getDiff(): string
     {
         return $this->diff;
+    }
+
+    public function getDiffConsoleFormatted(): string
+    {
+        return $this->diffConsoleFormatted;
     }
 
     public function getFile(): string


### PR DESCRIPTION
Closes #1455 

## Example output

```bash
bin/rector p src/Console/Output -n -o json
```

(`-n` = `--dry-run`, `-o` = `--output-format`)

```json
{
    "meta": {
        "version": "0.5.x-dev@adba626",
        "config": "/var/www/rector/rector.yaml"
    },
    "totals": {
        "changed_files": 1,
        "removed_and_added_files_count": 0,
        "errors": 0
    },
    "file_diffs": [
        {
            "file": "/var/www/rector/src/Console/Output/JsonOutputFormatter.php",
            "diff": "--- Original\n+++ New\n@@ -25,7 +25,7 @@\n      */\n     private $configuration;\n \n-    public function __construct(\\Symfony\\Component\\Console\\Style\\SymfonyStyle $symfonyStyle, Configuration $configuration)\n+    public function __construct(SymfonyStyle $symfonyStyle, Configuration $configuration)\n     {\n         $this->symfonyStyle = $symfonyStyle;\n         $this->configuration = $configuration;\n",
            "applied_rectors": [
                "Rector\\CodingStyle\\Rector\\Namespace_\\ImportFullyQualifiedNamesRector"
            ]
        }
    ],
    "changed_files": [
        "/var/www/rector/src/Console/Output/JsonOutputFormatter.php"
    ]
}
```