### PR TITLE
Widen `PHPStan` version constraint to `~0.11.6`.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "nette/utils": "^2.5|^3.0",
         "nikic/php-parser": "^4.2.2",
         "phpstan/phpdoc-parser": "^0.3.4",
-        "phpstan/phpstan": "0.11.6",
+        "phpstan/phpstan": "~0.11.6",
         "sebastian/diff": "^3.0",
         "symfony/console": "^3.4|^4.2",
         "symfony/dependency-injection": "^3.4|^4.2",


### PR DESCRIPTION
Issue #1515.