### PR TITLE
Fix Open Collective link for FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,3 @@
 patreon: rectorphp
-opencollective: rectorphp
+open_collective: rectorphp
 github: tomasvotruba


### PR DESCRIPTION
This fixes the `FUNDING.yml` file to use the correct Open Collective id.

Currently the Sponsor button shows the following error notice:
> Unknown funding platform 'opencollective'. 