### PR TITLE
FIXED: Catastrophic backtracking in regular expression if the current…

### DIFF
--- a/packages/BetterPhpDocParser/src/PhpDocParser/BetterPhpDocParser.php
+++ b/packages/BetterPhpDocParser/src/PhpDocParser/BetterPhpDocParser.php
@@ -146,7 +146,7 @@ final class BetterPhpDocParser extends PhpDocParser
 
             // we try to match original content without trimmed spaces
             $currentTextPattern = '#' . preg_quote($possibleMultilineText, '#') . '#s';
-            $currentTextPattern = Strings::replace($currentTextPattern, '#\s#', '\s+');
+            $currentTextPattern = Strings::replace($currentTextPattern, '#(\s)+#', '\s+');
             $match = Strings::match($originalContent, $currentTextPattern);
 
             if (isset($match[0])) {


### PR DESCRIPTION
… text pattern contains lot of white spaces
I got the following error with one of my Doc-Blocks:
``Backtrack limit was exhausted (pattern: #\+\-\-\-\-\+\s+\s+\s+\s+\s+\s+\s+\s+\s+\s+\s+\s+\s+\s+\s+\s+\s+\s+\s+\s+\s+\s+\s+\s+\+\=\=\=\=\+#s)". On line: 2  ``

Example Doc-Block which caused an issue:
```
   /**
     * format:
     *      current matrix:               layout:
     *      +----+                        +====+
     *      |    |                        X    X
     *      +    +                        +    +
     *      |    |                        X    X
     *      +    +                        +====+
     *      |    |                        X    X
     *      +    +                        +    +
     *      |    |                        X    X
     *      +----+                        +====+
     *
     * @return TableLayout
     */ 
```

The attached change should have the same pattern matching semantic.