### PR TITLE
Don't mess with lines between docblock comment and var type.

### DIFF
--- a/packages/BetterPhpDocParser/src/Printer/PhpDocInfoPrinter.php
+++ b/packages/BetterPhpDocParser/src/Printer/PhpDocInfoPrinter.php
@@ -74,7 +74,7 @@ final class PhpDocInfoPrinter
      * - Print(subnode2)
      * - Tokens[subnode2.endPos .. node.endPos]
      */
-    public function printFormatPreserving(PhpDocInfo $phpDocInfo): string
+    public function printFormatPreserving(PhpDocInfo $phpDocInfo, bool $shouldSkipEmptyLinesAbove = false): string
     {
         $this->attributeAwarePhpDocNode = $phpDocInfo->getPhpDocNode();
         $this->tokens = $phpDocInfo->getTokens();
@@ -84,11 +84,13 @@ final class PhpDocInfoPrinter
         $this->currentTokenPosition = 0;
         $this->removedNodePositions = [];
 
-        return $this->printPhpDocNode($this->attributeAwarePhpDocNode);
+        return $this->printPhpDocNode($this->attributeAwarePhpDocNode, $shouldSkipEmptyLinesAbove);
     }
 
-    private function printPhpDocNode(AttributeAwarePhpDocNode $attributeAwarePhpDocNode): string
-    {
+    private function printPhpDocNode(
+        AttributeAwarePhpDocNode $attributeAwarePhpDocNode,
+        bool $shouldSkipEmptyLinesAbove = false
+    ): string {
         // no nodes were, so empty doc
         if ($this->isPhpDocNodeEmpty($attributeAwarePhpDocNode)) {
             return '';
@@ -101,7 +103,7 @@ final class PhpDocInfoPrinter
         // node output
         $nodeCount = count($attributeAwarePhpDocNode->children);
         foreach ($attributeAwarePhpDocNode->children as $i => $phpDocChildNode) {
-            $output .= $this->printNode($phpDocChildNode, null, $i + 1, $nodeCount);
+            $output .= $this->printNode($phpDocChildNode, null, $i + 1, $nodeCount, $shouldSkipEmptyLinesAbove);
         }
 
         return $this->printEnd($output);
@@ -130,7 +132,8 @@ final class PhpDocInfoPrinter
         AttributeAwareNodeInterface $attributeAwareNode,
         ?StartEndInfo $startEndInfo = null,
         int $i = 0,
-        int $nodeCount = 0
+        int $nodeCount = 0,
+        bool $shouldSkipEmptyLinesAbove = false
     ): string {
         $output = '';
 
@@ -145,7 +148,7 @@ final class PhpDocInfoPrinter
                 $output,
                 $this->currentTokenPosition,
                 $startEndInfo->getStart(),
-                $isLastToken
+                ! $shouldSkipEmptyLinesAbove && $isLastToken
             );
 
             $this->currentTokenPosition = $startEndInfo->getEnd();

--- a/packages/CodingStyle/src/Rector/ClassConst/VarConstantCommentRector.php
+++ b/packages/CodingStyle/src/Rector/ClassConst/VarConstantCommentRector.php
@@ -69,8 +69,6 @@ CODE_SAMPLE
             return null;
         }
 
-        $varTypeInfo = $this->docBlockManipulator->getVarTypeInfo($node);
-
         $constStaticType = $this->getStaticType($node->consts[0]->value);
         if ($constStaticType === null) {
             return null;
@@ -82,6 +80,8 @@ CODE_SAMPLE
         if ($staticTypesInStrings === []) {
             return null;
         }
+
+        $varTypeInfo = $this->docBlockManipulator->getVarTypeInfo($node);
 
         if ($varTypeInfo && $varTypeInfo->getTypes() === $staticTypesInStrings) {
             // already set

--- a/packages/CodingStyle/tests/Rector/ClassConst/VarConstantCommentRector/Fixture/correct_invalid.php.inc
+++ b/packages/CodingStyle/tests/Rector/ClassConst/VarConstantCommentRector/Fixture/correct_invalid.php.inc
@@ -19,6 +19,24 @@ class CorrectInvalid
      * Some comment, but no type.
      */
     public const HI = 5;
+
+    /**
+     * Some comment and right type, with a line between.
+     *
+     * @var string[]
+     */
+    public const HELLO = [
+        'string'
+    ];
+
+    /**
+     * Some comment and wrong type, with a line between.
+     *
+     * @var int
+     */
+    public const HELLO_AGAIN = [
+        'string'
+    ];
 }
 
 ?>
@@ -48,6 +66,24 @@ class CorrectInvalid
      * @var int
      */
     public const HI = 5;
+
+    /**
+     * Some comment and right type, with a line between.
+     *
+     * @var string[]
+     */
+    public const HELLO = [
+        'string'
+    ];
+
+    /**
+     * Some comment and wrong type, with a line between.
+     *
+     * @var string[]
+     */
+    public const HELLO_AGAIN = [
+        'string'
+    ];
 }
 
 ?>

--- a/packages/NodeTypeResolver/src/PhpDoc/NodeAnalyzer/DocBlockManipulator.php
+++ b/packages/NodeTypeResolver/src/PhpDoc/NodeAnalyzer/DocBlockManipulator.php
@@ -145,7 +145,7 @@ final class DocBlockManipulator
         }
     }
 
