### PR TITLE
Fix FluentReplaceRector for more than 2 calls + add * matching support

### DIFF
--- a/tests/Rector/MethodBody/FluentReplaceRector/Fixture/multiple_some_command.php.inc
+++ b/tests/Rector/MethodBody/FluentReplaceRector/Fixture/multiple_some_command.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\Rector\MethodBody\FluentReplaceRector;
+
+use Symfony\Component\Console\Command\Command;
+
+class MultipleSomeCommand extends Command
+{
+    public function longerOne()
+    {
+        $this->setName('mail-queue:send')
+            ->setDescription('Consume the mail.')
+            ->setHelp('This command allows you to consume mail from another module.');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Rector\MethodBody\FluentReplaceRector;
+
+use Symfony\Component\Console\Command\Command;
+
+class MultipleSomeCommand extends Command
+{
+    public function longerOne()
+    {
+        $this->setName('mail-queue:send');
+        $this->setDescription('Consume the mail.');
+        $this->setHelp('This command allows you to consume mail from another module.');
+    }
+}
+
+?>

--- a/tests/Rector/MethodBody/FluentReplaceRector/Fixture/some_command.php.inc
+++ b/tests/Rector/MethodBody/FluentReplaceRector/Fixture/some_command.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Tests\Rector\MethodBody\FluentReplaceRector;
+
+use Symfony\Component\Console\Command\Command;
+
+class SomeCommand extends Command
+{
+    protected function configured()
+    {
+        $this
+            ->setName('push-notification-queue:compose')
+            ->setDescription('Compose push notifications to raw format to be send.');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Rector\MethodBody\FluentReplaceRector;
+
+use Symfony\Component\Console\Command\Command;
+
+class SomeCommand extends Command
+{
+    protected function configured()
+    {
+        $this
+            ->setName('push-notification-queue:compose');
+        $this->setDescription('Compose push notifications to raw format to be send.');
+    }
+}
+
+?>

--- a/tests/Rector/MethodBody/FluentReplaceRector/FluentReplaceRectorTest.php
+++ b/tests/Rector/MethodBody/FluentReplaceRector/FluentReplaceRectorTest.php
@@ -10,7 +10,11 @@ final class FluentReplaceRectorTest extends AbstractRectorTestCase
 {
     public function test(): void
     {
-        $this->doTestFiles([__DIR__ . '/Fixture/fixture.php.inc']);
+        $this->doTestFiles([
+            __DIR__ . '/Fixture/fixture.php.inc',
+            __DIR__ . '/Fixture/some_command.php.inc',
+            __DIR__ . '/Fixture/multiple_some_command.php.inc',
+        ]);
     }
 
     /**
@@ -20,7 +24,7 @@ final class FluentReplaceRectorTest extends AbstractRectorTestCase
     {
         return [
             FluentReplaceRector::class => [
-                '$classesToDefluent' => [FluentInterfaceClass::class],
+                '$classesToDefluent' => [FluentInterfaceClass::class, '*Command'],
             ],
         ];
     }


### PR DESCRIPTION
```yaml
# rector.yaml
services:
    Rector\Rector\MethodBody\FluentReplaceRector:
        $classesToDefluent:
            - FluentInterfaceClass
            - "*Command"
```