### PR TITLE
Add rector.yaml to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,8 @@
 .editorconfig
 .phpstorm.meta.php
 
+rector.yaml
+
 LICENSE
 
 .git/


### PR DESCRIPTION
Context: 
I'm trying to use the Rector docker image to upgrade a testsuite from PHPUnit 6 to PHPUnit 8.

Symptom: 
Rector refuses to process files in a directory named `tests`. It only finds these files if I create an 'empty' `rector.yaml` configuration file in my project and specify it on the command line using the `-c` flag.

Analysis:
It turns out that when no config file is specified as a command line option, Rector looks for one in its current working directory. In the docker image, this is `/rector`, the directory containing the source files of Rector itself. Among these is `rector.yaml`, which is the Rector configuration file for developing on rector itself (at least I think so). This file contains an exclude pattern for `/tests/`, which is useful when working on Rector itself, but is now also used as an exclude when applying Rector on another project.

Proposed solution:
The `rector.yaml` configuration file for developing on rector itself should never be used by default in runtime. We can do so by adding it to `.dockerignore`, so that it is excluded from the docker image.