### PR TITLE
Add cakephp3.8 target and fix a typo

### DIFF
--- a/config/set/cakephp/cakephp36.yaml
+++ b/config/set/cakephp/cakephp36.yaml
@@ -1,4 +1,4 @@
-# source: https://book.cakephp.org/3.next/en/appendices/3-6-migration-guide.html
+# source: https://book.cakephp.org/3.0/en/appendices/3-6-migration-guide.html
 
 services:
     Rector\Rector\MethodCall\RenameMethodRector:

--- a/config/set/cakephp/cakephp37.yaml
+++ b/config/set/cakephp/cakephp37.yaml
@@ -1,4 +1,4 @@
-# source: https://book.cakephp.org/3.next/en/appendices/3-7-migration-guide.html
+# source: https://book.cakephp.org/3.0/en/appendices/3-7-migration-guide.html
 
 services:
     Rector\Rector\MethodCall\RenameMethodRector:

--- a/config/set/cakephp/cakephp38.yaml
+++ b/config/set/cakephp/cakephp38.yaml
@@ -1,0 +1,6 @@
+# source: https://book.cakephp.org/3.0/en/appendices/3-8-migration-guide.html
+
+services:
+    Rector\Rector\MethodCall\RenameMethodRector:
+        Cake\ORM\Entity:
+            'visibleProperties': 'getVisible'

--- a/src/Rector/MethodCall/MethodCallToAnotherMethodCallWithArgumentsRector.php
+++ b/src/Rector/MethodCall/MethodCallToAnotherMethodCallWithArgumentsRector.php
@@ -26,7 +26,7 @@ final class MethodCallToAnotherMethodCallWithArgumentsRector extends AbstractRec
 
     public function getDefinition(): RectorDefinition
     {
-        return new RectorDefinition('Turns old method call with specfici type to new one with arguments', [
+        return new RectorDefinition('Turns old method call with specific types to new one with arguments', [
             new ConfiguredCodeSample(
                 <<<'CODE_SAMPLE'
 $serviceDefinition = new Nette\DI\ServiceDefinition;


### PR DESCRIPTION
There was only one rectorable deprecation in CakePHP 3.8