### PR TITLE
add failing testcase for PropertyTypeDeclarationRector

### DIFF
--- a/packages/TypeDeclaration/tests/Rector/Property/PropertyTypeDeclarationRector/Fixture/doctrine_relation_imported.php.inc
+++ b/packages/TypeDeclaration/tests/Rector/Property/PropertyTypeDeclarationRector/Fixture/doctrine_relation_imported.php.inc
@@ -1,0 +1,73 @@
+<?php
+
+namespace Rector\TypeDeclaration\Tests\Rector\FunctionLike\PropertyTypeDeclarationRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Rector\TypeDeclaration\Tests\Rector\FunctionLike\PropertyTypeDeclarationRector\Fixture\Product;
+use Rector\TypeDeclaration\Tests\Rector\FunctionLike\PropertyTypeDeclarationRector\Fixture\Car;
+use Rector\TypeDeclaration\Tests\Rector\FunctionLike\PropertyTypeDeclarationRector\Fixture\Entity as Entity;
+
+class DoctrineRelationImported
+{
+    /**
+     * @ORM\OneToMany(targetEntity="Product")
+     */
+    private $products;
+
+    /**
+     * @ORM\ManyToMany(targetEntity="Car")
+     */
+    private $cars;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="Entity\Company", inversedBy="userBuildings")
+     * @ORM\JoinColumn(name="company_id", referencedColumnName="id", nullable=true)
+     */
+    private $company;
+
+    /**
+     * @ORM\OneToOne(targetEntity="Entity\Company")
+     */
+    private $company2;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\TypeDeclaration\Tests\Rector\FunctionLike\PropertyTypeDeclarationRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Rector\TypeDeclaration\Tests\Rector\FunctionLike\PropertyTypeDeclarationRector\Fixture\Product;
+use Rector\TypeDeclaration\Tests\Rector\FunctionLike\PropertyTypeDeclarationRector\Fixture\Car;
+use Rector\TypeDeclaration\Tests\Rector\FunctionLike\PropertyTypeDeclarationRector\Fixture\Entity as Entity;
+
+class DoctrineRelationImported
+{
+    /**
+     * @ORM\OneToMany(targetEntity="Product")
+     * @var Product[]|\Doctrine\Common\Collections\Collection
+     */
+    private $products;
+
+    /**
+     * @ORM\ManyToMany(targetEntity="Car")
+     * @var Car[]|\Doctrine\Common\Collections\Collection
+     */
+    private $cars;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="Entity\Company", inversedBy="userBuildings")
+     * @ORM\JoinColumn(name="company_id", referencedColumnName="id", nullable=true)
+     * @var Entity\Company|null
+     */
+    private $company;
+
+    /**
+     * @ORM\OneToOne(targetEntity="Entity\Company")
+     * @var Entity\Company
+     */
+    private $company2;
+}
+
+?>

--- a/packages/TypeDeclaration/tests/Rector/Property/PropertyTypeDeclarationRector/Fixture/doctrine_relations.php
+++ b/packages/TypeDeclaration/tests/Rector/Property/PropertyTypeDeclarationRector/Fixture/doctrine_relations.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\TypeDeclaration\Tests\Rector\FunctionLike\PropertyTypeDeclarationRector\Fixture {
+    class Product
+    {
+    }
+
+    class Car
+    {
+    }
+}
+
+namespace Rector\TypeDeclaration\Tests\Rector\FunctionLike\PropertyTypeDeclarationRector\Fixture\Entity {
+    class Company
+    {
+    }
+}

--- a/packages/TypeDeclaration/tests/Rector/Property/PropertyTypeDeclarationRector/PropertyTypeDeclarationRectorTest.php
+++ b/packages/TypeDeclaration/tests/Rector/Property/PropertyTypeDeclarationRector/PropertyTypeDeclarationRectorTest.php
@@ -17,6 +17,7 @@ final class PropertyTypeDeclarationRectorTest extends AbstractRectorTestCase
             __DIR__ . '/Fixture/default_value.php.inc',
             __DIR__ . '/Fixture/doctrine_column.php.inc',
             __DIR__ . '/Fixture/doctrine_relation.php.inc',
+            __DIR__ . '/Fixture/doctrine_relation_imported.php.inc',
             // get and set
             __DIR__ . '/Fixture/complex.php.inc',
             __DIR__ . '/Fixture/single_nullable_return.php.inc',


### PR DESCRIPTION
I tried out https://www.tomasvotruba.cz/blog/2019/07/29/how-we-completed-thousands-of-missing-var-annotations-in-a-day/
Thanks, this is great!

Here's a failing testcase for `PropertyTypeDeclarationRector` with doctrine relations.

Doctrine does not require you to set fully quantified class names for relation classes - it will look at the class `use` statements. 