### PR TITLE
Fix classname change for FilterControllerEvent

### DIFF
--- a/config/level/symfony/symfony43.yaml
+++ b/config/level/symfony/symfony43.yaml
@@ -39,7 +39,7 @@ services:
 
         # EventDispatcher
         Symfony\Component\HttpKernel\Event\FilterControllerArgumentsEvent: 'Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent'
-        Symfony\Component\HttpKernel\Event\FilterControllerEvent: 'Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent'
+        Symfony\Component\HttpKernel\Event\FilterControllerEvent: 'Symfony\Component\HttpKernel\Event\ControllerEvent'
         Symfony\Component\HttpKernel\Event\FilterResponseEvent: 'Symfony\Component\HttpKernel\Event\ResponseEvent'
         Symfony\Component\HttpKernel\Event\GetResponseEvent: 'Symfony\Component\HttpKernel\Event\RequestEvent'
         Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent: 'Symfony\Component\HttpKernel\Event\ViewEvent'


### PR DESCRIPTION
As described in https://github.com/symfony/symfony/blob/4.4/UPGRADE-4.3.md#httpkernel the new name for the FilterControllerEvent is ControllerEvent