### PR TITLE
[Symfony] Fix GetRequestRector overlap to non-controllers

### DIFF
--- a/packages/Symfony/tests/Rector/HttpKernel/GetRequestRector/Fixture/skip_event_subscriber.php.inc
+++ b/packages/Symfony/tests/Rector/HttpKernel/GetRequestRector/Fixture/skip_event_subscriber.php.inc
@@ -1,0 +1,13 @@
+<?php declare (strict_types=1);
+
+namespace Rector\Symfony\Tests\Rector\HttpKernel\GetRequestRector\Fixture;
+
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+
+final class SkipEventSubscriber
+{
+    public function onKernelException(GetResponseForExceptionEvent $event)
+    {
+        $request = $event->getRequest();
+    }
+}

--- a/packages/Symfony/tests/Rector/HttpKernel/GetRequestRector/GetRequestRectorTest.php
+++ b/packages/Symfony/tests/Rector/HttpKernel/GetRequestRector/GetRequestRectorTest.php
@@ -13,6 +13,7 @@ final class GetRequestRectorTest extends AbstractRectorTestCase
             __DIR__ . '/Fixture/fixture.php.inc',
             __DIR__ . '/Fixture/fixture2.php.inc',
             __DIR__ . '/Fixture/fixture3.php.inc',
+            __DIR__ . '/Fixture/skip_event_subscriber.php.inc',
         ]);
     }
 


### PR DESCRIPTION
Closes #1607