### PR TITLE
Fixed the third argument in VarDumperTestTrait.

### DIFF
--- a/docs/AllRectorsOverview.md
+++ b/docs/AllRectorsOverview.md
@@ -5721,16 +5721,16 @@ Changes Process string argument to an array
 
 - class: `Rector\Symfony\Rector\VarDumper\VarDumperTestTraitMethodArgsRector`
 
-Adds new `$format` argument in `VarDumperTestTrait->assertDumpEquals()` in Validator in Symfony.
+Adds a new `$filter` argument in `VarDumperTestTrait->assertDumpEquals()` and `VarDumperTestTrait->assertDumpMatchesFormat()` in Validator in Symfony.
 
 ```diff
--$varDumperTestTrait->assertDumpEquals($dump, $data, $mesage = "");
-+$varDumperTestTrait->assertDumpEquals($dump, $data, $context = null, $mesage = "");
+-$varDumperTestTrait->assertDumpEquals($dump, $data, $message = "");
++$varDumperTestTrait->assertDumpEquals($dump, $data, $filter = 0, $message = "");
 ```
 
 ```diff
--$varDumperTestTrait->assertDumpMatchesFormat($dump, $format, $mesage = "");
-+$varDumperTestTrait->assertDumpMatchesFormat($dump, $format, $context = null,  $mesage = "");
+-$varDumperTestTrait->assertDumpMatchesFormat($dump, $data, $message = "");
++$varDumperTestTrait->assertDumpMatchesFormat($dump, $data, $filter = 0, $message = "");
 ```
 
 <br>

--- a/packages/Symfony/src/Rector/VarDumper/VarDumperTestTraitMethodArgsRector.php
+++ b/packages/Symfony/src/Rector/VarDumper/VarDumperTestTraitMethodArgsRector.php
@@ -28,15 +28,15 @@ final class VarDumperTestTraitMethodArgsRector extends AbstractRector
     public function getDefinition(): RectorDefinition
     {
         return new RectorDefinition(
-            'Adds new `$format` argument in `VarDumperTestTrait->assertDumpEquals()` in Validator in Symfony.',
+            'Adds a new `$filter` argument in `VarDumperTestTrait->assertDumpEquals()` and `VarDumperTestTrait->assertDumpMatchesFormat()` in Validator in Symfony.',
             [
                 new CodeSample(
-                    '$varDumperTestTrait->assertDumpEquals($dump, $data, $mesage = "");',
-                    '$varDumperTestTrait->assertDumpEquals($dump, $data, $context = null, $mesage = "");'
+                    '$varDumperTestTrait->assertDumpEquals($dump, $data, $message = "");',
+                    '$varDumperTestTrait->assertDumpEquals($dump, $data, $filter = 0, $message = "");'
                 ),
                 new CodeSample(
-                    '$varDumperTestTrait->assertDumpMatchesFormat($dump, $format, $mesage = "");',
-                    '$varDumperTestTrait->assertDumpMatchesFormat($dump, $format, $context = null,  $mesage = "");'
+                    '$varDumperTestTrait->assertDumpMatchesFormat($dump, $data, $message = "");',
+                    '$varDumperTestTrait->assertDumpMatchesFormat($dump, $data, $filter = 0, $message = "");'
                 ),
             ]
         );
@@ -69,7 +69,7 @@ final class VarDumperTestTraitMethodArgsRector extends AbstractRector
 
         if ($node->args[2]->value instanceof String_) {
             $node->args[3] = $node->args[2];
-            $node->args[2] = $this->createArg($this->createNull());
+            $node->args[2] = $this->createArg(0);
 
             return $node;
         }

--- a/packages/Symfony/tests/Rector/VarDumper/VarDumperTestTraitMethodArgsRector/Fixture/fixture.php.inc
+++ b/packages/Symfony/tests/Rector/VarDumper/VarDumperTestTraitMethodArgsRector/Fixture/fixture.php.inc
@@ -6,7 +6,7 @@ function varDumperTrait()
 {
     $trait = new ClassWithVarDumperTrait();
     $trait->assertDumpEquals($dump, $data, 'Some message');
-    $trait->assertDumpMatchesFormat($dump, $format, 'Some message');
+    $trait->assertDumpMatchesFormat($dump, $data, 'Some message');
 }
 
 ?>
@@ -18,8 +18,8 @@ use Rector\Symfony\Tests\Rector\VarDumper\VarDumperTestTraitMethodArgsRector\Sou
 function varDumperTrait()
 {
     $trait = new ClassWithVarDumperTrait();
-    $trait->assertDumpEquals($dump, $data, null, 'Some message');
-    $trait->assertDumpMatchesFormat($dump, $format, null, 'Some message');
+    $trait->assertDumpEquals($dump, $data, 0, 'Some message');
+    $trait->assertDumpMatchesFormat($dump, $data, 0, 'Some message');
 }
 
 ?>


### PR DESCRIPTION
In VarDumperTestTrait's asserts the third argument is called `$filter` and by default it should be equal to 0.
Right now it's called `$context` or `$format` and is set to null. Also `$data` argument is called `$format` sometimes.

`public function assertDumpEquals($expected, $data, $filter = 0, $message = '')`
`public function assertDumpMatchesFormat($expected, $data, $filter = 0, $message = '')` - 
https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/VarDumper/Test/VarDumperTestTrait.php