### PR TITLE
[TypeDeclaration] Add AddMethodCallBasedParamTypeRector

### DIFF
--- a/config/set/doctrine/doctrine-id-to-uuid-step-3.yaml
+++ b/config/set/doctrine/doctrine-id-to-uuid-step-3.yaml
@@ -3,3 +3,6 @@ services:
     Rector\Doctrine\Rector\MethodCall\ChangeGetUuidMethodCallToGetIdRector: ~
     Rector\Doctrine\Rector\ClassMethod\ChangeReturnTypeOfClassMethodWithGetIdRector: ~
     Rector\Doctrine\Rector\Identical\ChangeIdenticalUuidToEqualsMethodCallRector: ~
+
+    # add Uuid type declarations
+    Rector\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedParamTypeRector: ~

--- a/ecs.yaml
+++ b/ecs.yaml
@@ -115,6 +115,7 @@ parameters:
             - 'src/Rector/AbstractRector.php'
 
         Symplify\CodingStandard\Sniffs\CleanCode\CognitiveComplexitySniff:
+            - 'packages/Doctrine/src/Rector/ClassMethod/AddMethodCallBasedParamTypeRector.php'
             - 'packages/DoctrinePhpDocParser/src/PhpDocParser/OrmTagParser.php'
             - 'packages/TypeDeclaration/src/TypeInferer/ReturnTypeInferer/ReturnedNodesReturnTypeInferer.php'
             - 'packages/NodeTypeResolver/src/NodeTypeResolver.php'

--- a/packages/NodeTypeResolver/src/NodeTypeResolver.php
+++ b/packages/NodeTypeResolver/src/NodeTypeResolver.php
@@ -5,6 +5,7 @@ namespace Rector\NodeTypeResolver;
 use Countable;
 use Nette\Utils\Strings;
 use PhpParser\Node;
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayDimFetch;
@@ -277,6 +278,10 @@ final class NodeTypeResolver
     {
         if ($node instanceof String_) {
             return new ConstantStringType($node->value);
+        }
+
+        if ($node instanceof Arg) {
+            return $this->getStaticType($node->value);
         }
 
         if ($node instanceof Param) {

--- a/packages/NodeTypeResolver/src/StaticTypeMapper.php
+++ b/packages/NodeTypeResolver/src/StaticTypeMapper.php
@@ -419,6 +419,11 @@ final class StaticTypeMapper
             if ($node->name === 'string') {
                 return new StringType();
             }
+
+            $type = $this->mapScalarStringToType($node->name);
+            if ($type !== null) {
+                return $type;
+            }
         }
 
         if ($node instanceof FullyQualified) {
@@ -513,61 +518,19 @@ final class StaticTypeMapper
         }
 
         throw new NotImplementedException(sprintf('%s for "%s"', __METHOD__, $type));
-
-        return null;
     }
 
     public function mapPHPStanPhpDocTypeNodeToPHPStanType(TypeNode $typeNode, Node $node): Type
     {
         if ($typeNode instanceof IdentifierTypeNode) {
+            $type = $this->mapScalarStringToType($typeNode->name);
+            if ($type !== null) {
+                return $type;
+            }
+
             $loweredName = strtolower($typeNode->name);
-
-            if ($loweredName === 'string') {
-                return new StringType();
-            }
-
-            if (in_array($loweredName, ['float', 'real', 'double'], true)) {
-                return new FloatType();
-            }
-
             if ($loweredName === '\string') {
                 return new PreSlashStringType();
-            }
-
-            if (in_array($loweredName, ['int', 'integer'], true)) {
-                return new IntegerType();
-            }
-
-            if (in_array($loweredName, ['false', 'true', 'bool', 'boolean'], true)) {
-                return new BooleanType();
-            }
-
-            if ($loweredName === 'array') {
-                return new ArrayType(new MixedType(), new MixedType());
-            }
-
-            if ($loweredName === 'null') {
-                return new NullType();
-            }
-
-            if ($loweredName === 'void') {
-                return new VoidType();
-            }
-
-            if ($loweredName === 'object') {
-                return new ObjectWithoutClassType();
-            }
-
-            if ($loweredName === 'resource') {
-                return new ResourceType();
-            }
-
-            if (in_array($loweredName, ['callback', 'callable'], true)) {
-                return new CallableType();
-            }
-
-            if ($loweredName === 'mixed') {
-                return new MixedType(true);
             }
 
             if ($loweredName === 'self') {
@@ -731,5 +694,55 @@ final class StaticTypeMapper
         }
 
         return new Identifier($type);
+    }
+
+    private function mapScalarStringToType(string $scalarName): ?Type
+    {
+        $loweredScalarName = Strings::lower($scalarName);
+        if ($loweredScalarName === 'string') {
+            return new StringType();
+        }
+
+        if (in_array($loweredScalarName, ['float', 'real', 'double'], true)) {
+            return new FloatType();
+        }
+
+        if (in_array($loweredScalarName, ['int', 'integer'], true)) {
+            return new IntegerType();
+        }
+
+        if (in_array($loweredScalarName, ['false', 'true', 'bool', 'boolean'], true)) {
+            return new BooleanType();
+        }
+
+        if ($loweredScalarName === 'array') {
+            return new ArrayType(new MixedType(), new MixedType());
+        }
+
+        if ($loweredScalarName === 'null') {
+            return new NullType();
+        }
+
+        if ($loweredScalarName === 'void') {
+            return new VoidType();
+        }
+
+        if ($loweredScalarName === 'object') {
+            return new ObjectWithoutClassType();
+        }
+
+        if ($loweredScalarName === 'resource') {
+            return new ResourceType();
+        }
+
+        if (in_array($loweredScalarName, ['callback', 'callable'], true)) {
+            return new CallableType();
+        }
+
+        if ($loweredScalarName === 'mixed') {
+            return new MixedType(true);
+        }
+
+        return null;
     }
 }

