### PR TITLE
Do not mark injected properties as private when moved to constructor

### DIFF
--- a/src/Rector/Property/InjectAnnotationClassRector.php
+++ b/src/Rector/Property/InjectAnnotationClassRector.php
@@ -195,9 +195,6 @@ CODE_SAMPLE
 
         $this->docBlockManipulator->removeTagFromNode($property, $annotationClass);
 
-        // set to private
-        $property->flags = Class_::MODIFIER_PRIVATE;
-
         $classNode = $property->getAttribute(AttributeKey::CLASS_NODE);
         if (! $classNode instanceof Class_) {
             throw new ShouldNotHappenException();

--- a/tests/Rector/Property/InjectAnnotationClassRector/Fixture/fixture4.php.inc
+++ b/tests/Rector/Property/InjectAnnotationClassRector/Fixture/fixture4.php.inc
@@ -25,7 +25,7 @@ class ClassWithPublicInjects
     /**
      * @var \Rector\Symfony\Tests\Rector\FrameworkBundle\AbstractToConstructorInjectionRectorSource\SomeTranslatorInterface
      */
-    private $translator;
+    public $translator;
     public function __construct(\Rector\Symfony\Tests\Rector\FrameworkBundle\AbstractToConstructorInjectionRectorSource\SomeTranslatorInterface $translator)
     {
         $this->translator = $translator;

--- a/tests/Rector/Property/InjectAnnotationClassRector/Fixture/inject_from_var2.php.inc
+++ b/tests/Rector/Property/InjectAnnotationClassRector/Fixture/inject_from_var2.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Tests\Rector\Property\InjectAnnotationClassRector\Fixture;
+
+class InjectFromProtectedVar
+{
+    /**
+     * @Inject
+     * @var \Fully\Qualified\ClassName\To\Dependency
+     */
+    protected $someDependency;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Rector\Property\InjectAnnotationClassRector\Fixture;
+
+class InjectFromProtectedVar
+{
+    /**
+     * @var \Fully\Qualified\ClassName\To\Dependency
+     */
+    protected $someDependency;
+    public function __construct(\Fully\Qualified\ClassName\To\Dependency $someDependency)
+    {
+        $this->someDependency = $someDependency;
+    }
+}
+
+?>

--- a/tests/Rector/Property/InjectAnnotationClassRector/InjectAnnotationClassRectorTest.php
+++ b/tests/Rector/Property/InjectAnnotationClassRector/InjectAnnotationClassRectorTest.php
@@ -28,6 +28,7 @@ final class InjectAnnotationClassRectorTest extends AbstractRectorTestCase
             __DIR__ . '/Fixture/fixture4.php.inc',
             __DIR__ . '/Fixture/fixture5.php.inc',
             __DIR__ . '/Fixture/inject_from_var.php.inc',
+            __DIR__ . '/Fixture/inject_from_var2.php.inc',
         ]);
     }
 


### PR DESCRIPTION
As suggested in https://github.com/rectorphp/rector/issues/1400#issuecomment-508336071