### PR TITLE
[TypeDeclaration] Extend ReturnTypeDeclarationRector with incorrect types override

### DIFF
--- a/packages/TypeDeclaration/src/Contract/TypeInferer/ReturnTypeInfererInterface.php
+++ b/packages/TypeDeclaration/src/Contract/TypeInferer/ReturnTypeInfererInterface.php
@@ -4,7 +4,7 @@ namespace Rector\TypeDeclaration\Contract\TypeInferer;
 
 use PhpParser\Node\FunctionLike;
 
-interface FunctionLikeReturnTypeInfererInterface
+interface ReturnTypeInfererInterface
 {
     /**
      * @return string[]

--- a/packages/TypeDeclaration/src/Rector/ClassMethod/AddArrayParamDocTypeRector.php
+++ b/packages/TypeDeclaration/src/Rector/ClassMethod/AddArrayParamDocTypeRector.php
@@ -12,8 +12,8 @@ use Rector\NodeTypeResolver\PhpDoc\NodeAnalyzer\DocBlockManipulator;
 use Rector\Rector\AbstractRector;
 use Rector\RectorDefinition\CodeSample;
 use Rector\RectorDefinition\RectorDefinition;
-use Rector\TypeDeclaration\Contract\TypeInferer\ParamTypeInfererInterface;
 use Rector\TypeDeclaration\PhpDocParser\ParamPhpDocNodeFactory;
+use Rector\TypeDeclaration\TypeInferer\ParamTypeInferer;
 
 /**
  * @sponsor Thanks https://spaceflow.io/ for sponsoring this rule - visit them on https://github.com/SpaceFlow-app
@@ -27,26 +27,23 @@ final class AddArrayParamDocTypeRector extends AbstractRector
     private $docBlockManipulator;
 
     /**
-     * @var ParamTypeInfererInterface[]
-     */
-    private $paramTypeInferers = [];
-
-    /**
      * @var ParamPhpDocNodeFactory
      */
     private $paramPhpDocNodeFactory;
 
     /**
-     * @param ParamTypeInfererInterface[] $paramTypeInferers
+     * @var ParamTypeInferer
      */
+    private $paramTypeInferer;
+
     public function __construct(
         DocBlockManipulator $docBlockManipulator,
-        array $paramTypeInferers,
-        ParamPhpDocNodeFactory $paramPhpDocNodeFactory
+        ParamPhpDocNodeFactory $paramPhpDocNodeFactory,
+        ParamTypeInferer $paramTypeInferer
     ) {
         $this->docBlockManipulator = $docBlockManipulator;
-        $this->paramTypeInferers = $paramTypeInferers;
         $this->paramPhpDocNodeFactory = $paramPhpDocNodeFactory;
+        $this->paramTypeInferer = $paramTypeInferer;
     }
 
     public function getDefinition(): RectorDefinition
@@ -114,15 +111,7 @@ CODE_SAMPLE
                 return null;
             }
 
-            $types = [];
-            foreach ($this->paramTypeInferers as $paramTypeInferer) {
-                $types = $paramTypeInferer->inferParam($param);
-                if ($types !== []) {
-                    break;
-                }
-            }
-
-            // no types :/
+            $types = $this->paramTypeInferer->inferParam($param);
             if ($types === []) {
                 return null;
             }

--- a/packages/TypeDeclaration/src/Rector/ClassMethod/AddArrayReturnDocTypeRector.php
+++ b/packages/TypeDeclaration/src/Rector/ClassMethod/AddArrayReturnDocTypeRector.php
@@ -8,7 +8,6 @@ use Rector\NodeTypeResolver\PhpDoc\NodeAnalyzer\DocBlockManipulator;
 use Rector\Rector\AbstractRector;
 use Rector\RectorDefinition\CodeSample;
 use Rector\RectorDefinition\RectorDefinition;
-use Rector\TypeDeclaration\Contract\TypeInferer\ReturnTypeInfererInterface;
 use Rector\TypeDeclaration\TypeInferer\ReturnTypeInferer;
 
 /**
@@ -27,9 +26,6 @@ final class AddArrayReturnDocTypeRector extends AbstractRector
      */
     private $returnTypeInferer;
 
