### PR TITLE
Do not call parent constructor of AutowiredEventDispatcher unless it exists

### DIFF
--- a/src/EventDispatcher/AutowiredEventDispatcher.php
+++ b/src/EventDispatcher/AutowiredEventDispatcher.php
@@ -16,6 +16,8 @@ final class AutowiredEventDispatcher extends EventDispatcher
             $this->addSubscriber($eventSubscriber);
         }
 
-        parent::__construct();
+        if (method_exists(get_parent_class($this), '__construct')) {
+            parent::__construct();
+        }
     }
 }


### PR DESCRIPTION
Signed-off-by: Kevin R <22906111+cgkkevinr@users.noreply.github.com>