### PR TITLE
Refactoring order creates incompatible return types

### DIFF
--- a/packages/TypeDeclaration/tests/Rector/FunctionLike/ReturnTypeDeclarationRector/CovarianceTest.php
+++ b/packages/TypeDeclaration/tests/Rector/FunctionLike/ReturnTypeDeclarationRector/CovarianceTest.php
@@ -21,6 +21,7 @@ final class CovarianceTest extends AbstractRectorTestCase
     public function provideDataForTest(): iterable
     {
         yield [__DIR__ . '/Fixture/nikic/inheritance_covariance.php.inc'];
+        yield [__DIR__ . '/Fixture/nikic/inheritance_covariance_order.php.inc'];
         yield [__DIR__ . '/Fixture/Covariance/return_interface_to_class.php.inc'];
         yield [__DIR__ . '/Fixture/Covariance/return_nullable_with_parent_interface.php.inc'];
     }

--- a/packages/TypeDeclaration/tests/Rector/FunctionLike/ReturnTypeDeclarationRector/Fixture/nikic/inheritance_covariance_order.php.inc
+++ b/packages/TypeDeclaration/tests/Rector/FunctionLike/ReturnTypeDeclarationRector/Fixture/nikic/inheritance_covariance_order.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\TypeDeclaration\Tests\Rector\ClassMethod\ReturnTypeDeclarationRector\Fixture\InheritanceOrder;
+
+class CCovariance extends ACovariance {
+    /**
+     * Technically valid return type, but against PHP's variance restrictions.
+     * We use "ACovariance" instead, which is less accurate but valid.
+     *
+     * @return CCovariance
+     */
+    public function test() {
+        return $this;
+    }
+}
+
+class ACovariance {
+    /** @return ACovariance */
+    public function test() {
+        return $this;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\TypeDeclaration\Tests\Rector\ClassMethod\ReturnTypeDeclarationRector\Fixture\InheritanceOrder;
+
+class CCovariance extends ACovariance {
+    /**
+     * Technically valid return type, but against PHP's variance restrictions.
+     * We use "ACovariance" instead, which is less accurate but valid.
+     *
+     * @return CCovariance
+     */
+    public function test(): \Rector\TypeDeclaration\Tests\Rector\ClassMethod\ReturnTypeDeclarationRector\Fixture\InheritanceOrder\ACovariance {
+        return $this;
+    }
+}
+
+class ACovariance {
+    /** @return ACovariance */
+    public function test(): self {
+        return $this;
+    }
+}
+
+?>


### PR DESCRIPTION
This test case shows how the order in which files are parsed & refactored can lead to incompatible method signatures on the return type. The rector does `populateChildren`, but the implementation implicity relies on the superclass being processed before its subclasses to ensure return type compatibility. This in combination with the subtype logic leads to this result.

(Note: Actually I have to say I don't really understand why this subtype logic is there, since [return type variance is only supported from PHP 7.4 on](https://wiki.php.net/rfc/covariant-returns-and-contravariant-parameters). Earlier versions support [type variance for the "iterable" type](https://www.php.net/manual/de/language.types.iterable.php#language.types.iterable.variance) which is there as the test case, but I have the impression that's the one single case when PHP <7.4 supports return type variance).

I'd guess an approach similar to #1842 would be the solution. Doing it the other way round: instead of refactoring children after refactoring the node itself, the parents should be refactored before the node is refactored. This would ensure the return type decision for the parent class was made by the rector and we can make a correct decision for the node itself.

Bonus objective would be to support refactoring with return type variance when PHP7.4 is set as the language level.

I'll have a look at a potential fix as soon as I find time to have a deeper look.