### PR TITLE
[Laravel] Fix missing method name in 5.7

### DIFF
--- a/config/set/laravel/laravel57.yaml
+++ b/config/set/laravel/laravel57.yaml
@@ -22,5 +22,6 @@ services:
 
     Rector\Rector\Argument\ArgumentRemoverRector:
         Illuminate\Foundation\Application:
-            1:
-                name: 'options'
+            register:
+                1:
+                    name: 'options'


### PR DESCRIPTION
Closes #1598