--- a/packages/TypeDeclaration/src/Rector/ClassMethod/AddMethodCallBasedParamTypeRector.php
+++ b/packages/TypeDeclaration/src/Rector/ClassMethod/AddMethodCallBasedParamTypeRector.php
@@ -1,0 +1,167 @@
+<?php declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\Rector\ClassMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\Type;
+use Rector\NodeContainer\ParsedNodesByType;
+use Rector\NodeTypeResolver\PHPStan\Type\TypeFactory;
+use Rector\Rector\AbstractRector;
+use Rector\RectorDefinition\CodeSample;
+use Rector\RectorDefinition\RectorDefinition;
+
+/**
+ * @sponsor Thanks https://spaceflow.io/ for sponsoring this rule - visit them on https://github.com/SpaceFlow-app
+ *
+ * @see \Rector\TypeDeclaration\Tests\Rector\ClassMethod\AddMethodCallBasedParamTypeRector\AddMethodCallBasedParamTypeRectorTest
+ */
+final class AddMethodCallBasedParamTypeRector extends AbstractRector
+{
+    /**
+     * @var ParsedNodesByType
+     */
+    private $parsedNodesByType;
+
+    /**
+     * @var TypeFactory
+     */
+    private $typeFactory;
+
+    public function __construct(ParsedNodesByType $parsedNodesByType, TypeFactory $typeFactory)
+    {
+        $this->parsedNodesByType = $parsedNodesByType;
+        $this->typeFactory = $typeFactory;
+    }
+
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Change param type of passed getId() to UuidInterface type declaration', [
+            new CodeSample(
+                <<<'PHP'
+class SomeClass
+{
+    public function getById($id)
+    {
+    }
+}
+
+class CallerClass
+{
+    public function run()
+    {
+        $building = new Building();
+        $someClass = new SomeClass();
+        $someClass->getById($building->getId());
+    }
+}
+PHP
+                ,
+                <<<'PHP'
+class SomeClass
+{
+    public function getById(\Ramsey\Uuid\UuidInterface $id)
+    {
+    }
+}
+
+class CallerClass
+{
+    public function run()
+    {
+        $building = new Building();
+        $someClass = new SomeClass();
+        $someClass->getById($building->getId());
+    }
+}
+PHP
+            ),
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class];
+    }
+
+    /**
+     * @param ClassMethod $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $classMethodCalls = $this->parsedNodesByType->findClassMethodCalls($node);
+
+        $classParameterTypes = $this->getCallTypesByPosition($classMethodCalls);
+
+        foreach ($classParameterTypes as $position => $argumentStaticType) {
+            if ($this->skipArgumentStaticType($node, $argumentStaticType, $position)) {
+                continue;
+            }
+
+            $phpParserTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($argumentStaticType);
+
+            // update parameter
+            $node->params[$position]->type = $phpParserTypeNode;
+        }
+
+        return $node;
+    }
+
+    private function skipArgumentStaticType(Node $node, Type $argumentStaticType, int $position): bool
+    {
+        if ($argumentStaticType instanceof MixedType) {
+            return true;
+        }
+
+        if (! isset($node->params[$position])) {
+            return true;
+        }
+
+        $parameter = $node->params[$position];
+        if ($parameter->type === null) {
+            return false;
+        }
+
+        $parameterStaticType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($parameter->type);
+
+        // already completed → skip
+        if ($parameterStaticType->equals($argumentStaticType)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param MethodCall[]|StaticCall[]|Array_[] $classMethodCalls
+     * @return Type[]
+     */
+    private function getCallTypesByPosition(array $classMethodCalls): array
+    {
+        $staticTypesByArgumentPosition = [];
+        foreach ($classMethodCalls as $classMethodCall) {
+            if (! $classMethodCall instanceof StaticCall && ! $classMethodCall instanceof MethodCall) {
+                continue;
+            }
+
+            foreach ($classMethodCall->args as $position => $arg) {
+                $staticTypesByArgumentPosition[$position][] = $this->getStaticType($arg->value);
+            }
+        }
+
+        // unite to single type
+        $staticTypeByArgumentPosition = [];
+        foreach ($staticTypesByArgumentPosition as $position => $staticTypes) {
+            $staticTypeByArgumentPosition[$position] = $this->typeFactory->createMixedPassedOrUnionType($staticTypes);
+        }
+
+        return $staticTypeByArgumentPosition;
+    }
+}

