### PR TITLE
Break class name in @var when relation is defined in same namespace

### DIFF
--- a/packages/TypeDeclaration/tests/Rector/Property/PropertyTypeDeclarationRector/Fixture/doctrine_relation.php.inc
+++ b/packages/TypeDeclaration/tests/Rector/Property/PropertyTypeDeclarationRector/Fixture/doctrine_relation.php.inc
@@ -59,7 +59,7 @@ class DoctrineRelation
 
     /**
      * @ORM\OneToOne(targetEntity="DoctrineRelated")
-     * @var DoctrineRelated
+     * @var \Rector\TypeDeclaration\Tests\Rector\FunctionLike\PropertyTypeDeclarationRector\Fixture\DoctrineRelated
      */
     private $related;
 

--- a/packages/TypeDeclaration/tests/Rector/Property/PropertyTypeDeclarationRector/Fixture/doctrine_relation.php.inc
+++ b/packages/TypeDeclaration/tests/Rector/Property/PropertyTypeDeclarationRector/Fixture/doctrine_relation.php.inc
@@ -4,12 +4,21 @@ namespace Rector\TypeDeclaration\Tests\Rector\FunctionLike\PropertyTypeDeclarati
 
 use Doctrine\ORM\Mapping as ORM;
 
+class DoctrineRelated
+{
+}
+
 class DoctrineRelation
 {
     /**
      * @ORM\OneToMany(targetEntity="App\Product")
      */
     private $products;
+
+    /**
+     * @ORM\OneToOne(targetEntity="DoctrineRelated")
+     */
+    private $related;
 
     /**
      * @ORM\ManyToMany(targetEntity="App\Car")
@@ -36,6 +45,10 @@ namespace Rector\TypeDeclaration\Tests\Rector\FunctionLike\PropertyTypeDeclarati
 
 use Doctrine\ORM\Mapping as ORM;
 
+class DoctrineRelated
+{
+}
+
 class DoctrineRelation
 {
     /**
@@ -43,6 +56,12 @@ class DoctrineRelation
      * @var \App\Product[]|\Doctrine\Common\Collections\Collection
      */
     private $products;
+
+    /**
+     * @ORM\OneToOne(targetEntity="DoctrineRelated")
+     * @var DoctrineRelated
+     */
+    private $related;
 
     /**
      * @ORM\ManyToMany(targetEntity="App\Car")


### PR DESCRIPTION
Doctrine allow to define relation in same namespace without FQDN. However after rector process namespace is broken.