### PR TITLE
Add conditional method renaming rector

### DIFF
--- a/packages/CakePHP/src/Rector/MethodCall/RenameMethodCallBasedOnParameterRector.php
+++ b/packages/CakePHP/src/Rector/MethodCall/RenameMethodCallBasedOnParameterRector.php
@@ -1,0 +1,149 @@
+<?php declare(strict_types=1);
+
+namespace Rector\CakePHP\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\String_;
+use Rector\Rector\AbstractRector;
+use Rector\RectorDefinition\CodeSample;
+use Rector\RectorDefinition\RectorDefinition;
+
+/**
+ * @see https://book.cakephp.org/4.0/en/appendices/4-0-migration-guide.html
+ * @see https://github.com/cakephp/cakephp/commit/77017145961bb697b4256040b947029259f66a9b
+ * @see \Rector\CakePHP\Tests\Rector\MethodCall\RenameMethodCallBasedOnParameterRector\RenameMethodCallBasedOnParameterRectorTest
+ */
+final class RenameMethodCallBasedOnParameterRector extends AbstractRector
+{
+    /**
+     * @var mixed[]
+     */
+    private $methodNamesByTypes = [];
+
+    /**
+     * @param mixed[] $methodNamesByTypes
+     */
+    public function __construct(array $methodNamesByTypes = [])
+    {
+        $this->methodNamesByTypes = $methodNamesByTypes;
+    }
+
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition(
+            'Changes method calls based on matching the first parameter value.',
+            [
+                new CodeSample(
+                    <<<'PHP'
+$object = new ServerRequest();
+
+$config = $object->getParam('paging');
+$object = $object->withParam('paging', ['a value']);
+PHP
+                    ,
+                    <<<'PHP'
+$object = new ServerRequest();
+
+$config = $object->getAttribute('paging');
+$object = $object->withParam('paging', ['a value']);
+PHP
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    /**
+     * @param MethodCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $config = $this->matchTypeAndMethodName($node);
+        if ($config === null) {
+            return null;
+        }
+
+        $node->name = new Identifier($config['replaceWith']);
+
+        return $node;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function matchTypeAndMethodName(MethodCall $methodCall): ?array
+    {
+        foreach ($this->methodNamesByTypes as $type => $methodMapping) {
+            /** @var string[] $methodNames */
+            $methodNames = array_keys($methodMapping);
+            if (! $this->isObjectType($methodCall, $type)) {
+                continue;
+            }
+
+            if (! $this->isNames($methodCall, $methodNames)) {
+                continue;
+            }
+
+            $currentMethodName = $this->getName($methodCall);
+            if ($currentMethodName === null) {
+                continue;
+            }
+            $config = $methodMapping[$currentMethodName];
+            if (empty($config['matchParameter'])) {
+                continue;
+            }
+            if (count($methodCall->args) < 1) {
+                continue;
+            }
+            $arg = $methodCall->args[0];
+            if (! ($arg->value instanceof String_)) {
+                continue;
+            }
+            if ($arg->value->value !== $config['matchParameter']) {
+                continue;
+            }
+
+            return $config;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param mixed[] $config
+     */
+    private function resolveNewMethodNameByCondition(MethodCall $methodCall, array $config): string
+    {
+        if (count($methodCall->args) >= $config['minimal_argument_count']) {
+            return $config['set'];
+        }
+
+        if (! isset($methodCall->args[0])) {
+            return $config['get'];
+        }
+
+        // first argument type that is considered setter
+        if (! isset($config['first_argument_type_to_set'])) {
+            return $config['get'];
+        }
+
+        $argumentType = $config['first_argument_type_to_set'];
+        $argumentValue = $methodCall->args[0]->value;
+
+        if ($argumentType === 'array' && $argumentValue instanceof Array_) {
+            return $config['set'];
+        }
+
+        return $config['get'];
+    }
+}

--- a/packages/CakePHP/tests/Rector/MethodCall/RenameMethodCallBasedOnParameterRector/Fixture/fixture.php.inc
+++ b/packages/CakePHP/tests/Rector/MethodCall/RenameMethodCallBasedOnParameterRector/Fixture/fixture.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\RenameMethodCallBasedOnParameterRector;
+
+function renameMethodCallBasedOnParameter()
+{
+    $object = new Source\SomeModelType;
+
+    $config = $object->getParam('paging');
+    $object->withParam('paging', 'value');
+
+    $config = $object->getParam($value);
+
+    $config = $object->getParam('other');
+    $object->withParam('other', 'value');
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\RenameMethodCallBasedOnParameterRector;
+
+function renameMethodCallBasedOnParameter()
+{
+    $object = new Source\SomeModelType;
+
+    $config = $object->getAttribute('paging');
+    $object->withAttribute('paging', 'value');
+
+    $config = $object->getParam($value);
+
+    $config = $object->getParam('other');
+    $object->withParam('other', 'value');
+}
+
+?>

--- a/packages/CakePHP/tests/Rector/MethodCall/RenameMethodCallBasedOnParameterRector/Fixture/fixture.php.inc
+++ b/packages/CakePHP/tests/Rector/MethodCall/RenameMethodCallBasedOnParameterRector/Fixture/fixture.php.inc
@@ -8,11 +8,6 @@ function renameMethodCallBasedOnParameter()
 
     $config = $object->getParam('paging');
     $object->withParam('paging', 'value');
-
-    $config = $object->getParam($value);
-
-    $config = $object->getParam('other');
-    $object->withParam('other', 'value');
 }
 
 ?>
@@ -27,11 +22,6 @@ function renameMethodCallBasedOnParameter()
 
     $config = $object->getAttribute('paging');
     $object->withAttribute('paging', 'value');
-
-    $config = $object->getParam($value);
-
-    $config = $object->getParam('other');
-    $object->withParam('other', 'value');
 }
 
 ?>

--- a/packages/CakePHP/tests/Rector/MethodCall/RenameMethodCallBasedOnParameterRector/Fixture/fixture2.php.inc
+++ b/packages/CakePHP/tests/Rector/MethodCall/RenameMethodCallBasedOnParameterRector/Fixture/fixture2.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\RenameMethodCallBasedOnParameterRector;
+
+function renameMethodCallBasedOnParameterNoop()
+{
+    $object = new Source\SomeModelType;
+
+    $config = $object->getParam($value);
+    $config = $object->getParam('other');
+    $object->withParam('other', 'value');
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\RenameMethodCallBasedOnParameterRector;
+
+function renameMethodCallBasedOnParameterNoop()
+{
+    $object = new Source\SomeModelType;
+
+    $config = $object->getParam($value);
+    $config = $object->getParam('other');
+    $object->withParam('other', 'value');
+}
+
+?>

--- a/packages/CakePHP/tests/Rector/MethodCall/RenameMethodCallBasedOnParameterRector/RenameMethodCallBasedOnParameterRectorTest.php
+++ b/packages/CakePHP/tests/Rector/MethodCall/RenameMethodCallBasedOnParameterRector/RenameMethodCallBasedOnParameterRectorTest.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\RenameMethodCallBasedOnParameterRector;
+
+use Rector\CakePHP\Rector\MethodCall\RenameMethodCallBasedOnParameterRector;
+use Rector\CakePHP\Tests\Rector\MethodCall\RenameMethodCallBasedOnParameterRector\Source\SomeModelType;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RenameMethodCallBasedOnParameterRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideDataForTest()
+     */
+    public function test(string $file): void
+    {
+        $this->doTestFile($file);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function provideDataForTest(): iterable
+    {
+        yield [__DIR__ . '/Fixture/fixture.php.inc'];
+    }
+
+    /**
+     * @return mixed[]
+     */
+    protected function getRectorsWithConfiguration(): array
+    {
+        return [
+            RenameMethodCallBasedOnParameterRector::class => [
+                '$methodNamesByTypes' => [
+                    SomeModelType::class => [
+                        'getParam' => [
+                            'matchParameter' => 'paging',
+                            'replaceWith' => 'getAttribute',
+                        ],
+                        'withParam' => [
+                            'matchParameter' =>  'paging',
+                            'replaceWith' => 'withAttribute',
+                        ]
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/packages/CakePHP/tests/Rector/MethodCall/RenameMethodCallBasedOnParameterRector/RenameMethodCallBasedOnParameterRectorTest.php
+++ b/packages/CakePHP/tests/Rector/MethodCall/RenameMethodCallBasedOnParameterRector/RenameMethodCallBasedOnParameterRectorTest.php
@@ -22,6 +22,7 @@ final class RenameMethodCallBasedOnParameterRectorTest extends AbstractRectorTes
     public function provideDataForTest(): iterable
     {
         yield [__DIR__ . '/Fixture/fixture.php.inc'];
+        yield [__DIR__ . '/Fixture/fixture2.php.inc'];
     }
 
     /**
@@ -33,14 +34,15 @@ final class RenameMethodCallBasedOnParameterRectorTest extends AbstractRectorTes
             RenameMethodCallBasedOnParameterRector::class => [
                 '$methodNamesByTypes' => [
                     SomeModelType::class => [
+                        'invalidNoOptions' => [],
                         'getParam' => [
-                            'matchParameter' => 'paging',
-                            'replaceWith' => 'getAttribute',
+                            'match_parameter' => 'paging',
+                            'replace_with' => 'getAttribute',
                         ],
                         'withParam' => [
-                            'matchParameter' =>  'paging',
-                            'replaceWith' => 'withAttribute',
-                        ]
+                            'match_parameter' =>  'paging',
+                            'replace_with' => 'withAttribute',
+                        ],
                     ],
                 ],
             ],

--- a/packages/CakePHP/tests/Rector/MethodCall/RenameMethodCallBasedOnParameterRector/Source/SomeModelType.php
+++ b/packages/CakePHP/tests/Rector/MethodCall/RenameMethodCallBasedOnParameterRector/Source/SomeModelType.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\RenameMethodCallBasedOnParameterRector\Source;
+
+final class SomeModelType
+{
+
+}


### PR DESCRIPTION
We have a few renames in CakePHP that are parameter dependent. This rector lets a method be renamed based on the first parameter value. I've only supported string values as that is the current requirements.