-    public function removeTagFromNode(Node $node, string $name): void
+    public function removeTagFromNode(Node $node, string $name, bool $shouldSkipEmptyLinesAbove = false): void
     {
         if ($node->getDocComment() === null) {
             return;
@@ -154,7 +154,7 @@ final class DocBlockManipulator
         $phpDocInfo = $this->createPhpDocInfoFromNode($node);
 
         $this->removeTagByName($phpDocInfo, $name);
-        $this->updateNodeWithPhpDocInfo($node, $phpDocInfo);
+        $this->updateNodeWithPhpDocInfo($node, $phpDocInfo, $shouldSkipEmptyLinesAbove);
     }
 
     public function changeType(Node $node, string $oldType, string $newType, bool $includeChildren = false): void
@@ -259,7 +259,7 @@ final class DocBlockManipulator
 
     public function changeVarTag(Node $node, string $type): void
     {
-        $this->removeTagFromNode($node, 'var');
+        $this->removeTagFromNode($node, 'var', true);
         $this->addTypeSpecificTag($node, 'var', $type);
     }
 
@@ -506,14 +506,17 @@ final class DocBlockManipulator
         return (bool) Strings::match($text, '#\@(param|throws|return|var)\b#');
     }
 
-    public function updateNodeWithPhpDocInfo(Node $node, PhpDocInfo $phpDocInfo): bool
-    {
+    public function updateNodeWithPhpDocInfo(
+        Node $node,
+        PhpDocInfo $phpDocInfo,
+        bool $shouldSkipEmptyLinesAbove = false
+    ): bool {
         // skip if has no doc comment
         if ($node->getDocComment() === null) {
             return false;
         }
 
-        $phpDoc = $this->phpDocInfoPrinter->printFormatPreserving($phpDocInfo);
+        $phpDoc = $this->phpDocInfoPrinter->printFormatPreserving($phpDocInfo, $shouldSkipEmptyLinesAbove);
         if ($phpDoc !== '') {
             // no change, don't save it
             if ($node->getDocComment()->getText() === $phpDoc) {


### PR DESCRIPTION
Previously, this code:

```php
/**
 * My comment.
 *
 * @var array
 */
public const CONST = [
    'string'
];
```

would become:


```php
/**
 * My comment.
 * @var string[]
 */
public const CONST = [
    'string'
];
```
messing with code standards/style (removing the line between comment and `@var`).

Now it stays as is:



```php
/**
 * My comment.
 *
 * @var string[]
 */
public const CONST = [
    'string'
];
```

(without breaking anything else)