### PR TITLE
[NodeTypeResolver] Add phpunit extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "nikic/php-parser": "^4.2.2",
         "phpstan/phpdoc-parser": "^0.3.4",
         "phpstan/phpstan": "^0.11.6",
+        "phpstan/phpstan-phpunit": "^0.11.2",
         "sebastian/diff": "^3.0",
         "symfony/console": "^3.4|^4.2",
         "symfony/dependency-injection": "^3.4|^4.2",

--- a/packages/NodeTypeResolver/src/DependencyInjection/PHPStanServicesFactory.php
+++ b/packages/NodeTypeResolver/src/DependencyInjection/PHPStanServicesFactory.php
@@ -18,8 +18,16 @@ final class PHPStanServicesFactory
 
     public function __construct()
     {
-        $this->container = (new ContainerFactory(getcwd()))
-            ->create(sys_get_temp_dir(), [], []);
+        $containerFactory = new ContainerFactory(getcwd());
+        $additionalConfigFiles = [];
+
+        // possible path collision for Docker
+        $phpstanPhpunitExtensionConfig = getcwd() . '/vendor/phpstan/phpstan-phpunit/extension.neon';
+        if (file_exists($phpstanPhpunitExtensionConfig)) {
+            $additionalConfigFiles[] = $phpstanPhpunitExtensionConfig;
+        }
+
+        $this->container = $containerFactory->create(sys_get_temp_dir(), $additionalConfigFiles, []);
     }
 
     public function createBroker(): Broker

--- a/packages/NodeTypeResolver/src/StaticTypeToStringResolver.php
+++ b/packages/NodeTypeResolver/src/StaticTypeToStringResolver.php
@@ -8,6 +8,7 @@ use PHPStan\Type\CallableType;
 use PHPStan\Type\ClosureType;
 use PHPStan\Type\FloatType;
 use PHPStan\Type\IntegerType;
+use PHPStan\Type\IntersectionType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\ObjectWithoutClassType;
@@ -52,6 +53,14 @@ final class StaticTypeToStringResolver
             function (UnionType $unionType): array {
                 $types = [];
                 foreach ($unionType->getTypes() as $singleStaticType) {
+                    $types = array_merge($types, $this->resolveObjectType($singleStaticType));
+                }
+
+                return $types;
+            },
+            function (IntersectionType $intersectionType): array {
+                $types = [];
+                foreach ($intersectionType->getTypes() as $singleStaticType) {
                     $types = array_merge($types, $this->resolveObjectType($singleStaticType));
                 }
 


### PR DESCRIPTION
Now `$stub` returns both `Mock|Request` compared to only `Mock` before

```php
$stub = $this->getMockBuilder(Request::class)
            ->disableOriginalConstructor()
            ->getMock();
```