### PR TITLE
Add a Laravel rector to change all the array_* helpers to Arr::* calls.

### DIFF
--- a/config/set/laravel/laravel58.yaml
+++ b/config/set/laravel/laravel58.yaml
@@ -19,3 +19,4 @@ services:
     Rector\Rector\Property\RenamePropertyRector:
         Illuminate\Routing\UrlGenerator:
             cachedSchema: 'cachedScheme'
+    Rector\Laravel\Rector\FuncCall\ArrayHelperToIlluminateSupportClassRector: ~

--- a/docs/AllRectorsOverview.md
+++ b/docs/AllRectorsOverview.md
@@ -1,4 +1,4 @@
-# All 329 Rectors Overview
+# All 332 Rectors Overview
 
 - [Projects](#projects)
 - [General](#general)
@@ -1139,7 +1139,7 @@ Add extra space before new assign set
 +            'numberz' => ['id' => 10]
 +        ];
 +
-+        $someJsonAsString = json_encode($data);
++        $someJsonAsString = Nette\Utils\Json::encode($data);
      }
  }
 ```
@@ -1724,6 +1724,35 @@ Remove unused parent call with no parent class
 
 <br>
 
+### `RemoveSetterOnlyPropertyAndMethodCallRector`
+
+- class: `Rector\DeadCode\Rector\Class_\RemoveSetterOnlyPropertyAndMethodCallRector`
+
+Removes method that set values that are never used
+
+```diff
+ class SomeClass
+ {
+-    private $name;
+-
+-    public function setName($name)
+-    {
+-        $this->name = $name;
+-    }
+ }
+
+ class ActiveOnlySetter
+ {
+     public function run()
+     {
+         $someClass = new SomeClass();
+-        $someClass->setName('Tom');
+     }
+ }
+```
+
+<br>
+
 ### `RemoveUnusedDoctrineEntityMethodAndPropertyRector`
 
 - class: `Rector\DeadCode\Rector\Class_\RemoveUnusedDoctrineEntityMethodAndPropertyRector`
@@ -2033,6 +2062,89 @@ Changes getMessage(..., true) to getMessageAsArray()
 
 ## Laravel
 
+### `ArrayHelperToIlluminateSupportClassRector`
+
+- class: `Rector\Laravel\Rector\FuncCall\ArrayHelperToIlluminateSupportClassRector`
+
+Use the Illuminate Support Arr class instead of the array helper functions
+
+```diff
+ class SomeClass
+ {
+     public function run($data)
+     {
+-        array_add($data, 'field', 'value');
+-        array_collapse($data);
+-        array_divide($data);
+-        array_dot($data);
+-        array_dot($data, '-');
+-        array_except($data, 'ignore');
+-        array_first($data);
+-        array_first($data, static function ($value) {$value > 5;});
+-        array_first($data, static function ($value) {$value > 5;}, 10);
+-        array_flatten($data);
+-        array_flatten($data, 5);
+-        array_forget($data, 'forget_this');
+-        array_get($data, 'field');
+-        array_get($data, 'field', 'default');
+-        array_has($data, 'needed');
+-        array_last($data);
+-        array_last($data, static function ($value) {$value > 5;});
+-        array_last($data, static function ($value) {$value > 5;}, 10);
+-        array_only($data, 'key');
+-        array_pluck($data, 'value');
+-        array_pluck($data, 'value', 'key');
+-        array_prepend($data, 'value');
+-        array_prepend($data, 'value', 'key');
+-        array_pull($data, 'value');
+-        array_pull($data, 'value', 'key');
+-        array_random($data);
+-        array_random($data, 5);
+-        array_set($data, 'key', 'value');
+-        array_sort($data);
+-        array_sort($data, static function ($value) {return strrev($value);});
+-        array_sort_recursive($data);
+-        array_where($data, static function ($value) { return $value > 5;});
+-        array_wrap($data);
++        \Illuminate\Support\Arr::add($data, 'field', 'value');
++        \Illuminate\Support\Arr::collapse($data);
++        \Illuminate\Support\Arr::divide($data);
++        \Illuminate\Support\Arr::dot($data);
++        \Illuminate\Support\Arr::dot($data, '-');
++        \Illuminate\Support\Arr::except($data, 'ignore');
++        \Illuminate\Support\Arr::first($data);
++        \Illuminate\Support\Arr::first($data, static function ($value) {$value > 5;});
++        \Illuminate\Support\Arr::first($data, static function ($value) {$value > 5;}, 10);
++        \Illuminate\Support\Arr::flatten($data);
++        \Illuminate\Support\Arr::flatten($data, 5);
++        \Illuminate\Support\Arr::forget($data, 'forget_this');
++        \Illuminate\Support\Arr::get($data, 'field');
++        \Illuminate\Support\Arr::get($data, 'field', 'default');
++        \Illuminate\Support\Arr::has($data, 'needed');
++        \Illuminate\Support\Arr::last($data);
++        \Illuminate\Support\Arr::last($data, static function ($value) {$value > 5;});
++        \Illuminate\Support\Arr::last($data, static function ($value) {$value > 5;}, 10);
++        \Illuminate\Support\Arr::only($data, 'key');
++        \Illuminate\Support\Arr::pluck($data, 'value');
++        \Illuminate\Support\Arr::pluck($data, 'value', 'key');
++        \Illuminate\Support\Arr::prepend($data, 'value');
++        \Illuminate\Support\Arr::prepend($data, 'value', 'key');
++        \Illuminate\Support\Arr::pull($data, 'value');
++        \Illuminate\Support\Arr::pull($data, 'value', 'key');
++        \Illuminate\Support\Arr::random($data);
++        \Illuminate\Support\Arr::random($data, 5);
++        \Illuminate\Support\Arr::set($data, 'key', 'value');
++        \Illuminate\Support\Arr::sort($data);
++        \Illuminate\Support\Arr::sort($data, static function ($value) {return strrev($value);});
++        \Illuminate\Support\Arr::sortRecursive($data);
++        \Illuminate\Support\Arr::where($data, static function ($value) { return $value > 5;});
++        \Illuminate\Support\Arr::wrap($data);
+     }
+ }
+```
+
+<br>
+
 ### `FacadeStaticCallToConstructorInjectionRector`
 
 - class: `Rector\Laravel\Rector\StaticCall\FacadeStaticCallToConstructorInjectionRector`
@@ -2254,6 +2366,39 @@ Use Nette\Utils\Strings over bare string-functions
 -        $no = $needle !== substr($content, -strlen($needle));
 +        $yes = \Nette\Utils\Strings::endsWith($content, $needle);
 +        $no = !\Nette\Utils\Strings::endsWith($content, $needle);
+     }
+ }
+```
+
+<br>
+
+### `JsonDecodeEncodeToNetteUtilsJsonDecodeEncodeRector`
+
+- class: `Rector\Nette\Rector\FuncCall\JsonDecodeEncodeToNetteUtilsJsonDecodeEncodeRector`
+
+Changes json_encode()/json_decode() to safer and more verbose Nette\Utils\Json::encode()/decode() calls
+
+```diff
+ class SomeClass
+ {
+     public function decodeJson(string $jsonString)
+     {
+-        $stdClass = json_decode($jsonString);
++        $stdClass = \Nette\Utils\Json::decode($jsonString);
+
+-        $array = json_decode($jsonString, true);
+-        $array = json_decode($jsonString, false);
++        $array = \Nette\Utils\Json::decode($jsonString, \Nette\Utils\Json::FORCE_ARRAY);
++        $array = \Nette\Utils\Json::decode($jsonString);
+     }
+
+     public function encodeJson(array $data)
+     {
+-        $jsonString = json_encode($data);
++        $jsonString = \Nette\Utils\Json::encode($data);
+
+-        $prettyJsonString = json_encode($data, JSON_PRETTY_PRINT);
++        $prettyJsonString = \Nette\Utils\Json::encode($data, \Nette\Utils\Json::PRETTY);
      }
  }
 ```
