### PR TITLE
[Symfony] Use Symfony bridge interface for `doctrine` service

### DIFF
--- a/packages/Symfony/src/Bridge/DefaultAnalyzedSymfonyApplicationContainer.php
+++ b/packages/Symfony/src/Bridge/DefaultAnalyzedSymfonyApplicationContainer.php
@@ -32,7 +32,7 @@ final class DefaultAnalyzedSymfonyApplicationContainer implements AnalyzedApplic
      * @var string[]
      */
     private $commonNamesToTypes = [
-        'doctrine' => 'Doctrine\Bundle\DoctrineBundle\Registry',
+        'doctrine' => 'Symfony\Bridge\Doctrine\RegistryInterface',
         'doctrine.orm.entity_manager' => 'Doctrine\ORM\EntityManagerInterface',
         'doctrine.orm.default_entity_manager' => 'Doctrine\ORM\EntityManagerInterface',
     ];


### PR DESCRIPTION
Autowire is using `Symfony\Bridge\Doctrine\RegistryInterface` not the Doctrine one.