### PR TITLE
[MethodCall] Fix multilevel array subsets

### DIFF
--- a/packages/PHPUnit/tests/Rector/MethodCall/ReplaceAssertArraySubsetRector/Fixture/multilevel_array.php.inc
+++ b/packages/PHPUnit/tests/Rector/MethodCall/ReplaceAssertArraySubsetRector/Fixture/multilevel_array.php.inc
@@ -1,0 +1,72 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\MethodCall\ReplaceAssertArraySubsetRector\Fixture;
+
+class MultiLevelArray extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $checkedArray = [];
+        $expectedSubset = [
+            'cache_directory' => [
+                [
+                    'new_value' => true,
+                ],
+            ],
+        ];
+
+        $this->assertArraySubset($expectedSubset, $checkedArray);
+    }
+
+    public function otherTest()
+    {
+        $checkedArray = [];
+
+        $this->assertArraySubset(
+            [
+                'cache_directory' => [
+                    [
+                        'new_value' => true,
+                    ],
+                ],
+            ],
+            $checkedArray
+        );
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\MethodCall\ReplaceAssertArraySubsetRector\Fixture;
+
+class MultiLevelArray extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        $checkedArray = [];
+        $expectedSubset = [
+            'cache_directory' => [
+                [
+                    'new_value' => true,
+                ],
+            ],
+        ];
+        $this->assertArrayHasKey('cache_directory', $checkedArray);
+        $this->assertSame([['new_value' => true]], $checkedArray['cache_directory']);
+    }
+
+    public function otherTest()
+    {
+        $checkedArray = [];
+        $this->assertArrayHasKey('cache_directory', $checkedArray);
+        $this->assertSame([
+            [
+                'new_value' => true,
+            ],
+        ], $checkedArray['cache_directory']);
+    }
+}
+
+?>

--- a/packages/PHPUnit/tests/Rector/MethodCall/ReplaceAssertArraySubsetRector/ReplaceAssertArraySubsetRectorTest.php
+++ b/packages/PHPUnit/tests/Rector/MethodCall/ReplaceAssertArraySubsetRector/ReplaceAssertArraySubsetRectorTest.php
@@ -13,6 +13,7 @@ final class ReplaceAssertArraySubsetRectorTest extends AbstractRectorTestCase
             __DIR__ . '/Fixture/fixture.php.inc',
             __DIR__ . '/Fixture/issue_2069.php.inc',
             __DIR__ . '/Fixture/issue_2237.php.inc',
+            __DIR__ . '/Fixture/multilevel_array.php.inc',
             __DIR__ . '/Fixture/variable.php.inc',
         ]);
     }

--- a/src/PhpParser/Node/Value/ValueResolver.php
+++ b/src/PhpParser/Node/Value/ValueResolver.php
@@ -177,8 +177,12 @@ final class ValueResolver
 
         $values = [];
         foreach ($constantArrayType->getValueTypes() as $i => $valueType) {
-            /** @var ConstantScalarType $valueType */
-            $value = $valueType->getValue();
+            if ($valueType instanceof ConstantArrayType) {
+                $value = $this->extractConstantArrayTypeValue($valueType);
+            } else {
+                /** @var ConstantScalarType $valueType */
+                $value = $valueType->getValue();
+            }
             $values[$keys[$i]] = $value;
         }
 


### PR DESCRIPTION
When multi-level arrays were used, an error was thrown:

```
Error: Call to undefined method PHPStan\Type\Constant\ConstantArrayType::getValue()

/rector/src/PhpParser/Node/Value/ValueResolver.php:181
/rector/src/PhpParser/Node/Value/ValueResolver.php:75
/rector/src/Rector/AbstractRector/ValueResolverTrait.php:32
/rector/packages/PHPUnit/src/Rector/MethodCall/ReplaceAssertArraySubsetRector.php:174
/rector/packages/PHPUnit/src/Rector/MethodCall/ReplaceAssertArraySubsetRector.php:89
```