### PR TITLE
Update composer scripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -139,7 +139,7 @@
             "@check-cs",
             "phpunit",
             "@phpstan",
-            "@update-docs"
+            "@docs"
         ],
         "check-cs": "vendor/bin/ecs check bin packages src tests utils --ansi",
         "fix-cs": [


### PR DESCRIPTION
There was a call to `@update-docs` but the script is called `@docs`.

**Note**: `phpstan` is failing [on master too](https://github.com/rectorphp/rector/commits/master). I've fixed it on #1698 