--- a/packages/TypeDeclaration/tests/Rector/ClassMethod/AddMethodCallBasedParamTypeRector/AddMethodCallBasedParamTypeRectorTest.php
+++ b/packages/TypeDeclaration/tests/Rector/ClassMethod/AddMethodCallBasedParamTypeRector/AddMethodCallBasedParamTypeRectorTest.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\Tests\Rector\ClassMethod\AddMethodCallBasedParamTypeRector;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedParamTypeRector;
+
+final class AddMethodCallBasedParamTypeRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideDataForTest()
+     */
+    public function test(string $file): void
+    {
+        $this->doTestFile($file);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function provideDataForTest(): iterable
+    {
+        yield [__DIR__ . '/Fixture/second_position.php.inc'];
+        yield [__DIR__ . '/Fixture/static_call.php.inc'];
+        yield [__DIR__ . '/Fixture/assigned_variable.php.inc'];
+        yield [__DIR__ . '/Fixture/instant_class_call.php.inc'];
+        yield [__DIR__ . '/Fixture/unioned_double_calls.php.inc'];
+        yield [__DIR__ . '/Fixture/override.php.inc'];
+        yield [__DIR__ . '/Fixture/skip_already_completed.php.inc'];
+        yield [__DIR__ . '/Fixture/skip_mixed.php.inc'];
+    }
+
+    protected function getRectorClass(): string
+    {
+        return AddMethodCallBasedParamTypeRector::class;
+    }
+}

