### PR TITLE
[PHP 7.1] Skip extra argument removal for parent static call

### DIFF
--- a/packages/Php71/tests/Rector/FuncCall/RemoveExtraParametersRector/Fixture/skip_values_passed_from_parent.php.inc
+++ b/packages/Php71/tests/Rector/FuncCall/RemoveExtraParametersRector/Fixture/skip_values_passed_from_parent.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Php71\Tests\Rector\FuncCall\RemoveExtraParametersRector\Fixture;
+
+final class SkipValuePassedFromParent extends HttpException
+{
+    private $apiError;
+
+    public function __construct(ApiError $apiError, ?\Throwable $previous = null, array $headers = [], $code = 0)
+    {
+        $this->apiError = $apiError;
+        $statusCode = $apiError->getStatusCode();
+        $message = $apiError->getMessage();
+
+        parent::__construct($statusCode, $message, $previous, $headers, $code);
+    }
+}
+
+class HttpException extends \Exception
+{
+    public function __construct(
+        int $statusCode,
+        string $message = null,
+        \Throwable $previous = null,
+        array $headers = [],
+        ?int $code = 0
+    ) {
+    }
+}

--- a/packages/Php71/tests/Rector/FuncCall/RemoveExtraParametersRector/RemoveExtraParametersRectorTest.php
+++ b/packages/Php71/tests/Rector/FuncCall/RemoveExtraParametersRector/RemoveExtraParametersRectorTest.php
@@ -31,6 +31,7 @@ final class RemoveExtraParametersRectorTest extends AbstractRectorTestCase
         yield [__DIR__ . '/Fixture/skip_commented_param_func_get_args.php.inc'];
         yield [__DIR__ . '/Fixture/skip_call_user_func_array.php.inc'];
         yield [__DIR__ . '/Fixture/skip_invoke.php.inc'];
+        yield [__DIR__ . '/Fixture/skip_values_passed_from_parent.php.inc'];
     }
 
     protected function getRectorClass(): string


### PR DESCRIPTION
Close #2058