@@ -3857,7 +4002,7 @@ services:
 
 - class: `Rector\Php\Rector\FuncCall\PregReplaceEModifierRector`
 
-The /e modifier is no longer supported, use preg_replace_callback instead
+The /e modifier is no longer supported, use preg_replace_callback instead 
 
 ```diff
  class SomeClass

--- a/docs/NodesOverview.md
+++ b/docs/NodesOverview.md
@@ -917,7 +917,7 @@ if (true) {
 
 ```php
 ?>
-<strong>feel</strong><?php
+<strong>feel</strong><?php 
 ```
 <br>
 

--- a/packages/Laravel/src/Rector/FuncCall/ArrayHelperToIlluminateSupportClassRector.php
+++ b/packages/Laravel/src/Rector/FuncCall/ArrayHelperToIlluminateSupportClassRector.php
@@ -1,0 +1,162 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Laravel\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use Rector\Rector\AbstractRector;
+use Rector\RectorDefinition\CodeSample;
+use Rector\RectorDefinition\RectorDefinition;
+
+/**
+ * @see https://laravel.com/docs/5.8/upgrade#string-and-array-helpers
+ */
+
+/**
+ * @see \Rector\Laravel\Tests\Rector\FuncCall\ArrayHelperToIlluminateSupportClassRector\ArrayHelperToIlluminateSupportClassRectorTest
+ */
+final class ArrayHelperToIlluminateSupportClassRector extends AbstractRector
+{
+    private $helpersToFunction = [
+        'array_add' => 'add',
+        'array_collapse' => 'collapse',
+        'array_divide' => 'divide',
+        'array_dot' => 'dot',
+        'array_except' => 'except',
+        'array_first' => 'first',
+        'array_flatten' => 'flatten',
+        'array_forget' => 'forget',
+        'array_get' => 'get',
+        'array_has' => 'has',
+        'array_last' => 'last',
+        'array_only' => 'only',
+        'array_pluck' => 'pluck',
+        'array_prepend' => 'prepend',
+        'array_pull' => 'pull',
+        'array_random' => 'random',
+        'array_set' => 'set',
+        'array_sort' => 'sort',
+        'array_sort_recursive' => 'sortRecursive',
+        'array_where' => 'where',
+        'array_wrap' => 'wrap',
+    ];
+
+    private $supportClass = '\Illuminate\Support\Arr';
+
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Use the Illuminate Support Arr class instead of the array helper functions', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run($data)
+    {
+        array_add($data, 'field', 'value');
+        array_collapse($data);
+        array_divide($data);
+        array_dot($data);
+        array_dot($data, '-');
+        array_except($data, 'ignore');
+        array_first($data);
+        array_first($data, static function ($value) {$value > 5;});
+        array_first($data, static function ($value) {$value > 5;}, 10);
+        array_flatten($data);
+        array_flatten($data, 5);
+        array_forget($data, 'forget_this');
+        array_get($data, 'field');
+        array_get($data, 'field', 'default');
+        array_has($data, 'needed');
+        array_last($data);
+        array_last($data, static function ($value) {$value > 5;});
+        array_last($data, static function ($value) {$value > 5;}, 10);
+        array_only($data, 'key');
+        array_pluck($data, 'value');
+        array_pluck($data, 'value', 'key');
+        array_prepend($data, 'value');
+        array_prepend($data, 'value', 'key');
+        array_pull($data, 'value');
+        array_pull($data, 'value', 'key');
+        array_random($data);
+        array_random($data, 5);
+        array_set($data, 'key', 'value');
+        array_sort($data);
+        array_sort($data, static function ($value) {return strrev($value);});
+        array_sort_recursive($data);
+        array_where($data, static function ($value) { return $value > 5;});
+        array_wrap($data);
+    }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run($data)
+    {
+        \Illuminate\Support\Arr::add($data, 'field', 'value');
+        \Illuminate\Support\Arr::collapse($data);
+        \Illuminate\Support\Arr::divide($data);
+        \Illuminate\Support\Arr::dot($data);
+        \Illuminate\Support\Arr::dot($data, '-');
+        \Illuminate\Support\Arr::except($data, 'ignore');
+        \Illuminate\Support\Arr::first($data);
+        \Illuminate\Support\Arr::first($data, static function ($value) {$value > 5;});
+        \Illuminate\Support\Arr::first($data, static function ($value) {$value > 5;}, 10);
+        \Illuminate\Support\Arr::flatten($data);
+        \Illuminate\Support\Arr::flatten($data, 5);
+        \Illuminate\Support\Arr::forget($data, 'forget_this');
+        \Illuminate\Support\Arr::get($data, 'field');
+        \Illuminate\Support\Arr::get($data, 'field', 'default');
+        \Illuminate\Support\Arr::has($data, 'needed');
+        \Illuminate\Support\Arr::last($data);
+        \Illuminate\Support\Arr::last($data, static function ($value) {$value > 5;});
+        \Illuminate\Support\Arr::last($data, static function ($value) {$value > 5;}, 10);
+        \Illuminate\Support\Arr::only($data, 'key');
+        \Illuminate\Support\Arr::pluck($data, 'value');
+        \Illuminate\Support\Arr::pluck($data, 'value', 'key');
+        \Illuminate\Support\Arr::prepend($data, 'value');
+        \Illuminate\Support\Arr::prepend($data, 'value', 'key');
+        \Illuminate\Support\Arr::pull($data, 'value');
+        \Illuminate\Support\Arr::pull($data, 'value', 'key');
+        \Illuminate\Support\Arr::random($data);
+        \Illuminate\Support\Arr::random($data, 5);
+        \Illuminate\Support\Arr::set($data, 'key', 'value');
+        \Illuminate\Support\Arr::sort($data);
+        \Illuminate\Support\Arr::sort($data, static function ($value) {return strrev($value);});
+        \Illuminate\Support\Arr::sortRecursive($data);
+        \Illuminate\Support\Arr::where($data, static function ($value) { return $value > 5;});
+        \Illuminate\Support\Arr::wrap($data);
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    /**
+     * @param FuncCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        foreach ($this->helpersToFunction as $helperFunction => $classFunction) {
+            if (! $this->isName($node, $helperFunction)) {
+                continue;
+            }
+
+            return new StaticCall(new Name($this->supportClass), new Identifier($classFunction), $node->args);
+        }
+        return $node;
+    }
+}

--- a/packages/Laravel/src/Rector/FuncCall/ArrayHelperToIlluminateSupportClassRector.php
+++ b/packages/Laravel/src/Rector/FuncCall/ArrayHelperToIlluminateSupportClassRector.php
@@ -150,13 +150,10 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        foreach ($this->helpersToFunction as $helperFunction => $classFunction) {
-            if (! $this->isName($node, $helperFunction)) {
-                continue;
-            }
-
-            return new StaticCall(new Name($this->supportClass), new Identifier($classFunction), $node->args);
+        $name = $this->getName($node);
+        if (!array_key_exists($name, $this->helpersToFunction)) {
+            return null;
         }
-        return $node;
+        return new StaticCall(new Name($this->supportClass), new Identifier($this->helpersToFunction[$name]), $node->args);
     }
 }

--- a/packages/Laravel/src/Rector/FuncCall/ArrayHelperToIlluminateSupportClassRector.php
+++ b/packages/Laravel/src/Rector/FuncCall/ArrayHelperToIlluminateSupportClassRector.php
@@ -151,9 +151,12 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         $name = $this->getName($node);
-        if (!array_key_exists($name, $this->helpersToFunction)) {
+
+        if (! isset($this->helpersToFunction[$name])) {
             return null;
         }
-        return new StaticCall(new Name($this->supportClass), new Identifier($this->helpersToFunction[$name]), $node->args);
+        return new StaticCall(new Name($this->supportClass), new Identifier(
+            $this->helpersToFunction[$name]
+        ), $node->args);
     }
 }

--- a/packages/Laravel/tests/Rector/FuncCall/ArrayHelperToIlluminateSupportClassRector/ArrayHelperToIlluminateSupportClassRectorTest.php
+++ b/packages/Laravel/tests/Rector/FuncCall/ArrayHelperToIlluminateSupportClassRector/ArrayHelperToIlluminateSupportClassRectorTest.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Laravel\Tests\Rector\FuncCall\ArrayHelperToIlluminateSupportClassRector;
+
+use Rector\Laravel\Rector\FuncCall\ArrayHelperToIlluminateSupportClassRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ArrayHelperToIlluminateSupportClassRectorTest extends AbstractRectorTestCase
+{
+    public function test(): void
+    {
+        $this->doTestFiles([__DIR__ . '/Fixture/fixture.php.inc']);
+    }
+
+    protected function getRectorClass(): string
+    {
+        return ArrayHelperToIlluminateSupportClassRector::class;
+    }
+}

--- a/packages/Laravel/tests/Rector/FuncCall/ArrayHelperToIlluminateSupportClassRector/Fixture/fixture.php.inc
+++ b/packages/Laravel/tests/Rector/FuncCall/ArrayHelperToIlluminateSupportClassRector/Fixture/fixture.php.inc
@@ -1,0 +1,91 @@
+<?php
+
+namespace Rector\Laravel\Tests\Rector\FuncCall\ArrayHelperToIlluminateSupportClassRector\Fixture;
+
+class SomeClass
+{
+    public function run($data)
+    {
+        array_add($data, 'field', 'value');
+        array_collapse($data);
+        array_divide($data);
+        array_dot($data);
+        array_dot($data, '-');
+        array_except($data, 'ignore');
+        array_first($data);
+        array_first($data, static function ($value) {$value > 5;});
+        array_first($data, static function ($value) {$value > 5;}, 10);
+        array_flatten($data);
+        array_flatten($data, 5);
+        array_forget($data, 'forget_this');
+        array_get($data, 'field');
+        array_get($data, 'field', 'default');
+        array_has($data, 'needed');
+        array_last($data);
+        array_last($data, static function ($value) {$value > 5;});
+        array_last($data, static function ($value) {$value > 5;}, 10);
+        array_only($data, 'key');
+        array_pluck($data, 'value');
+        array_pluck($data, 'value', 'key');
+        array_prepend($data, 'value');
+        array_prepend($data, 'value', 'key');
+        array_pull($data, 'value');
+        array_pull($data, 'value', 'key');
+        array_random($data);
+        array_random($data, 5);
+        array_set($data, 'key', 'value');
+        array_sort($data);
+        array_sort($data, static function ($value) {return strrev($value);});
+        array_sort_recursive($data);
+        array_where($data, static function ($value) { return $value > 5;});
+        array_wrap($data);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Laravel\Tests\Rector\FuncCall\ArrayHelperToIlluminateSupportClassRector\Fixture;
+
+class SomeClass
+{
+    public function run($data)
+    {
+        \Illuminate\Support\Arr::add($data, 'field', 'value');
+        \Illuminate\Support\Arr::collapse($data);
+        \Illuminate\Support\Arr::divide($data);
+        \Illuminate\Support\Arr::dot($data);
+        \Illuminate\Support\Arr::dot($data, '-');
+        \Illuminate\Support\Arr::except($data, 'ignore');
+        \Illuminate\Support\Arr::first($data);
+        \Illuminate\Support\Arr::first($data, static function ($value) {$value > 5;});
+        \Illuminate\Support\Arr::first($data, static function ($value) {$value > 5;}, 10);
+        \Illuminate\Support\Arr::flatten($data);
+        \Illuminate\Support\Arr::flatten($data, 5);
+        \Illuminate\Support\Arr::forget($data, 'forget_this');
+        \Illuminate\Support\Arr::get($data, 'field');
+        \Illuminate\Support\Arr::get($data, 'field', 'default');
+        \Illuminate\Support\Arr::has($data, 'needed');
+        \Illuminate\Support\Arr::last($data);
+        \Illuminate\Support\Arr::last($data, static function ($value) {$value > 5;});
+        \Illuminate\Support\Arr::last($data, static function ($value) {$value > 5;}, 10);
+        \Illuminate\Support\Arr::only($data, 'key');
+        \Illuminate\Support\Arr::pluck($data, 'value');
+        \Illuminate\Support\Arr::pluck($data, 'value', 'key');
+        \Illuminate\Support\Arr::prepend($data, 'value');
+        \Illuminate\Support\Arr::prepend($data, 'value', 'key');
+        \Illuminate\Support\Arr::pull($data, 'value');
+        \Illuminate\Support\Arr::pull($data, 'value', 'key');
+        \Illuminate\Support\Arr::random($data);
+        \Illuminate\Support\Arr::random($data, 5);
+        \Illuminate\Support\Arr::set($data, 'key', 'value');
+        \Illuminate\Support\Arr::sort($data);
+        \Illuminate\Support\Arr::sort($data, static function ($value) {return strrev($value);});
+        \Illuminate\Support\Arr::sortRecursive($data);
+        \Illuminate\Support\Arr::where($data, static function ($value) { return $value > 5;});
+        \Illuminate\Support\Arr::wrap($data);
+    }
+}
+
+?>


### PR DESCRIPTION
The array_* helpers are deprecated in Laravel 5.8 (See: https://laravel.com/docs/5.8/upgrade#string-and-array-helpers )

The only part that I'm not sure about is that the composer complete-check from https://github.com/rectorphp/rector#how-to-contribute changed more on the docs than about the Rector I just created. If wanted I can reverse that part.