--- a/packages/TypeDeclaration/tests/Rector/ClassMethod/AddMethodCallBasedParamTypeRector/Fixture/assigned_variable.php.inc
+++ b/packages/TypeDeclaration/tests/Rector/ClassMethod/AddMethodCallBasedParamTypeRector/Fixture/assigned_variable.php.inc
@@ -1,0 +1,53 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\ClassMethod\AddMethodCallBasedParamTypeRector\Fixture;
+
+use Rector\TypeDeclaration\Tests\Rector\ClassMethod\AddMethodCallBasedParamTypeRector\Source\Apple;
+
+class AssignedVariable
+{
+    public function getById($id)
+    {
+    }
+}
+
+class CallerClassAssignedVariable
+{
+    public function run()
+    {
+        $building = new Apple();
+        $someClass = new AssignedVariable();
+
+        $assignedVariable = $building->getId();
+        $someClass->getById($assignedVariable);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\ClassMethod\AddMethodCallBasedParamTypeRector\Fixture;
+
+use Rector\TypeDeclaration\Tests\Rector\ClassMethod\AddMethodCallBasedParamTypeRector\Source\Apple;
+
+class AssignedVariable
+{
+    public function getById(\Ramsey\Uuid\UuidInterface $id)
+    {
+    }
+}
+
+class CallerClassAssignedVariable
+{
+    public function run()
+    {
+        $building = new Apple();
+        $someClass = new AssignedVariable();
+
+        $assignedVariable = $building->getId();
+        $someClass->getById($assignedVariable);
+    }
+}
+
+?>

--- a/packages/TypeDeclaration/tests/Rector/ClassMethod/AddMethodCallBasedParamTypeRector/Fixture/instant_class_call.php.inc
+++ b/packages/TypeDeclaration/tests/Rector/ClassMethod/AddMethodCallBasedParamTypeRector/Fixture/instant_class_call.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\ClassMethod\AddMethodCallBasedParamTypeRector\Fixture;
+
+class InstantClassCall
+{
+    public function takeString($name)
+    {
+    }
+}
+
+class CallerClassInstantClassCall
+{
+    public function run(string $name)
+    {
+        (new InstantClassCall())->takeString($name);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\ClassMethod\AddMethodCallBasedParamTypeRector\Fixture;
+
+class InstantClassCall
+{
+    public function takeString(string $name)
+    {
+    }
+}
+
+class CallerClassInstantClassCall
+{
+    public function run(string $name)
+    {
+        (new InstantClassCall())->takeString($name);
+    }
+}
+
+?>

--- a/packages/TypeDeclaration/tests/Rector/ClassMethod/AddMethodCallBasedParamTypeRector/Fixture/override.php.inc
+++ b/packages/TypeDeclaration/tests/Rector/ClassMethod/AddMethodCallBasedParamTypeRector/Fixture/override.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\ClassMethod\AddMethodCallBasedParamTypeRector\Fixture;
+
+class Override
+{
+    public function process(bool $name, string $id)
+    {
+    }
+}
+
+class CallerClassForOverride
+{
+    public function run()
+    {
+        $someClass = new Override();
+        $someClass->process('hi', false);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\ClassMethod\AddMethodCallBasedParamTypeRector\Fixture;
+
+class Override
+{
+    public function process(string $name, bool $id)
+    {
+    }
+}
+
+class CallerClassForOverride
+{
+    public function run()
+    {
+        $someClass = new Override();
+        $someClass->process('hi', false);
+    }
+}
+
+?>

--- a/packages/TypeDeclaration/tests/Rector/ClassMethod/AddMethodCallBasedParamTypeRector/Fixture/second_position.php.inc
+++ b/packages/TypeDeclaration/tests/Rector/ClassMethod/AddMethodCallBasedParamTypeRector/Fixture/second_position.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\ClassMethod\AddMethodCallBasedParamTypeRector\Fixture;
+
+use Rector\TypeDeclaration\Tests\Rector\ClassMethod\AddMethodCallBasedParamTypeRector\Source\Apple;
+
+class SecondPosition
+{
+    public function process($name, $id)
+    {
+    }
+}
+
+class CallerClassForSecondPosition
+{
+    public function run()
+    {
+        $building = new Apple();
+        $someClass = new SecondPosition();
+        $someClass->process('hi', $building->getId());
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\ClassMethod\AddMethodCallBasedParamTypeRector\Fixture;
+
+use Rector\TypeDeclaration\Tests\Rector\ClassMethod\AddMethodCallBasedParamTypeRector\Source\Apple;
+
+class SecondPosition
+{
+    public function process(string $name, \Ramsey\Uuid\UuidInterface $id)
+    {
+    }
+}
+
+class CallerClassForSecondPosition
+{
+    public function run()
+    {
+        $building = new Apple();
+        $someClass = new SecondPosition();
+        $someClass->process('hi', $building->getId());
+    }
+}
+
+?>

--- a/packages/TypeDeclaration/tests/Rector/ClassMethod/AddMethodCallBasedParamTypeRector/Fixture/skip_already_completed.php.inc
+++ b/packages/TypeDeclaration/tests/Rector/ClassMethod/AddMethodCallBasedParamTypeRector/Fixture/skip_already_completed.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\ClassMethod\AddMethodCallBasedParamTypeRector\Fixture;
+
+use Ramsey\Uuid\UuidInterface;
+use Rector\TypeDeclaration\Tests\Rector\ClassMethod\AddMethodCallBasedParamTypeRector\Source\Apple;
+
+class SkipAlreadyCompleted
+{
+    public function process(string $name, string $random, UuidInterface $id)
+    {
+    }
+}
+
+class CallerClassForSkipAlreadyCompleted
+{
+    public function run()
+    {
+        $building = new Apple();
+        $someClass = new SkipAlreadyCompleted();
+        $someClass->process('hi', 'args', $building->getId());
+    }
+}

--- a/packages/TypeDeclaration/tests/Rector/ClassMethod/AddMethodCallBasedParamTypeRector/Fixture/skip_mixed.php.inc
+++ b/packages/TypeDeclaration/tests/Rector/ClassMethod/AddMethodCallBasedParamTypeRector/Fixture/skip_mixed.php.inc
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Doctrine\Tests\Rector\ClassMethod\AddMethodCallBasedParamTypeRector\Fixture;
+
+use Rector\TypeDeclaration\Tests\Rector\ClassMethod\AddMethodCallBasedParamTypeRector\Source\Apple;
+use stdClass;
+
+class SkipMixed
+{
+    public function process($name, $random, $id)
+    {
+    }
+}
+
+class CallerClassForSkipMixed
+{
+    public function run()
+    {
+        $building = new Apple();
+        $someClass = new SkipMixed();
+        $someClass->process('hi', 'args', $building->getId());
+        $someClass->process(5, new stdClass(), false);
+    }
+}

--- a/packages/TypeDeclaration/tests/Rector/ClassMethod/AddMethodCallBasedParamTypeRector/Fixture/static_call.php.inc
+++ b/packages/TypeDeclaration/tests/Rector/ClassMethod/AddMethodCallBasedParamTypeRector/Fixture/static_call.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\ClassMethod\AddMethodCallBasedParamTypeRector\Fixture;
+
+use Rector\TypeDeclaration\Tests\Rector\ClassMethod\AddMethodCallBasedParamTypeRector\Source\Apple;
+
+class StaticCall
+{
+    public static function process($name, $id)
+    {
+    }
+}
+
+class CallerClassForStaticCall
+{
+    public function run()
+    {
+        $building = new Apple();
+
+        StaticCall::process('hi', $building->getId());
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\ClassMethod\AddMethodCallBasedParamTypeRector\Fixture;
+
+use Rector\TypeDeclaration\Tests\Rector\ClassMethod\AddMethodCallBasedParamTypeRector\Source\Apple;
+
+class StaticCall
+{
+    public static function process(string $name, \Ramsey\Uuid\UuidInterface $id)
+    {
+    }
+}
+
+class CallerClassForStaticCall
+{
+    public function run()
+    {
+        $building = new Apple();
+
+        StaticCall::process('hi', $building->getId());
+    }
+}
+
+?>

--- a/packages/TypeDeclaration/tests/Rector/ClassMethod/AddMethodCallBasedParamTypeRector/Fixture/unioned_double_calls.php.inc
+++ b/packages/TypeDeclaration/tests/Rector/ClassMethod/AddMethodCallBasedParamTypeRector/Fixture/unioned_double_calls.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\ClassMethod\AddMethodCallBasedParamTypeRector\Fixture;
+
+class UnionedDoubleCalls
+{
+    public function getById($id)
+    {
+    }
+}
+
+class CallerClassUnionedDoubleCalls
+{
+    public function run()
+    {
+        $someClass = new UnionedDoubleCalls();
+        $someClass->getById(5);
+        $someClass->getById(null);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\ClassMethod\AddMethodCallBasedParamTypeRector\Fixture;
+
+class UnionedDoubleCalls
+{
+    public function getById(?int $id)
+    {
+    }
+}
+
+class CallerClassUnionedDoubleCalls
+{
+    public function run()
+    {
+        $someClass = new UnionedDoubleCalls();
+        $someClass->getById(5);
+        $someClass->getById(null);
+    }
+}
+
+?>

--- a/packages/TypeDeclaration/tests/Rector/ClassMethod/AddMethodCallBasedParamTypeRector/Source/Apple.php
+++ b/packages/TypeDeclaration/tests/Rector/ClassMethod/AddMethodCallBasedParamTypeRector/Source/Apple.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\Tests\Rector\ClassMethod\AddMethodCallBasedParamTypeRector\Source;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class Apple
+{
+    private $id;
+
+    public function getId(): \Ramsey\Uuid\UuidInterface
+    {
+        return $this->id;
+    }
+}


### PR DESCRIPTION
Closes #1887

```diff
 class CallerClassForSecondPosition
 {
     public function run()
     {
         $building = new Apple();
         $someClass = new SecondPosition();
         $someClass->process('hi', $building->getId());
     }
 }

 class SecondPosition
 {
-    public function process($name, $id)
+    public function process(string $name, \Ramsey\Uuid\UuidInterface $id)
     {
     }
 }

```