### PR TITLE
is_real() is deprecated instead of is_float()

### DIFF
--- a/config/set/php/php74.yaml
+++ b/config/set/php/php74.yaml
@@ -3,7 +3,7 @@ services:
 
     Rector\Rector\Function_\RenameFunctionRector:
         # https://wiki.php.net/rfc/deprecations_php_7_4#the_real_type
-        is_float: 'is_real'
+        is_real: 'is_float'
         # https://wiki.php.net/rfc/deprecations_php_7_4#apache_request_headers_function
         apache_request_headers: 'getallheaders'
         hebrevc: ['nl2br', 'hebrev']


### PR DESCRIPTION
As reported  in https://github.com/rectorphp/rector/issues/1724