-    /**
-     * @param ReturnTypeInfererInterface[] $docBlockManipulator
-     */
     public function __construct(DocBlockManipulator $docBlockManipulator, ReturnTypeInferer $returnTypeInferer)
     {
         $this->docBlockManipulator = $docBlockManipulator;

--- a/packages/TypeDeclaration/src/Rector/ClassMethod/AddArrayReturnDocTypeRector.php
+++ b/packages/TypeDeclaration/src/Rector/ClassMethod/AddArrayReturnDocTypeRector.php
@@ -8,7 +8,8 @@ use Rector\NodeTypeResolver\PhpDoc\NodeAnalyzer\DocBlockManipulator;
 use Rector\Rector\AbstractRector;
 use Rector\RectorDefinition\CodeSample;
 use Rector\RectorDefinition\RectorDefinition;
-use Rector\TypeDeclaration\Contract\TypeInferer\FunctionLikeReturnTypeInfererInterface;
+use Rector\TypeDeclaration\Contract\TypeInferer\ReturnTypeInfererInterface;
+use Rector\TypeDeclaration\TypeInferer\ReturnTypeInferer;
 
 /**
  * @sponsor Thanks https://spaceflow.io/ for sponsoring this rule - visit them on https://github.com/SpaceFlow-app
@@ -22,17 +23,17 @@ final class AddArrayReturnDocTypeRector extends AbstractRector
     private $docBlockManipulator;
 
     /**
-     * @var FunctionLikeReturnTypeInfererInterface[]
+     * @var ReturnTypeInferer
      */
-    private $functionLikeReturnTypeInferers = [];
+    private $returnTypeInferer;
 
     /**
-     * @param FunctionLikeReturnTypeInfererInterface[] $functionLikeReturnTypeInferers
+     * @param ReturnTypeInfererInterface[] $docBlockManipulator
      */
-    public function __construct(DocBlockManipulator $docBlockManipulator, array $functionLikeReturnTypeInferers)
+    public function __construct(DocBlockManipulator $docBlockManipulator, ReturnTypeInferer $returnTypeInferer)
     {
         $this->docBlockManipulator = $docBlockManipulator;
-        $this->functionLikeReturnTypeInferers = $functionLikeReturnTypeInferers;
+        $this->returnTypeInferer = $returnTypeInferer;
     }
 
     public function getDefinition(): RectorDefinition
@@ -92,14 +93,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $docTypes = [];
-        foreach ($this->functionLikeReturnTypeInferers as $functionLikeReturnTypeInferer) {
-            $docTypes = $functionLikeReturnTypeInferer->inferFunctionLike($node);
-            if ($docTypes !== []) {
-                break;
-            }
-        }
-
+        $docTypes = $this->returnTypeInferer->inferFunctionLike($node);
         if ($docTypes !== []) {
             $docType = implode('|', $docTypes);
 

--- a/packages/TypeDeclaration/src/Rector/Property/PropertyTypeDeclarationRector.php
+++ b/packages/TypeDeclaration/src/Rector/Property/PropertyTypeDeclarationRector.php
@@ -9,8 +9,7 @@ use PhpParser\Node\Stmt\Property;
 use Rector\NodeTypeResolver\PhpDoc\NodeAnalyzer\DocBlockManipulator;
 use Rector\Rector\AbstractRector;
 use Rector\RectorDefinition\RectorDefinition;
-use Rector\TypeDeclaration\Contract\TypeInferer\PropertyTypeInfererInterface;
-use Rector\TypeDeclaration\Exception\ConflictingPriorityException;
+use Rector\TypeDeclaration\TypeInferer\PropertyTypeInferer;
 use Rector\TypeDeclaration\ValueObject\IdentifierValueObject;
 
 /**
@@ -24,18 +23,14 @@ final class PropertyTypeDeclarationRector extends AbstractRector
     private $docBlockManipulator;
 
     /**
-     * @var PropertyTypeInfererInterface[]
+     * @var PropertyTypeInferer
      */
-    private $propertyTypeInferers = [];
+    private $propertyTypeInferer;
 
-    /**
-     * @param PropertyTypeInfererInterface[] $propertyTypeInferers
-     */
-    public function __construct(DocBlockManipulator $docBlockManipulator, array $propertyTypeInferers = [])
+    public function __construct(DocBlockManipulator $docBlockManipulator, PropertyTypeInferer $propertyTypeInferer)
     {
         $this->docBlockManipulator = $docBlockManipulator;
-
-        $this->sortAndSetPropertyTypeInferers($propertyTypeInferers);
+        $this->propertyTypeInferer = $propertyTypeInferer;
     }
 
     public function getDefinition(): RectorDefinition
@@ -64,12 +59,10 @@ final class PropertyTypeDeclarationRector extends AbstractRector
             return null;
         }
 
-        foreach ($this->propertyTypeInferers as $propertyTypeInferer) {
-            $types = $propertyTypeInferer->inferProperty($node);
-            if ($types) {
-                $this->setNodeVarTypes($node, $types);
-                return $node;
-            }
+        $types = $this->propertyTypeInferer->inferProperty($node);
+        if ($types) {
+            $this->setNodeVarTypes($node, $types);
+            return $node;
         }
 
         return null;
@@ -83,29 +76,5 @@ final class PropertyTypeDeclarationRector extends AbstractRector
         $this->docBlockManipulator->changeVarTag($node, $varTypes);
 
         return $node;
-    }
-
-    /**
-     * @param PropertyTypeInfererInterface[] $propertyTypeInferers
-     */
-    private function sortAndSetPropertyTypeInferers(array $propertyTypeInferers): void
-    {
-        foreach ($propertyTypeInferers as $propertyTypeInferer) {
-            $this->ensurePriorityIsUnique($propertyTypeInferer);
-            $this->propertyTypeInferers[$propertyTypeInferer->getPriority()] = $propertyTypeInferer;
-        }
-
-        krsort($this->propertyTypeInferers);
-    }
-
-    private function ensurePriorityIsUnique(PropertyTypeInfererInterface $propertyTypeInferer): void
-    {
-        if (! isset($this->propertyTypeInferers[$propertyTypeInferer->getPriority()])) {
-            return;
-        }
-
-        $alreadySetPropertyTypeInferer = $this->propertyTypeInferers[$propertyTypeInferer->getPriority()];
-
-        throw new ConflictingPriorityException($propertyTypeInferer, $alreadySetPropertyTypeInferer);
     }
 }

