### PR TITLE
Overriding constants require at least the parent's visibility

### DIFF
--- a/packages/SOLID/tests/Rector/ClassConst/PrivatizeLocalClassConstantRector/Fixture/override_protected_constant.php.inc
+++ b/packages/SOLID/tests/Rector/ClassConst/PrivatizeLocalClassConstantRector/Fixture/override_protected_constant.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace Rector\SOLID\Tests\Rector\ClassConst\PrivatizeLocalClassConstantRector\Fixture;
+
+class OverridingProtectedConstantClass extends DeclaringProtectedConstantClass
+{
+    const PROTECTED_CONSTANT = false;
+}
+
+class ProtectedConstantUser extends DeclaringProtectedConstantClass
+{
+    public function run()
+    {
+        return self::PROTECTED_CONSTANT;
+    }
+}
+
+class DeclaringProtectedConstantClass
+{
+    const PROTECTED_CONSTANT = true;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\SOLID\Tests\Rector\ClassConst\PrivatizeLocalClassConstantRector\Fixture;
+
+class OverridingProtectedConstantClass extends DeclaringProtectedConstantClass
+{
+    protected const PROTECTED_CONSTANT = false;
+}
+
+class ProtectedConstantUser extends DeclaringProtectedConstantClass
+{
+    public function run()
+    {
+        return self::PROTECTED_CONSTANT;
+    }
+}
+
+class DeclaringProtectedConstantClass
+{
+    protected const PROTECTED_CONSTANT = true;
+}
+
+?>

--- a/packages/SOLID/tests/Rector/ClassConst/PrivatizeLocalClassConstantRector/Fixture/override_public_constant.php.inc
+++ b/packages/SOLID/tests/Rector/ClassConst/PrivatizeLocalClassConstantRector/Fixture/override_public_constant.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace Rector\SOLID\Tests\Rector\ClassConst\PrivatizeLocalClassConstantRector\Fixture;
+
+class OverridingPublicConstantClass extends DeclaringPublicConstantClass
+{
+    const PUBLIC_CONSTANT = false;
+}
+
+class DeclaringPublicConstantClass
+{
+    const PUBLIC_CONSTANT = true;
+}
+
+class PublicConstantUser
+{
+    public function run()
+    {
+        return DeclaringPublicConstantClass::PUBLIC_CONSTANT;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\SOLID\Tests\Rector\ClassConst\PrivatizeLocalClassConstantRector\Fixture;
+
+class OverridingPublicConstantClass extends DeclaringPublicConstantClass
+{
+    public const PUBLIC_CONSTANT = false;
+}
+
+class DeclaringPublicConstantClass
+{
+    public const PUBLIC_CONSTANT = true;
+}
+
+class PublicConstantUser
+{
+    public function run()
+    {
+        return DeclaringPublicConstantClass::PUBLIC_CONSTANT;
+    }
+}
+
+?>

--- a/packages/SOLID/tests/Rector/ClassConst/PrivatizeLocalClassConstantRector/PrivatizeLocalClassConstantRectorTest.php
+++ b/packages/SOLID/tests/Rector/ClassConst/PrivatizeLocalClassConstantRector/PrivatizeLocalClassConstantRectorTest.php
@@ -20,6 +20,8 @@ final class PrivatizeLocalClassConstantRectorTest extends AbstractRectorTestCase
             __DIR__ . '/Fixture/in_interface_used_child_and_external.php.inc',
             __DIR__ . '/Fixture/in_interface_used_child_and_extended.php.inc',
             __DIR__ . '/Fixture/skip_used_in_another_class.php.inc',
+            __DIR__ . '/Fixture/override_public_constant.php.inc',
+            __DIR__ . '/Fixture/override_protected_constant.php.inc',
         ]);
     }
 


### PR DESCRIPTION
When a constant is overridden in a subclass, it must have at least the access level of the superclass' constant. E.g. when the parent declares the constant `public`, the subclass _must_ also declare it as `public`, regardless if it's used or not.

It is possible to weaken the access level of a constant in a subclass, e.g. the superclass declares it as `private`, then the subclass can declare it `protected` or `public`. It's not allowed to have a more restrictive access level in a subclass tough.

If the access level of an overriding constant is not allowed, the PHP parser errors with:
`PHP Fatal error:  Access level to Subclass::OVERRIDDEN_CONSTANT must be [private|protected] (as in class Superclass::OVERRIDDEN_CONSTANT) or weaker in ... on line ...`

So what does that mean for rector:

Whenever it recognizes that a constant of the same name is declared in a superclass (not sure how to do that), it must take that constant's visibility into account (also not sure how to do that, if it's not explicitly declared, rector would first need to do the visibility evaluation for the superclass constant).

This is the same rules that also apply to class properties btw., so there could be a similar issue with property visibility rectors and however the solution to this issue may look like, it could be adopted.

(This is the last constant-related issue I've found with my codebase. Sorry for bothering you about all of these, I blieve if we get them fixed it makes it better for everyone who's dealing with a 5.x style codebase. Keep up the good work and let me know if I can help :) )