### PR TITLE
Test `void` methods doesn't have the `return` statement added.

### DIFF
--- a/packages/CodeQuality/tests/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/CallableThisArrayToAnonymousFunctionRectorTest.php
+++ b/packages/CodeQuality/tests/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/CallableThisArrayToAnonymousFunctionRectorTest.php
@@ -16,6 +16,7 @@ final class CallableThisArrayToAnonymousFunctionRectorTest extends AbstractRecto
             __DIR__ . '/Fixture/skip_another_class.php.inc',
             __DIR__ . '/Fixture/skip_empty_first_array.php.inc',
             __DIR__ . '/Fixture/skip_as_well.php.inc',
+            __DIR__ . '/Fixture/no_return_for_void.php.inc',
         ]);
     }
 

--- a/packages/CodeQuality/tests/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/Fixture/no_return_for_void.php.inc
+++ b/packages/CodeQuality/tests/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/Fixture/no_return_for_void.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\CodeQuality\Tests\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+class HasVoidMethod
+{
+    public function run(array $values)
+    {
+        usort($values, [$this, 'compareSize']);
+
+        return $values;
+    }
+
+    private function thisReturnsVoid(): void
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CodeQuality\Tests\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+class HasVoidMethod
+{
+    public function run(array $values)
+    {
+        usort($values, function () : void {
+            $this->thisReturnsVoid();
+        });
+
+        return $values;
+    }
+
+    private function thisReturnsVoid(): void
+    {
+    }
+}
+
+?>

--- a/packages/CodeQuality/tests/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/Fixture/no_return_for_void.php.inc
+++ b/packages/CodeQuality/tests/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/Fixture/no_return_for_void.php.inc
@@ -6,7 +6,7 @@ class HasVoidMethod
 {
     public function run(array $values)
     {
-        usort($values, [$this, 'compareSize']);
+        usort($values, [$this, 'thisReturnsVoid']);
 
         return $values;
     }


### PR DESCRIPTION
Failing test for https://github.com/rectorphp/rector/issues/1499