### PR TITLE
added failing `func_get_arg()` testcase for RemoveExtraParametersRector

### DIFF
--- a/packages/Php/tests/Rector/FuncCall/RemoveExtraParametersRector/Fixture/func_get_arg.php.inc
+++ b/packages/Php/tests/Rector/FuncCall/RemoveExtraParametersRector/Fixture/func_get_arg.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Php\Tests\Rector\FuncCall\RemoveExtraParametersRector\Fixture;
+
+class FuncGetArg
+{
+    public function __construct() {
+        self::("aa", "bb", "cc");
+    }
+    
+    static public function dumpArgs() {
+        $arg_list = func_get_args();
+        var_dump($arg_list);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Php\Tests\Rector\FuncCall\RemoveExtraParametersRector\Fixture;
+
+class FuncGetArg
+{
+    public function __construct() {
+        self::("aa", "bb", "cc");
+    }
+    
+    static public function dumpArgs() {
+        $arg_list = func_get_args();
+        var_dump($arg_list);
+    }
+}
+
+?>

--- a/packages/Php/tests/Rector/FuncCall/RemoveExtraParametersRector/Fixture/func_get_arg.php.inc
+++ b/packages/Php/tests/Rector/FuncCall/RemoveExtraParametersRector/Fixture/func_get_arg.php.inc
@@ -5,7 +5,7 @@ namespace Rector\Php\Tests\Rector\FuncCall\RemoveExtraParametersRector\Fixture;
 class FuncGetArg
 {
     public function __construct() {
-        self::("aa", "bb", "cc");
+        self::dumpArgs("aa", "bb", "cc");
     }
     
     static public function dumpArgs() {
@@ -23,7 +23,7 @@ namespace Rector\Php\Tests\Rector\FuncCall\RemoveExtraParametersRector\Fixture;
 class FuncGetArg
 {
     public function __construct() {
-        self::("aa", "bb", "cc");
+        self::dumpArgs("aa", "bb", "cc");
     }
     
     static public function dumpArgs() {

--- a/packages/Php/tests/Rector/FuncCall/RemoveExtraParametersRector/RemoveExtraParametersRectorTest.php
+++ b/packages/Php/tests/Rector/FuncCall/RemoveExtraParametersRector/RemoveExtraParametersRectorTest.php
@@ -12,6 +12,7 @@ final class RemoveExtraParametersRectorTest extends AbstractRectorTestCase
         $this->doTestFiles([
             __DIR__ . '/Fixture/fixture.php.inc',
             __DIR__ . '/Fixture/func_get_all.php.inc',
+            __DIR__ . '/Fixture/func_get_arg.php.inc ',
             __DIR__ . '/Fixture/better_func_get_all.php.inc',
             __DIR__ . '/Fixture/methods.php.inc',
             __DIR__ . '/Fixture/static_calls.php.inc',

--- a/packages/Php/tests/Rector/FuncCall/RemoveExtraParametersRector/RemoveExtraParametersRectorTest.php
+++ b/packages/Php/tests/Rector/FuncCall/RemoveExtraParametersRector/RemoveExtraParametersRectorTest.php
@@ -12,7 +12,7 @@ final class RemoveExtraParametersRectorTest extends AbstractRectorTestCase
         $this->doTestFiles([
             __DIR__ . '/Fixture/fixture.php.inc',
             __DIR__ . '/Fixture/func_get_all.php.inc',
-            __DIR__ . '/Fixture/func_get_arg.php.inc ',
+            __DIR__ . '/Fixture/func_get_arg.php.inc',
             __DIR__ . '/Fixture/better_func_get_all.php.inc',
             __DIR__ . '/Fixture/methods.php.inc',
             __DIR__ . '/Fixture/static_calls.php.inc',


### PR DESCRIPTION
adding a failing testcase for https://github.com/rectorphp/rector/issues/1746 since we are also experiencing the mentioned problem.

hopefully I did everything right - my first PR to this project.
In case I missing something I am willing to improve the testcase with you guidance.