### PR TITLE
[Bugfix] PHPDoc type-hint `resource` should not be used as PHP type-hint

### DIFF
--- a/packages/TypeDeclaration/src/Rector/FunctionLike/ParamTypeDeclarationRector.php
+++ b/packages/TypeDeclaration/src/Rector/FunctionLike/ParamTypeDeclarationRector.php
@@ -151,6 +151,13 @@ CODE_SAMPLE
                 }
             } else {
                 $paramNode->type = $paramTypeInfo->getTypeNode();
+
+                // "resource" is valid phpdoc type, but it's not implemented in PHP
+                if ($paramNode->type instanceof Node\Name && reset($paramNode->type->parts) === 'resource') {
+                    $paramNode->type = null;
+
+                    continue;
+                }
             }
 
             $this->populateChildren($node, $position, $paramTypeInfo);

--- a/packages/TypeDeclaration/tests/Rector/FunctionLike/ParamTypeDeclarationRector/Fixture/resource.php.inc
+++ b/packages/TypeDeclaration/tests/Rector/FunctionLike/ParamTypeDeclarationRector/Fixture/resource.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\TypeDeclaration\Tests\Rector\ClassMethod\ParamTypeDeclarationRector\Fixture;
+
+class ResourceTypes
+{
+    /**
+     * @param resource $value
+     */
+    public function someFunction($value)
+    {
+    }
+}

--- a/packages/TypeDeclaration/tests/Rector/FunctionLike/ParamTypeDeclarationRector/ParamTypeDeclarationRectorTest.php
+++ b/packages/TypeDeclaration/tests/Rector/FunctionLike/ParamTypeDeclarationRector/ParamTypeDeclarationRectorTest.php
@@ -15,6 +15,7 @@ final class ParamTypeDeclarationRectorTest extends AbstractRectorTestCase
             // various
             __DIR__ . '/Fixture/variadic.php.inc',
             __DIR__ . '/Fixture/mixed.php.inc',
+            __DIR__ . '/Fixture/resource.php.inc',
             __DIR__ . '/Fixture/trait_interface.php.inc',
             __DIR__ . '/Fixture/this.php.inc',
             __DIR__ . '/Fixture/false.php.inc',


### PR DESCRIPTION
Closes #1663.