### PR TITLE
Test concatenation dot is ignored.

### DIFF
--- a/packages/Php/tests/Rector/BinaryOp/BinaryOpBetweenNumberAndStringRector/BinaryOpBetweenNumberAndStringRectorTest.php
+++ b/packages/Php/tests/Rector/BinaryOp/BinaryOpBetweenNumberAndStringRector/BinaryOpBetweenNumberAndStringRectorTest.php
@@ -9,7 +9,10 @@ final class BinaryOpBetweenNumberAndStringRectorTest extends AbstractRectorTestC
 {
     public function test(): void
     {
-        $this->doTestFiles([__DIR__ . '/Fixture/fixture.php.inc']);
+        $this->doTestFiles([
+            __DIR__ . '/Fixture/fixture.php.inc',
+            __DIR__ . '/Fixture/ignore_concatenation_dot.php.inc',
+        ]);
     }
 
     protected function getRectorClass(): string

--- a/packages/Php/tests/Rector/BinaryOp/BinaryOpBetweenNumberAndStringRector/Fixture/ignore_concatenation_dot.php.inc
+++ b/packages/Php/tests/Rector/BinaryOp/BinaryOpBetweenNumberAndStringRector/Fixture/ignore_concatenation_dot.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Php\Tests\Rector\BinaryOp\BinaryOpBetweenNumberAndStringRector\Fixture;
+
+class IgnoreConcatenationDots
+{
+    public function run()
+    {
+        $string = 'this is a string to cancatenate with the number';
+        $number = 10;
+        $value = $string . ' ' . $number;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Php\Tests\Rector\BinaryOp\BinaryOpBetweenNumberAndStringRector\Fixture;
+
+class IgnoreConcatenationDots
+{
+    public function run()
+    {
+        $string = 'this is a string to cancatenate with the number';
+        $number = 10;
+        $value = $string . ' ' . $number;
+    }
+}
+
+?>


### PR DESCRIPTION
Ensure that if a concatenation is made between a `string` and an `int`, Rector will not change anything, leaving the code as is.

https://github.com/rectorphp/rector/issues/1501