### PR TITLE
merge isName and isNameInsensitive

### DIFF
--- a/packages/NetteTesterToPHPUnit/src/Rector/Class_/NetteTesterClassToPHPUnitClassRector.php
+++ b/packages/NetteTesterToPHPUnit/src/Rector/Class_/NetteTesterClassToPHPUnitClassRector.php
@@ -135,7 +135,7 @@ CODE_SAMPLE
         $methods = $this->classManipulator->getMethods($class);
 
         foreach ($methods as $method) {
-            if ($this->isNamesInsensitive($method, ['setUp', 'tearDown'])) {
+            if ($this->isNames($method, ['setUp', 'tearDown'])) {
                 $this->makeProtected($method);
             }
         }

--- a/packages/NetteToSymfony/src/Route/RouteInfoFactory.php
+++ b/packages/NetteToSymfony/src/Route/RouteInfoFactory.php
@@ -55,7 +55,7 @@ final class RouteInfoFactory
                 return null;
             }
 
-            $method = $this->nameResolver->matchNameInsensitiveInMap($node, [
+            $method = $this->nameResolver->matchNameInMap($node, [
                 'get' => 'GET',
                 'head' => 'HEAD',
                 'post' => 'POST',

--- a/packages/PHPUnit/src/Rector/MethodCall/UseSpecificWillMethodRector.php
+++ b/packages/PHPUnit/src/Rector/MethodCall/UseSpecificWillMethodRector.php
@@ -84,11 +84,11 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->isNameInsensitive($node, 'with')) {
+        if ($this->isName($node, 'with')) {
             return $this->processWithCall($node);
         }
 
-        if ($this->isNameInsensitive($node, 'will')) {
+        if ($this->isName($node, 'will')) {
             return $this->processWillCall($node);
         }
 
@@ -123,7 +123,7 @@ CODE_SAMPLE
         $nestedMethodCall = $node->args[0]->value;
 
         foreach ($this->nestedMethodToRenameMap as $oldMethodName => $newParentMethodName) {
-            if ($this->isNameInsensitive($nestedMethodCall, $oldMethodName)) {
+            if ($this->isName($nestedMethodCall, $oldMethodName)) {
                 $node->name = new Identifier($newParentMethodName);
 
                 // move args up

--- a/packages/Php/src/Rector/ConstFetch/RenameConstantRector.php
+++ b/packages/Php/src/Rector/ConstFetch/RenameConstantRector.php
@@ -65,7 +65,7 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         foreach ($this->oldToNewConstants as $oldConstant => $newConstant) {
-            if (! $this->isNameInsensitive($node, $oldConstant)) {
+            if (! $this->isName($node, $oldConstant)) {
                 continue;
             }
 

--- a/packages/Php/src/Rector/FunctionLike/Php4ConstructorRector.php
+++ b/packages/Php/src/Rector/FunctionLike/Php4ConstructorRector.php
@@ -86,7 +86,7 @@ CODE_SAMPLE
         $this->processClassMethodStatementsForParentConstructorCalls($node);
 
         // not PSR-4 constructor
-        if (! $this->isNameInsensitive($classNode, $this->getName($node))) {
+        if (! $this->isName($classNode, $this->getName($node))) {
             return null;
         }
 
@@ -193,7 +193,7 @@ CODE_SAMPLE
         }
 
         // it's not a parent PHP 4 constructor call
-        if (! $this->isNameInsensitive($node, $parentClassName)) {
+        if (! $this->isName($node, $parentClassName)) {
             return;
         }
 

--- a/src/PhpParser/Node/Resolver/NameResolver.php
+++ b/src/PhpParser/Node/Resolver/NameResolver.php
@@ -100,10 +100,10 @@ final class NameResolver
     /**
      * @param string[] $map
      */
-    public function matchNameInsensitiveInMap(Node $node, array $map): ?string
+    public function matchNameInMap(Node $node, array $map): ?string
     {
         foreach ($map as $nameToMatch => $return) {
-            if ($this->isNameInsensitive($node, $nameToMatch)) {
+            if ($this->isName($node, $nameToMatch)) {
                 return $return;
             }
         }
@@ -111,18 +111,13 @@ final class NameResolver
         return null;
     }
 
-    public function isNameInsensitive(Node $node, string $name): bool
-    {
-        return strtolower((string) $this->getName($node)) === strtolower($name);
-    }
-
     /**
      * @param string[] $names
      */
-    public function isNamesInsensitive(Node $node, array $names): bool
+    public function isNames(Node $node, array $names): bool
     {
         foreach ($names as $name) {
-            if ($this->isNameInsensitive($node, $name)) {
+            if ($this->isName($node, $name)) {
                 return true;
             }
         }
@@ -151,15 +146,12 @@ final class NameResolver
             return fnmatch($name, $resolvedName, FNM_NOESCAPE);
         }
 
-        return $resolvedName === $name;
-    }
+        // special case
+        if ($name === 'Object') {
+            return $name === $resolvedName;
+        }
 
-    /**
-     * @param string[] $names
-     */
-    public function isNames(Node $node, array $names): bool
-    {
-        return in_array($this->getName($node), $names, true);
+        return strtolower($resolvedName) === strtolower($name);
     }
 
     public function getName(Node $node): ?string

--- a/src/Rector/AbstractPHPUnitRector.php
+++ b/src/Rector/AbstractPHPUnitRector.php
@@ -15,7 +15,7 @@ abstract class AbstractPHPUnitRector extends AbstractRector
             return false;
         }
 
-        return $this->isNameInsensitive($node, $name);
+        return $this->isName($node, $name);
     }
 
     /**
@@ -27,7 +27,7 @@ abstract class AbstractPHPUnitRector extends AbstractRector
             return false;
         }
 
-        return $this->isNamesInsensitive($node, $names);
+        return $this->isNames($node, $names);
     }
 
     protected function isInTestClass(Node $node): bool

--- a/src/Rector/AbstractRector/NameResolverTrait.php
+++ b/src/Rector/AbstractRector/NameResolverTrait.php
@@ -34,31 +34,12 @@ trait NameResolverTrait
         return $this->nameResolver->areNamesEqual($firstNode, $secondNode);
     }
 
-    public function isNameInsensitive(Node $node, string $name): bool
-    {
-        return $this->nameResolver->isNameInsensitive($node, $name);
-    }
-
-    /**
-     * @param string[] $names
-     */
-    public function isNamesInsensitive(Node $node, array $names): bool
-    {
-        return $this->nameResolver->isNamesInsensitive($node, $names);
-    }
-
     /**
      * @param string[] $names
      */
     public function isNames(Node $node, array $names): bool
     {
-        foreach ($names as $name) {
-            if ($this->isName($node, $name)) {
-                return true;
-            }
-        }
-
-        return false;
+        return $this->nameResolver->isNames($node, $names);
     }
 
     public function getName(Node $node): ?string

--- a/src/Rector/Constant/RenameClassConstantRector.php
+++ b/src/Rector/Constant/RenameClassConstantRector.php
@@ -73,7 +73,7 @@ CODE_SAMPLE
             }
 
             foreach ($oldToNewConstants as $oldConstant => $newConstant) {
-                if (! $this->isNameInsensitive($node->name, $oldConstant)) {
+                if (! $this->isName($node->name, $oldConstant)) {
                     continue;
                 }
 

--- a/src/Rector/Function_/RenameFunctionRector.php
+++ b/src/Rector/Function_/RenameFunctionRector.php
@@ -54,7 +54,7 @@ final class RenameFunctionRector extends AbstractRector
     public function refactor(Node $node): ?Node
     {
         foreach ($this->oldFunctionToNewFunction as $oldFunction => $newFunction) {
-            if (! $this->isNameInsensitive($node, $oldFunction)) {
+            if (! $this->isName($node, $oldFunction)) {
                 continue;
             }
 

--- a/src/Rector/MethodCall/RenameMethodCallRector.php
+++ b/src/Rector/MethodCall/RenameMethodCallRector.php
@@ -72,7 +72,7 @@ CODE_SAMPLE
             }
 
             foreach ($oldToNewMethods as $oldMethod => $newMethod) {
-                if (! $this->isNameInsensitive($node, $oldMethod)) {
+                if (! $this->isName($node, $oldMethod)) {
                     continue;
                 }
 

--- a/src/Rector/MethodCall/RenameMethodRector.php
+++ b/src/Rector/MethodCall/RenameMethodRector.php
@@ -74,7 +74,7 @@ CODE_SAMPLE
             }
 
             foreach ($oldToNewMethods as $oldMethod => $newMethod) {
-                if (! $this->isNameInsensitive($node, $oldMethod)) {
+                if (! $this->isName($node, $oldMethod)) {
                     continue;
                 }
 

--- a/src/Rector/MethodCall/RenameStaticMethodRector.php
+++ b/src/Rector/MethodCall/RenameStaticMethodRector.php
@@ -70,7 +70,7 @@ final class RenameStaticMethodRector extends AbstractRector
             }
 
             foreach ($oldToNewMethods as $oldMethod => $newMethod) {
-                if (! $this->isNameInsensitive($node, $oldMethod)) {
+                if (! $this->isName($node, $oldMethod)) {
                     continue;
                 }
 

--- a/src/Rector/Property/RenamePropertyRector.php
+++ b/src/Rector/Property/RenamePropertyRector.php
@@ -64,7 +64,7 @@ final class RenamePropertyRector extends AbstractRector
             }
 
             foreach ($oldToNewProperties as $oldProperty => $newProperty) {
-                if (! $this->isNameInsensitive($node, $oldProperty)) {
+                if (! $this->isName($node, $oldProperty)) {
                     continue;
                 }
 


### PR DESCRIPTION
When working with legacy code, from technical point of view all names are insesntive:

```php
public function setUp() {}
```

is the same as:

```php
public function setup() {}
```

Saying that, all `*Name*` methods work will match both names