### PR TITLE
[DeadCode] Rector `RemoveDeadConstructorRector` should skip `private` method

### DIFF
--- a/packages/DeadCode/src/Rector/ClassMethod/RemoveDeadConstructorRector.php
+++ b/packages/DeadCode/src/Rector/ClassMethod/RemoveDeadConstructorRector.php
@@ -53,6 +53,11 @@ CODE_SAMPLE
             return null;
         }
 
+        // Skip private as they lock creating new instances via `new ClassName()`
+        if ($node->isPrivate()) {
+            return null;
+        }
+
         $this->removeNode($node);
 
         return null;

--- a/packages/DeadCode/tests/Rector/ClassMethod/RemoveDeadConstructorRector/Fixture/skip_private.php.inc
+++ b/packages/DeadCode/tests/Rector/ClassMethod/RemoveDeadConstructorRector/Fixture/skip_private.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\DeadCode\Tests\Rector\ClassMethod\RemoveDeadConstructorRector\Fixture;
+
+class SkipPrivate
+{
+    private function __construct()
+    {
+    }
+}

--- a/packages/DeadCode/tests/Rector/ClassMethod/RemoveDeadConstructorRector/RemoveDeadConstructorRectorTest.php
+++ b/packages/DeadCode/tests/Rector/ClassMethod/RemoveDeadConstructorRector/RemoveDeadConstructorRectorTest.php
@@ -9,7 +9,13 @@ final class RemoveDeadConstructorRectorTest extends AbstractRectorTestCase
 {
     public function test(): void
     {
-        $this->doTestFiles([__DIR__ . '/Fixture/fixture.php.inc', __DIR__ . '/Fixture/skip.php.inc']);
+        $this->doTestFiles(
+            [
+                __DIR__ . '/Fixture/fixture.php.inc',
+                __DIR__ . '/Fixture/skip.php.inc',
+                __DIR__ . '/Fixture/skip_private.php.inc',
+            ]
+        );
     }
 
     protected function getRectorClass(): string


### PR DESCRIPTION
Fixes #1750.