### PR TITLE
Consider reference symbol in docblock for param type declaration rector

### DIFF
--- a/packages/TypeDeclaration/tests/Rector/FunctionLike/ParamTypeDeclarationRector/Fixture/reference_symbol_in_docblock.php.inc
+++ b/packages/TypeDeclaration/tests/Rector/FunctionLike/ParamTypeDeclarationRector/Fixture/reference_symbol_in_docblock.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\TypeDeclaration\Tests\Rector\ClassMethod\ParamTypeDeclarationRector\Fixture;
+
+class ReferenceSymbolInDocBlock
+{
+    /**
+     * @param array &$value
+     */
+    public function someFunction(&$value)
+    {
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\TypeDeclaration\Tests\Rector\ClassMethod\ParamTypeDeclarationRector\Fixture;
+
+class ReferenceSymbolInDocBlock
+{
+    /**
+     * @param array &$value
+     */
+    public function someFunction(array &$value)
+    {
+    }
+}
+?>

--- a/packages/TypeDeclaration/tests/Rector/FunctionLike/ParamTypeDeclarationRector/ParamTypeDeclarationRectorTest.php
+++ b/packages/TypeDeclaration/tests/Rector/FunctionLike/ParamTypeDeclarationRector/ParamTypeDeclarationRectorTest.php
@@ -16,6 +16,7 @@ final class ParamTypeDeclarationRectorTest extends AbstractRectorTestCase
             __DIR__ . '/Fixture/variadic.php.inc',
             __DIR__ . '/Fixture/mixed.php.inc',
             __DIR__ . '/Fixture/resource.php.inc',
+            __DIR__ . '/Fixture/reference_symbol_in_docblock.php.inc',
             __DIR__ . '/Fixture/trait_interface.php.inc',
             __DIR__ . '/Fixture/this.php.inc',
             __DIR__ . '/Fixture/false.php.inc',


### PR DESCRIPTION
 Linked to #1734 

The idea here would be to ignore the `&` during parsing. Unfortunately in this case, rector depends on phpstan doc parser which maintainers decided not to support this type of documenting: https://github.com/phpstan/phpstan/issues/699

I've dug a little and found that adding this line:
```php
$tokens->tryConsumeTokenType(Lexer::TOKEN_REFERENCE);
```

After this line: 
https://github.com/phpstan/phpdoc-parser/blob/master/src/Parser/PhpDocParser.php#L166

Would effectively ignore it and make the test green.

I'm wondering if there could be any workaround that can be put in rector code directly.