### PR TITLE
[DeadCode] Allow static constant call on RemoveUnusedPrivateConstantRector

### DIFF
--- a/packages/DeadCode/tests/Rector/ClassConst/RemoveUnusedPrivateConstantRector/Fixture/keep_static_constant.php.inc
+++ b/packages/DeadCode/tests/Rector/ClassConst/RemoveUnusedPrivateConstantRector/Fixture/keep_static_constant.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\DeadCode\Tests\Rector\ClassConst\RemoveUnusedPrivateConstantRector\Fixture;
+
+final class KeepStaticConstant
+{
+    private const SOME_CONSTANT = 5;
+    public function run()
+    {
+        return static::SOME_CONSTANT;
+    }
+}

--- a/packages/DeadCode/tests/Rector/ClassConst/RemoveUnusedPrivateConstantRector/RemoveUnusedPrivateConstantRectorTest.php
+++ b/packages/DeadCode/tests/Rector/ClassConst/RemoveUnusedPrivateConstantRector/RemoveUnusedPrivateConstantRectorTest.php
@@ -9,7 +9,11 @@ final class RemoveUnusedPrivateConstantRectorTest extends AbstractRectorTestCase
 {
     public function test(): void
     {
-        $this->doTestFiles([__DIR__ . '/Fixture/fixture.php.inc', __DIR__ . '/Fixture/keep_constant.php.inc']);
+        $this->doTestFiles([
+            __DIR__ . '/Fixture/fixture.php.inc',
+            __DIR__ . '/Fixture/keep_constant.php.inc',
+            __DIR__ . '/Fixture/keep_static_constant.php.inc',
+        ]);
     }
 
     protected function getRectorClass(): string

--- a/src/PhpParser/Node/Manipulator/ClassConstManipulator.php
+++ b/src/PhpParser/Node/Manipulator/ClassConstManipulator.php
@@ -58,12 +58,13 @@ final class ClassConstManipulator
                 return false;
             }
 
-            // is it the name match?
-            if ($this->nameResolver->resolve($node) !== 'self::' . $this->nameResolver->resolve($classConst)) {
-                return false;
-            }
-
-            return true;
+            return $this->isNameMatch($node, $classConst);
         });
+    }
+
+    private function isNameMatch(Node $node, ClassConst $classConst): bool
+    {
+        return $this->nameResolver->resolve($node) === 'self::' . $this->nameResolver->resolve($classConst)
+            || $this->nameResolver->resolve($node) === 'static::' . $this->nameResolver->resolve($classConst);
     }
 }


### PR DESCRIPTION
Basically there were false positives regarding private constant uses when called with `static::` instead of `self::`

**Note**: `phpstan` is failing [on master too](https://github.com/rectorphp/rector/commits/master). I've fixed it on #1698 