--- a/packages/TypeDeclaration/src/TypeInferer/ParamTypeInferer.php
+++ b/packages/TypeDeclaration/src/TypeInferer/ParamTypeInferer.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\TypeInferer;
+
+use PhpParser\Node\Param;
+use Rector\TypeDeclaration\Contract\TypeInferer\ParamTypeInfererInterface;
+
+final class ParamTypeInferer
+{
+    /**
+     * @var ParamTypeInfererInterface[]
+     */
+    private $paramTypeInferers = [];
+
+    /**
+     * @param ParamTypeInfererInterface[] $paramTypeInferers
+     */
+    public function __construct(array $paramTypeInferers)
+    {
+        $this->paramTypeInferers = $paramTypeInferers;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function inferParam(Param $param): array
+    {
+        foreach ($this->paramTypeInferers as $paramTypeInferers) {
+            $types = $paramTypeInferers->inferParam($param);
+            if ($types !== []) {
+                return $types;
+            }
+        }
+
+        return [];
+    }
+}

--- a/packages/TypeDeclaration/src/TypeInferer/PropertyTypeInferer.php
+++ b/packages/TypeDeclaration/src/TypeInferer/PropertyTypeInferer.php
@@ -4,6 +4,8 @@ namespace Rector\TypeDeclaration\TypeInferer;
 
 use PhpParser\Node\Stmt\Property;
 use Rector\TypeDeclaration\Contract\TypeInferer\PropertyTypeInfererInterface;
+use Rector\TypeDeclaration\Exception\ConflictingPriorityException;
+use Rector\TypeDeclaration\ValueObject\IdentifierValueObject;
 
 final class PropertyTypeInferer
 {
@@ -17,21 +19,45 @@ final class PropertyTypeInferer
      */
     public function __construct(array $propertyTypeInferers)
     {
-        $this->propertyTypeInferers = $propertyTypeInferers;
+        $this->sortAndSetPropertyTypeInferers($propertyTypeInferers);
     }
 
     /**
-     * @property string[]
+     * @return string[]|IdentifierValueObject[]
      */
     public function inferProperty(Property $property): array
     {
         foreach ($this->propertyTypeInferers as $propertyTypeInferers) {
-            $types = $propertyTypeInferers->inferFunctionLike($property);
+            $types = $propertyTypeInferers->inferProperty($property);
             if ($types !== []) {
                 return $types;
             }
         }
 
         return [];
+    }
+
+    /**
+     * @param PropertyTypeInfererInterface[] $propertyTypeInferers
+     */
+    private function sortAndSetPropertyTypeInferers(array $propertyTypeInferers): void
+    {
+        foreach ($propertyTypeInferers as $propertyTypeInferer) {
+            $this->ensurePriorityIsUnique($propertyTypeInferer);
+            $this->propertyTypeInferers[$propertyTypeInferer->getPriority()] = $propertyTypeInferer;
+        }
+
+        krsort($this->propertyTypeInferers);
+    }
+
+    private function ensurePriorityIsUnique(PropertyTypeInfererInterface $propertyTypeInferer): void
+    {
+        if (! isset($this->propertyTypeInferers[$propertyTypeInferer->getPriority()])) {
+            return;
+        }
+
+        $alreadySetPropertyTypeInferer = $this->propertyTypeInferers[$propertyTypeInferer->getPriority()];
+
+        throw new ConflictingPriorityException($propertyTypeInferer, $alreadySetPropertyTypeInferer);
     }
 }

--- a/packages/TypeDeclaration/src/TypeInferer/PropertyTypeInferer.php
+++ b/packages/TypeDeclaration/src/TypeInferer/PropertyTypeInferer.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\TypeInferer;
+
+use PhpParser\Node\Stmt\Property;
+use Rector\TypeDeclaration\Contract\TypeInferer\PropertyTypeInfererInterface;
+
+final class PropertyTypeInferer
+{
+    /**
+     * @var PropertyTypeInfererInterface[]
+     */
+    private $propertyTypeInferers = [];
+
+    /**
+     * @param PropertyTypeInfererInterface[] $propertyTypeInferers
+     */
+    public function __construct(array $propertyTypeInferers)
+    {
+        $this->propertyTypeInferers = $propertyTypeInferers;
+    }
+
+    /**
+     * @property string[]
+     */
+    public function inferProperty(Property $property): array
+    {
+        foreach ($this->propertyTypeInferers as $propertyTypeInferers) {
+            $types = $propertyTypeInferers->inferFunctionLike($property);
+            if ($types !== []) {
+                return $types;
+            }
+        }
+
+        return [];
+    }
+}

--- a/packages/TypeDeclaration/src/TypeInferer/ReturnTypeInferer.php
+++ b/packages/TypeDeclaration/src/TypeInferer/ReturnTypeInferer.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\TypeInferer;
+
+use PhpParser\Node\FunctionLike;
+use Rector\TypeDeclaration\Contract\TypeInferer\ReturnTypeInfererInterface;
+
+final class ReturnTypeInferer
+{
+    /**
+     * @var ReturnTypeInfererInterface[]
+     */
+    private $returnTypeInferers = [];
+
+    /**
+     * @param ReturnTypeInfererInterface[] $returnTypeInferers
+     */
+    public function __construct(array $returnTypeInferers)
+    {
+        $this->returnTypeInferers = $returnTypeInferers;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function inferFunctionLike(FunctionLike $functionLike): array
+    {
+        foreach ($this->returnTypeInferers as $returnTypeInferers) {
+            $types = $returnTypeInferers->inferFunctionLike($functionLike);
+            if ($types !== []) {
+                return $types;
+            }
+        }
+
+        return [];
+    }
+}

--- a/packages/TypeDeclaration/src/TypeInferer/ReturnTypeInferer/ReturnedNodeReturnTypeInferer.php
+++ b/packages/TypeDeclaration/src/TypeInferer/ReturnTypeInferer/ReturnedNodeReturnTypeInferer.php
@@ -7,10 +7,10 @@ use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use Rector\PhpParser\Node\Manipulator\FunctionLikeManipulator;
-use Rector\TypeDeclaration\Contract\TypeInferer\FunctionLikeReturnTypeInfererInterface;
+use Rector\TypeDeclaration\Contract\TypeInferer\ReturnTypeInfererInterface;
 use Rector\TypeDeclaration\TypeInferer\AbstractTypeInferer;
 
-final class ReturnedNodeFunctionLikeReturnTypeInferer extends AbstractTypeInferer implements FunctionLikeReturnTypeInfererInterface
+final class ReturnedNodeReturnTypeInferer extends AbstractTypeInferer implements ReturnTypeInfererInterface
 {
     /**
      * @var FunctionLikeManipulator

--- a/packages/TypeDeclaration/src/TypeInferer/ReturnTypeInferer/ReturnedPropertyReturnTypeInferer.php
+++ b/packages/TypeDeclaration/src/TypeInferer/ReturnTypeInferer/ReturnedPropertyReturnTypeInferer.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\TypeInferer\ReturnTypeInferer;
+
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\Property;
+use PhpParser\Node\Stmt\Return_;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\TypeDeclaration\Contract\TypeInferer\ReturnTypeInfererInterface;
+use Rector\TypeDeclaration\TypeInferer\AbstractTypeInferer;
+use Rector\TypeDeclaration\TypeInferer\PropertyTypeInferer;
+
+/**
+ * Infer return type from $this->variable → and get type $this->variable from @var annotation
+ */
+final class ReturnedPropertyReturnTypeInferer extends AbstractTypeInferer implements ReturnTypeInfererInterface
+{
+    /**
+     * @var PropertyTypeInferer
+     */
+    private $propertyTypeInferer;
+
+    public function __construct(PropertyTypeInferer $propertyTypeInferer)
+    {
+        $this->propertyTypeInferer = $propertyTypeInferer;
+    }
+
+    /**
+     * @param ClassMethod|Closure|Function_ $functionLike
+     * @return string[]
+     */
+    public function inferFunctionLike(FunctionLike $functionLike): array
+    {
+        if (! $functionLike instanceof ClassMethod) {
+            return [];
+        }
+
+        $propertyFetch = $this->matchSingleStmtReturnPropertyFetch($functionLike);
+        if ($propertyFetch === null) {
+            return [];
+        }
+
+        $property = $this->getPropertyByPropertyFetch($propertyFetch);
+        if ($property === null) {
+            return [];
+        }
+
+        return $this->propertyTypeInferer->inferProperty($property);
+    }
+
+    private function matchSingleStmtReturnPropertyFetch(ClassMethod $classMethod): ?PropertyFetch
+    {
+        if (count($classMethod->stmts) !== 1) {
+            return null;
+        }
+
+        $singleStmt = $classMethod->stmts[0];
+        if ($singleStmt instanceof Expression) {
+            $singleStmt = $singleStmt->expr;
+        }
+
+        // is it return?
+        if (! $singleStmt instanceof Return_) {
+            return null;
+        }
+
+        if (! $singleStmt->expr instanceof PropertyFetch) {
+            return null;
+        }
+
+        $propertyFetch = $singleStmt->expr;
+        if (! $this->nameResolver->isName($propertyFetch->var, 'this')) {
+            return null;
+        }
+
+        return $propertyFetch;
+    }
+
+    private function getPropertyByPropertyFetch(PropertyFetch $propertyFetch): ?Property
+    {
+        $class = $propertyFetch->getAttribute(AttributeKey::CLASS_NODE);
+        if ($class instanceof ClassLike) {
+            return null;
+        }
+
+        $propertyName = $this->nameResolver->getName($propertyFetch->name);
+        foreach ($class->stmts as $stmt) {
+            if (!$stmt instanceof Property) {
+                continue;
+            }
+
+            if (!$this->nameResolver->isName($stmt, $propertyName)) {
+                continue;
+            }
+
+            return $stmt;
+        }
+
+        return null;
+    }
+}

--- a/packages/TypeDeclaration/src/TypeInferer/ReturnTypeInferer/SetterNodeReturnTypeInferer.php
+++ b/packages/TypeDeclaration/src/TypeInferer/ReturnTypeInferer/SetterNodeReturnTypeInferer.php
@@ -6,11 +6,11 @@ use PhpParser\Node\FunctionLike;
 use PHPStan\Type\IntersectionType;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PhpParser\Node\Manipulator\FunctionLikeManipulator;
-use Rector\TypeDeclaration\Contract\TypeInferer\FunctionLikeReturnTypeInfererInterface;
+use Rector\TypeDeclaration\Contract\TypeInferer\ReturnTypeInfererInterface;
 use Rector\TypeDeclaration\TypeInferer\AbstractTypeInferer;
 use Rector\TypeDeclaration\TypeInferer\AssignToPropertyTypeInferer;
 
-final class SetterNodeFunctionLikeReturnTypeInferer extends AbstractTypeInferer implements FunctionLikeReturnTypeInfererInterface
+final class SetterNodeReturnTypeInferer extends AbstractTypeInferer implements ReturnTypeInfererInterface
 {
     /**
      * @var FunctionLikeManipulator

--- a/packages/TypeDeclaration/tests/Rector/FunctionLike/ReturnTypeDeclarationRector/CorrectionTest.php
+++ b/packages/TypeDeclaration/tests/Rector/FunctionLike/ReturnTypeDeclarationRector/CorrectionTest.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\Tests\Rector\FunctionLike\ReturnTypeDeclarationRector;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Rector\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector;
+
+final class CorrectionTest extends AbstractRectorTestCase
+{
+    public function test(): void
+    {
+        $this->doTestFiles([__DIR__ . '/Fixture/Correction/constructor_property_assign_over_getter.php.inc']);
+    }
+
+    protected function getRectorClass(): string
+    {
+        return ReturnTypeDeclarationRector::class;
+    }
+}

--- a/packages/TypeDeclaration/tests/Rector/FunctionLike/ReturnTypeDeclarationRector/Fixture/Correction/constructor_property_assign_over_getter.php.inc
+++ b/packages/TypeDeclaration/tests/Rector/FunctionLike/ReturnTypeDeclarationRector/Fixture/Correction/constructor_property_assign_over_getter.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\TypeDeclaration\Tests\Rector\ClassMethod\ReturnTypeDeclarationRector\Fixture\Correction;
+
+class ConstructorPropertyAssignOverGetter
+{
+    private $nullableValue;
+
+    public function __construct(?array $nullableValue)
+    {
+        $this->nullableValue = $nullableValue;
+    }
+
+    public function getNullableValue(): array
+    {
+        return $this->nullableValue;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\TypeDeclaration\Tests\Rector\ClassMethod\ReturnTypeDeclarationRector\Fixture\Correction;
+
+class ConstructorPropertyAssignOverGetter
+{
+    private $nullableValue;
+
+    public function __construct(?array $nullableValue)
+    {
+        $this->nullableValue = $nullableValue;
+    }
+
+    public function getNullableValue(): ?array
+    {
+        return $this->nullableValue;
+    }
+}
+
+?>


### PR DESCRIPTION
```diff
class SomeClass
{
    private $decodedContents;

    public function __construct(?array $decodedContents)
    {
        $this->decodedContents = $decodedContents;
    }


-    public function getDecodedContents(): array
+    public function getDecodedContents(): ?array
    {
        return $this->decodedContents;
    }
}
```