### PR TITLE
HelperFunctionToDependencyInjectionRector fix

### DIFF
--- a/packages/Laravel/src/Rector/FuncCall/HelperFunctionToConstructorInjectionRector.php
+++ b/packages/Laravel/src/Rector/FuncCall/HelperFunctionToConstructorInjectionRector.php
@@ -233,7 +233,7 @@ CODE_SAMPLE
 
             if (count($node->args) === 0) {
                 if (isset($service['method_if_no_args'])) {
-                    return new MethodCall($propertyFetchNode, $service['method_if_no_args'], $node->args);
+                    return new MethodCall($propertyFetchNode, $service['method_if_no_args']);
                 }
 
                 return $propertyFetchNode;

--- a/packages/Laravel/src/Rector/FuncCall/HelperFunctionToConstructorInjectionRector.php
+++ b/packages/Laravel/src/Rector/FuncCall/HelperFunctionToConstructorInjectionRector.php
@@ -107,6 +107,7 @@ final class HelperFunctionToConstructorInjectionRector extends AbstractRector
             'type' => 'Illuminate\Routing\Redirector',
             'property' => 'redirector',
             'method_if_args' => 'back',
+            'method_if_no_args' => 'back',
         ],
         'broadcast' => [
             'type' => 'Illuminate\Contracts\Broadcasting\Factory',
@@ -231,6 +232,10 @@ CODE_SAMPLE
             $propertyFetchNode = $this->createPropertyFetch('this', $service['property']);
 
             if (count($node->args) === 0) {
+                if (isset($service['method_if_no_args'])) {
+                    return new MethodCall($propertyFetchNode, $service['method_if_no_args'], $node->args);
+                }
+
                 return $propertyFetchNode;
             }
 

--- a/packages/Laravel/src/Rector/FuncCall/HelperFunctionToConstructorInjectionRector.php
+++ b/packages/Laravel/src/Rector/FuncCall/HelperFunctionToConstructorInjectionRector.php
@@ -25,6 +25,7 @@ final class HelperFunctionToConstructorInjectionRector extends AbstractRector
         // set/get
         'config' => [
             'type' => 'Illuminate\Contracts\Config\Repository',
+            'property' => 'configRepository',
             'array_method' => 'set',
             'non_array_method' => 'get',
         ],

--- a/packages/Laravel/tests/Rector/FuncCall/HelperFunctionToConstructorInjectionRector/Fixture/back.php.inc
+++ b/packages/Laravel/tests/Rector/FuncCall/HelperFunctionToConstructorInjectionRector/Fixture/back.php.inc
@@ -6,7 +6,12 @@ class SomeBackController
 {
     public function action()
     {
-        return back('template.blade');
+        return back();
+    }
+
+    public function actionWithParams()
+    {
+        return back(200);
     }
 }
 
@@ -19,16 +24,21 @@ namespace Rector\Laravel\Tests\Rector\FuncCall\HelperFunctionToConstructorInject
 class SomeBackController
 {
     /**
-     * @var \Illuminate\Routing\UrlGenerator
+     * @var \Illuminate\Routing\Redirector
      */
-    private $urlGenerator;
-    public function __construct(\Illuminate\Routing\UrlGenerator $urlGenerator)
+    private $redirector;
+    public function __construct(\Illuminate\Routing\Redirector $redirector)
     {
-        $this->urlGenerator = $urlGenerator;
+        $this->redirector = $redirector;
     }
     public function action()
     {
-        return $this->urlGenerator->route('template.blade');
+        return $this->redirector->back();
+    }
+
+    public function actionWithParams()
+    {
+        return $this->redirector->back(200);
     }
 }
 

--- a/packages/Laravel/tests/Rector/FuncCall/HelperFunctionToConstructorInjectionRector/Fixture/config.php.inc
+++ b/packages/Laravel/tests/Rector/FuncCall/HelperFunctionToConstructorInjectionRector/Fixture/config.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\Laravel\Tests\Rector\FuncCall\HelperFunctionToConstructorInjectionRector\Fixture;
+
+class SomeConfigController
+{
+    public function actionGet()
+    {
+        $value = config('value');
+    }
+
+    public function actionSet($value)
+    {
+        config(['value' => $value]);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Laravel\Tests\Rector\FuncCall\HelperFunctionToConstructorInjectionRector\Fixture;
+
+class SomeConfigController
+{
+    /**
+     * @var \Illuminate\Contracts\Config\Repository
+     */
+    private $configRepository;
+    public function __construct(\Illuminate\Contracts\Config\Repository $configRepository)
+    {
+        $this->configRepository = $configRepository;
+    }
+    public function actionGet()
+    {
+        $value = $this->configRepository->get('value');
+    }
+
+    public function actionSet($value)
+    {
+        $this->configRepository->set(['value' => $value]);
+    }
+}
+
+?>

--- a/packages/Laravel/tests/Rector/FuncCall/HelperFunctionToConstructorInjectionRector/HelperFunctionToConstructorInjectionRectorTest.php
+++ b/packages/Laravel/tests/Rector/FuncCall/HelperFunctionToConstructorInjectionRector/HelperFunctionToConstructorInjectionRectorTest.php
@@ -14,6 +14,7 @@ final class HelperFunctionToConstructorInjectionRectorTest extends AbstractRecto
             __DIR__ . '/Fixture/broadcast.php.inc',
             __DIR__ . '/Fixture/session.php.inc',
             __DIR__ . '/Fixture/route.php.inc',
+            __DIR__ . '/Fixture/back.php.inc',
         ]);
     }
 

--- a/packages/Laravel/tests/Rector/FuncCall/HelperFunctionToConstructorInjectionRector/HelperFunctionToConstructorInjectionRectorTest.php
+++ b/packages/Laravel/tests/Rector/FuncCall/HelperFunctionToConstructorInjectionRector/HelperFunctionToConstructorInjectionRectorTest.php
@@ -14,6 +14,7 @@ final class HelperFunctionToConstructorInjectionRectorTest extends AbstractRecto
             __DIR__ . '/Fixture/broadcast.php.inc',
             __DIR__ . '/Fixture/session.php.inc',
             __DIR__ . '/Fixture/route.php.inc',
+            __DIR__ . '/Fixture/config.php.inc',
             __DIR__ . '/Fixture/back.php.inc',
         ]);
     }


### PR DESCRIPTION
Create new parameter `method_if_no_args`, fix transforming `back()` function, add `back` file to test cases

https://github.com/rectorphp/rector/issues/1824

The file [back.php.inc](https://github.com/rectorphp/rector/blob/master/packages/Laravel/tests/Rector/FuncCall/HelperFunctionToConstructorInjectionRector/Fixture/back.php.inc) was not added to test cases, and its template was either deprecated or invalid, because `back()` function doesn't relay to UrlGenerator (as was expected in this file), it is a call of [Illuminate\Routing\Redirector@back()](https://github.com/laravel/framework/blob/5.8/src/Illuminate/Foundation/helpers.php#L169).

I've created a little customization when there are no args in usage.