### PR TITLE
Parent constant visibility when it is declared in a super-superclass

### DIFF
--- a/packages/SOLID/src/Rector/ClassConst/PrivatizeLocalClassConstantRector.php
+++ b/packages/SOLID/src/Rector/ClassConst/PrivatizeLocalClassConstantRector.php
@@ -137,6 +137,9 @@ CODE_SAMPLE
                     $this->refactor($parentClassConstant);
 
                     return $parentClassConstant;
+                } else {
+                    // If the constant isn't declared in the parent, it might be declared in the parent's parent
+                    return $this->findParentClassConstant($parentClassName, $constant);
                 }
             }
         }

--- a/packages/SOLID/tests/Rector/ClassConst/PrivatizeLocalClassConstantRector/Fixture/override_public_constant.php.inc
+++ b/packages/SOLID/tests/Rector/ClassConst/PrivatizeLocalClassConstantRector/Fixture/override_public_constant.php.inc
@@ -2,7 +2,11 @@
 
 namespace Rector\SOLID\Tests\Rector\ClassConst\PrivatizeLocalClassConstantRector\Fixture;
 
-class OverridingPublicConstantClass extends DeclaringPublicConstantClass
+class MiddleExtendingClass extends DeclaringPublicConstantClass
+{
+}
+
+class OverridingPublicConstantClass extends MiddleExtendingClass
 {
     const PUBLIC_CONSTANT = false;
 }
@@ -26,7 +30,11 @@ class PublicConstantUser
 
 namespace Rector\SOLID\Tests\Rector\ClassConst\PrivatizeLocalClassConstantRector\Fixture;
 
-class OverridingPublicConstantClass extends DeclaringPublicConstantClass
+class MiddleExtendingClass extends DeclaringPublicConstantClass
+{
+}
+
+class OverridingPublicConstantClass extends MiddleExtendingClass
 {
     public const PUBLIC_CONSTANT = false;
 }


### PR DESCRIPTION
After my recent improvements on the `PrivatizeLocalClassConstantRector`, I've executed it on our big PHP project. Found out that the parent constant visibility is not detected correctly, when the constant is declared in the parent's parent or futher up the class hierarchy. This PR fixes the issue.

Worth mentioning: I've executed it on a project with 50k PHP files, did an almost perfect job. This issue was only a handful of cases. So :thumbsup: for rector!