### PR TITLE
Add test for #1816: Resolving constant fetches is unsafe 

### DIFF
--- a/packages/SOLID/config/config.yaml
+++ b/packages/SOLID/config/config.yaml
@@ -1,0 +1,8 @@
+services:
+    _defaults:
+        public: true
+        autowire: true
+
+    Rector\SOLID\:
+        resource: '../src/'
+        exclude: '../src/{Rector/**/*Rector.php}'

--- a/packages/SOLID/src/Analyzer/ClassConstantFetchAnalyzer.php
+++ b/packages/SOLID/src/Analyzer/ClassConstantFetchAnalyzer.php
@@ -1,0 +1,127 @@
+<?php declare(strict_types=1);
+
+namespace Rector\SOLID\Analyzer;
+
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Stmt\ClassConst;
+use Rector\NodeContainer\ParsedNodesByType;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\NodeTypeResolver\NodeTypeResolver;
+use Rector\PhpParser\Node\Resolver\NameResolver;
+use Rector\Testing\PHPUnit\PHPUnitEnvironment;
+
+final class ClassConstantFetchAnalyzer
+{
+    /**
+     * @var ParsedNodesByType
+     */
+    private $parsedNodesByType;
+
+    /**
+     * @var NameResolver
+     */
+    private $nameResolver;
+
+    /**
+     * @var string[][][]
+     */
+    private $classConstantFetchByClassAndName = [];
+
+    /**
+     * @var NodeTypeResolver
+     */
+    private $nodeTypeResolver;
+
+    public function __construct(
+        ParsedNodesByType $parsedNodesByType,
+        NodeTypeResolver $nodeTypeResolver,
+        NameResolver $nameResolver
+    ) {
+        $this->parsedNodesByType = $parsedNodesByType;
+        $this->nodeTypeResolver = $nodeTypeResolver;
+        $this->nameResolver = $nameResolver;
+    }
+
+    /**
+     * Returns class constant usages for the declaring class name and constant name
+     * @return string[][][]
+     */
+    public function provideClassConstantFetchByClassAndName(): array
+    {
+        if ($this->classConstantFetchByClassAndName !== [] && ! PHPUnitEnvironment::isPHPUnitRun()) {
+            return $this->classConstantFetchByClassAndName;
+        }
+
+        foreach ($this->parsedNodesByType->getClassConstantFetches() as $classConstantFetch) {
+            $this->addClassConstantFetch($classConstantFetch);
+        }
+
+        return $this->classConstantFetchByClassAndName;
+    }
+
+    private function addClassConstantFetch(ClassConstFetch $classConstFetch): void
+    {
+        $constantName = $this->nameResolver->getName($classConstFetch->name);
+
+        if ($constantName === 'class' || $constantName === null) {
+            // this is not a manual constant
+            return;
+        }
+
+        $className = $this->nameResolver->getName($classConstFetch->class);
+
+        if (in_array($className, ['static', 'self', 'parent'], true)) {
+            $resolvedClassTypes = $this->nodeTypeResolver->resolve($classConstFetch->class);
+
+            $className = $this->matchClassTypeThatContainsConstant($resolvedClassTypes, $constantName);
+            if ($className === null) {
+                return;
+            }
+        } else {
+            $resolvedClassTypes = $this->nodeTypeResolver->resolve($classConstFetch->class);
+            $className = $this->matchClassTypeThatContainsConstant($resolvedClassTypes, $constantName);
+
+            if ($className === null) {
+                return;
+            }
+        }
+
+        // current class
+        $classOfUse = $classConstFetch->getAttribute(AttributeKey::CLASS_NAME);
+
+        $this->classConstantFetchByClassAndName[$className][$constantName][] = $classOfUse;
+
+        $this->classConstantFetchByClassAndName[$className][$constantName] = array_unique(
+            $this->classConstantFetchByClassAndName[$className][$constantName]
+        );
+    }
+
+    /**
+     * @param string[] $resolvedClassTypes
+     */
+    private function matchClassTypeThatContainsConstant(array $resolvedClassTypes, string $constant): ?string
+    {
+        if (count($resolvedClassTypes) === 1) {
+            return $resolvedClassTypes[0];
+        }
+
+        foreach ($resolvedClassTypes as $resolvedClassType) {
+            $classOrInterface = $this->parsedNodesByType->findClassOrInterface($resolvedClassType);
+            if ($classOrInterface === null) {
+                continue;
+            }
+
+            foreach ($classOrInterface->stmts as $stmt) {
+                if (! $stmt instanceof ClassConst) {
+                    continue;
+                }
+
+                if ($this->nameResolver->isName($stmt, $constant)) {
+                    return $resolvedClassType;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/packages/SOLID/src/Rector/ClassConst/PrivatizeLocalClassConstantRector.php
+++ b/packages/SOLID/src/Rector/ClassConst/PrivatizeLocalClassConstantRector.php
@@ -9,6 +9,7 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Rector\AbstractRector;
 use Rector\RectorDefinition\CodeSample;
 use Rector\RectorDefinition\RectorDefinition;
+use Rector\SOLID\Analyzer\ClassConstantFetchAnalyzer;
 
 final class PrivatizeLocalClassConstantRector extends AbstractRector
 {
@@ -17,9 +18,15 @@ final class PrivatizeLocalClassConstantRector extends AbstractRector
      */
     private $parsedNodesByType;
 
-    public function __construct(ParsedNodesByType $parsedNodesByType)
+    /**
+     * @var ClassConstantFetchAnalyzer
+     */
+    private $constFetchAnalyzer;
+
+    public function __construct(ParsedNodesByType $parsedNodesByType, ClassConstantFetchAnalyzer $constFetchAnalyzer)
     {
-        $this->parsedNodesByType = $parsedNodesByType;
+        $this->parsedNodesByType = $parsedNodesByType;;
+        $this->constFetchAnalyzer = $constFetchAnalyzer;
     }
 
     public function getDefinition(): RectorDefinition
@@ -85,7 +92,7 @@ CODE_SAMPLE
 
         /** @var string $constant */
         $constant = $this->getName($node);
-        $useClasses = $this->parsedNodesByType->findClassConstantFetches($class, $constant);
+        $useClasses = $this->findClassConstantFetches($class, $constant);
 
         // 1. is actually never used (@todo use in "dead-code" set)
         if ($useClasses === null) {
@@ -126,5 +133,12 @@ CODE_SAMPLE
         }
 
         return $isChild;
+    }
+
+    private function findClassConstantFetches(string $className, string $constantName): ?array
+    {
+        $classConstantFetchByClassAndName = $this->constFetchAnalyzer->provideClassConstantFetchByClassAndName();
+
+        return $classConstantFetchByClassAndName[$className][$constantName] ?? null;
     }
 }

--- a/packages/SOLID/tests/Rector/ClassConst/PrivatizeLocalClassConstantRector/Fixture/keep_public_parsing_order.php.inc
+++ b/packages/SOLID/tests/Rector/ClassConst/PrivatizeLocalClassConstantRector/Fixture/keep_public_parsing_order.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\SOLID\Tests\Rector\ClassConst\PrivatizeLocalClassConstantRector\Fixture;
+
+// The class using the constant must be parsed first
+class ForeignConstantAddictUser2
+{
+    public function run()
+    {
+        return ClassWithConstantUsedSomewhereElse2::NON_LOCAL_ONLY;
+    }
+}
+
+class ClassWithConstantUsedSomewhereElse2Parent
+{
+}
+
+// The class declaring the constant must have a superclass, so that rector must find out which one declares the constant
+class ClassWithConstantUsedSomewhereElse2 extends ClassWithConstantUsedSomewhereElse2Parent
+{
+    const NON_LOCAL_ONLY = true;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\SOLID\Tests\Rector\ClassConst\PrivatizeLocalClassConstantRector\Fixture;
+
+// The class using the constant must be parsed first
+class ForeignConstantAddictUser2
+{
+    public function run()
+    {
+        return ClassWithConstantUsedSomewhereElse2::NON_LOCAL_ONLY;
+    }
+}
+
+class ClassWithConstantUsedSomewhereElse2Parent
+{
+}
+
+// The class declaring the constant must have a superclass, so that rector must find out which one declares the constant
+class ClassWithConstantUsedSomewhereElse2 extends ClassWithConstantUsedSomewhereElse2Parent
+{
+    public const NON_LOCAL_ONLY = true;
+}
+
+?>

--- a/packages/SOLID/tests/Rector/ClassConst/PrivatizeLocalClassConstantRector/PrivatizeLocalClassConstantRectorTest.php
+++ b/packages/SOLID/tests/Rector/ClassConst/PrivatizeLocalClassConstantRector/PrivatizeLocalClassConstantRectorTest.php
@@ -13,6 +13,7 @@ final class PrivatizeLocalClassConstantRectorTest extends AbstractRectorTestCase
             __DIR__ . '/Fixture/fixture.php.inc',
             __DIR__ . '/Fixture/skip_multi_overcomplex.php.inc',
             __DIR__ . '/Fixture/keep_public.php.inc',
+            __DIR__ . '/Fixture/keep_public_parsing_order.php.inc',
             __DIR__ . '/Fixture/protected.php.inc',
             __DIR__ . '/Fixture/protected_parent_parent.php.inc',
             __DIR__ . '/Fixture/in_interface.php.inc',

--- a/src/NodeContainer/ParsedNodesByType.php
+++ b/src/NodeContainer/ParsedNodesByType.php
@@ -65,6 +65,11 @@ final class ParsedNodesByType
     private $constantsByType = [];
 
     /**
+     * @var ClassConstFetch[]
+     */
+    private $classConstantFetches = [];
+
+    /**
      * @var string[][][]
      */
     private $classConstantFetchByClassAndName = [];
@@ -297,6 +302,8 @@ final class ParsedNodesByType
      */
     public function findClassConstantFetches(string $className, string $constantName): ?array
     {
+        $this->processClassConstantFetches();
+
         return $this->classConstantFetchByClassAndName[$className][$constantName] ?? null;
     }
 
@@ -484,6 +491,21 @@ final class ParsedNodesByType
     }
 
     private function addClassConstantFetch(ClassConstFetch $classConstFetch): void
+    {
+        $this->classConstantFetches[] = $classConstFetch;
+    }
+
+    private function processClassConstantFetches(): void
+    {
+        if ($this->classConstantFetches) {
+            foreach ($this->classConstantFetches as $rawClassConstantFetch) {
+                $this->processClassConstantFetch($rawClassConstantFetch);
+            }
+            $this->classConstantFetches = [];
+        }
+    }
+
+    private function processClassConstantFetch(ClassConstFetch $classConstFetch): void
     {
         $constantName = $this->nameResolver->getName($classConstFetch->name);
 


### PR DESCRIPTION
Test case to demonstrate issue #1816.

1) The constant usages must be parsed before the class declaring the constant.
2) The class declaring the constant must be a subclass.

rector is then forced find the declaring class from the class hierarchy, which it can't when the declaring class and its superclasses haven't been parsed yet.