### PR TITLE
Constants declared in interfaces have to be public

### DIFF
--- a/packages/SOLID/src/Rector/ClassConst/PrivatizeLocalClassConstantRector.php
+++ b/packages/SOLID/src/Rector/ClassConst/PrivatizeLocalClassConstantRector.php
@@ -77,23 +77,29 @@ CODE_SAMPLE
         /** @var string $class */
         $class = $node->getAttribute(AttributeKey::CLASS_NAME);
 
+        // 0. constants declared in interfaces have to be public
+        if ($this->parsedNodesByType->findInterface($class) !== null) {
+            $this->makePublic($node);
+            return $node;
+        }
+
         /** @var string $constant */
         $constant = $this->getName($node);
         $useClasses = $this->parsedNodesByType->findClassConstantFetches($class, $constant);
 
-        // 0. is actually never used (@todo use in "dead-code" set)
+        // 1. is actually never used (@todo use in "dead-code" set)
         if ($useClasses === null) {
             $this->makePrivate($node);
             return $node;
         }
 
-        // 1. is only local use? → private
+        // 2. is only local use? → private
         if ($useClasses === [$class]) {
             $this->makePrivate($node);
             return $node;
         }
 
-        // 2. used by children → protected
+        // 3. used by children → protected
         if ($this->isUsedByChildrenOnly($useClasses, $class)) {
             $this->makeProtected($node);
         } else {

--- a/packages/SOLID/tests/Rector/ClassConst/PrivatizeLocalClassConstantRector/Fixture/in_interface.php.inc
+++ b/packages/SOLID/tests/Rector/ClassConst/PrivatizeLocalClassConstantRector/Fixture/in_interface.php.inc
@@ -23,7 +23,7 @@ namespace Rector\SOLID\Tests\Rector\ClassConst\PrivatizeLocalClassConstantRector
 
 interface InterfaceWithConstant
 {
-    protected const LOCAL_ONLY = true;
+    public const LOCAL_ONLY = true;
 }
 
 class ClassExtendingInterface implements InterfaceWithConstant


### PR DESCRIPTION
Constants declared in an interface have to be `public`, having `private` or `protected` constants in interfaces is not supported by the language. PHP will error with `PHP Fatal error:  Access type for interface constant SomeInterface::CONSTANT must be public`.

So whenever a constant is defined in an interface, we can just make it `public`.