### PR TITLE
[FuncCall] Don't add $result to parse_str if second parameter is already set

### DIFF
--- a/packages/Php/src/Rector/FuncCall/ParseStrWithResultArgumentRector.php
+++ b/packages/Php/src/Rector/FuncCall/ParseStrWithResultArgumentRector.php
@@ -52,6 +52,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if (isset($node->args[1])) {
+            return null;
+        }
+
         $resultVariable = new Variable('result');
         $node->args[1] = new Arg($resultVariable);
 

--- a/packages/Php/tests/Rector/FuncCall/ParseStrWithResultArgumentRector/Fixture/already_set.php.inc
+++ b/packages/Php/tests/Rector/FuncCall/ParseStrWithResultArgumentRector/Fixture/already_set.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Php\Tests\Rector\FuncCall\ParseStrWithResultArgumentRector\Fixture;
+
+class AlreadySet
+{
+    public function run()
+    {
+        $query = 'bla';
+        parse_str($query, $data);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Php\Tests\Rector\FuncCall\ParseStrWithResultArgumentRector\Fixture;
+
+class AlreadySet
+{
+    public function run()
+    {
+        $query = 'bla';
+        parse_str($query, $data);
+    }
+}
+
+?>

--- a/packages/Php/tests/Rector/FuncCall/ParseStrWithResultArgumentRector/ParseStrWithResultArgumentRectorTest.php
+++ b/packages/Php/tests/Rector/FuncCall/ParseStrWithResultArgumentRector/ParseStrWithResultArgumentRectorTest.php
@@ -9,7 +9,7 @@ final class ParseStrWithResultArgumentRectorTest extends AbstractRectorTestCase
 {
     public function test(): void
     {
-        $this->doTestFiles([__DIR__ . '/Fixture/fixture.php.inc']);
+        $this->doTestFiles([__DIR__ . '/Fixture/fixture.php.inc', __DIR__ . '/Fixture/already_set.php.inc']);
     }
 
     protected function getRectorClass(): string


### PR DESCRIPTION
Before this fix, `parse_str($query, $data);` would turn into `parse_str($query, $result);` by no reason, breaking valid code.