### PR TITLE
Add an option to skip importing root namespace classes (like \DateTime)

### DIFF
--- a/packages/CodingStyle/src/Rector/Namespace_/ImportFullyQualifiedNamesRector.php
+++ b/packages/CodingStyle/src/Rector/Namespace_/ImportFullyQualifiedNamesRector.php
@@ -2,7 +2,6 @@
 
 namespace Rector\CodingStyle\Rector\Namespace_;
 
-use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Name;
 use Rector\CodingStyle\Node\NameImporter;
@@ -83,9 +82,9 @@ PHP
     public function refactor(Node $node): ?Node
     {
         // Importing root namespace classes (like \DateTime) is optional
-        if (! $this->shouldImportRootNamespaceClasses) {
+        if (! $this->shouldImportRootNamespaceClasses && $node instanceof Name) {
             $name = $this->getName($node);
-            if (Strings::startsWith($name, '\\') && substr_count($name, '\\') === 1) {
+            if ($name !== null && substr_count($name, '\\') === 0) {
                 return null;
             }
         }

--- a/packages/CodingStyle/src/Rector/Namespace_/ImportFullyQualifiedNamesRector.php
+++ b/packages/CodingStyle/src/Rector/Namespace_/ImportFullyQualifiedNamesRector.php
@@ -20,14 +20,23 @@ final class ImportFullyQualifiedNamesRector extends AbstractRector
     private $shouldImportDocBlocks = true;
 
     /**
+     * @var bool
+     */
+    private $shouldImportRootNamespaceClasses = true;
+
+    /**
      * @var NameImporter
      */
     private $nameImporter;
 
-    public function __construct(NameImporter $nameImporter, bool $shouldImportDocBlocks = true)
-    {
+    public function __construct(
+        NameImporter $nameImporter,
+        bool $shouldImportDocBlocks = true,
+        bool $shouldImportRootNamespaceClasses = true
+    ) {
         $this->nameImporter = $nameImporter;
         $this->shouldImportDocBlocks = $shouldImportDocBlocks;
+        $this->shouldImportRootNamespaceClasses = $shouldImportRootNamespaceClasses;
     }
 
     public function getDefinition(): RectorDefinition
@@ -72,6 +81,11 @@ PHP
      */
     public function refactor(Node $node): ?Node
     {
+        // Importing root namespace classes (like \DateTime) is optional
+        if (!$this->shouldImportRootNamespaceClasses && $node instanceof Name && !$node->isQualified()) {
+            return null;
+        }
+
         $this->useAddingCommander->analyseFileInfoUseStatements($node);
 
         if ($node instanceof Name) {

--- a/packages/CodingStyle/src/Rector/Namespace_/ImportFullyQualifiedNamesRector.php
+++ b/packages/CodingStyle/src/Rector/Namespace_/ImportFullyQualifiedNamesRector.php
@@ -81,23 +81,23 @@ PHP
      */
     public function refactor(Node $node): ?Node
     {
-        // Importing root namespace classes (like \DateTime) is optional
-        if (! $this->shouldImportRootNamespaceClasses && $node instanceof Name) {
-            $name = $this->getName($node);
-            if ($name !== null && substr_count($name, '\\') === 0) {
-                return null;
-            }
-        }
-
         $this->useAddingCommander->analyseFileInfoUseStatements($node);
 
         if ($node instanceof Name) {
+            // Importing root namespace classes (like \DateTime) is optional
+            if (! $this->shouldImportRootNamespaceClasses) {
+                $name = $this->getName($node);
+                if ($name !== null && substr_count($name, '\\') === 0) {
+                    return null;
+                }
+            }
+
             return $this->nameImporter->importName($node);
         }
 
         // process doc blocks
         if ($this->shouldImportDocBlocks) {
-            $this->docBlockManipulator->importNames($node);
+            $this->docBlockManipulator->importNames($node, $this->shouldImportRootNamespaceClasses);
             return $node;
         }
 

--- a/packages/CodingStyle/src/Rector/Namespace_/ImportFullyQualifiedNamesRector.php
+++ b/packages/CodingStyle/src/Rector/Namespace_/ImportFullyQualifiedNamesRector.php
@@ -2,6 +2,7 @@
 
 namespace Rector\CodingStyle\Rector\Namespace_;
 
+use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Name;
 use Rector\CodingStyle\Node\NameImporter;
@@ -82,8 +83,11 @@ PHP
     public function refactor(Node $node): ?Node
     {
         // Importing root namespace classes (like \DateTime) is optional
-        if (!$this->shouldImportRootNamespaceClasses && $node instanceof Name && !$node->isQualified()) {
-            return null;
+        if (! $this->shouldImportRootNamespaceClasses) {
+            $name = $this->getName($node);
+            if (Strings::startsWith($name, '\\') && substr_count($name, '\\') === 1) {
+                return null;
+            }
         }
 
         $this->useAddingCommander->analyseFileInfoUseStatements($node);

--- a/packages/CodingStyle/tests/Rector/Namespace_/ImportFullyQualifiedNamesRector/Fixture/import_root_namespace_classes_disabled.php.inc
+++ b/packages/CodingStyle/tests/Rector/Namespace_/ImportFullyQualifiedNamesRector/Fixture/import_root_namespace_classes_disabled.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\CodingStyle\Tests\Rector\Namespace_\ImportFullyQualifiedNamesRector\Fixture;
+
+final class ImportRootNamespaceClassesDisabled
+{
+    /**
+     * @var \DateTime
+     */
+    private $date;
+
+    public function __construct()
+    {
+        /** @var \DateTime $currentDate */
+        $currentDate = new \DateTime();
+
+        $this->date = $currentDate;
+    }
+
+    public function setDate(?\DateTime $date): void
+    {
+        $this->date = $date;
+    }
+
+    public function getDate(): ?\DateTime
+    {
+        return $this->date;
+    }
+}

--- a/packages/CodingStyle/tests/Rector/Namespace_/ImportFullyQualifiedNamesRector/Fixture/import_root_namespace_classes_disabled.php.inc
+++ b/packages/CodingStyle/tests/Rector/Namespace_/ImportFullyQualifiedNamesRector/Fixture/import_root_namespace_classes_disabled.php.inc
@@ -9,12 +9,21 @@ final class ImportRootNamespaceClassesDisabled
      */
     private $date;
 
+    /**
+     * @var \Rector\CodingStyle\Tests\Rector\Namespace_\ImportFullyQualifiedNamesRector\Source\Response
+     */
+    private $response;
+
     public function __construct()
     {
         /** @var \DateTime $currentDate */
         $currentDate = new \DateTime();
 
+        /** @var \Rector\CodingStyle\Tests\Rector\Namespace_\ImportFullyQualifiedNamesRector\Source\Response $response */
+        $response = new \Rector\CodingStyle\Tests\Rector\Namespace_\ImportFullyQualifiedNamesRector\Source\Response();
+
         $this->date = $currentDate;
+        $this->response = $response;
     }
 
     public function setDate(?\DateTime $date): void
@@ -26,4 +35,66 @@ final class ImportRootNamespaceClassesDisabled
     {
         return $this->date;
     }
+
+    public function setResponse(?\Rector\CodingStyle\Tests\Rector\Namespace_\ImportFullyQualifiedNamesRector\Source\Response $response): void
+    {
+        $this->response = $response;
+    }
+
+    public function getResponse(): ?\Rector\CodingStyle\Tests\Rector\Namespace_\ImportFullyQualifiedNamesRector\Source\Response
+    {
+        return $this->response;
+    }
 }
+?>
+-----
+<?php
+
+namespace Rector\CodingStyle\Tests\Rector\Namespace_\ImportFullyQualifiedNamesRector\Fixture;
+
+use Rector\CodingStyle\Tests\Rector\Namespace_\ImportFullyQualifiedNamesRector\Source\Response;
+final class ImportRootNamespaceClassesDisabled
+{
+    /**
+     * @var \DateTime
+     */
+    private $date;
+
+    /**
+     * @var Response
+     */
+    private $response;
+
+    public function __construct()
+    {
+        /** @var \DateTime $currentDate */
+        $currentDate = new \DateTime();
+
+        /** @var Response $response */
+        $response = new Response();
+
+        $this->date = $currentDate;
+        $this->response = $response;
+    }
+
+    public function setDate(?\DateTime $date): void
+    {
+        $this->date = $date;
+    }
+
+    public function getDate(): ?\DateTime
+    {
+        return $this->date;
+    }
+
+    public function setResponse(?Response $response): void
+    {
+        $this->response = $response;
+    }
+
+    public function getResponse(): ?Response
+    {
+        return $this->response;
+    }
+}
+?>

--- a/packages/CodingStyle/tests/Rector/Namespace_/ImportFullyQualifiedNamesRector/Fixture/import_root_namespace_classes_enabled.php.inc
+++ b/packages/CodingStyle/tests/Rector/Namespace_/ImportFullyQualifiedNamesRector/Fixture/import_root_namespace_classes_enabled.php.inc
@@ -1,0 +1,62 @@
+<?php
+
+namespace Rector\CodingStyle\Tests\Rector\Namespace_\ImportFullyQualifiedNamesRector\Fixture;
+
+final class ImportRootNamespaceClassesEnabled
+{
+    /**
+     * @var \DateTime
+     */
+    private $date;
+
+    public function __construct()
+    {
+        /** @var \DateTime $currentDate */
+        $currentDate = new \DateTime();
+
+        $this->date = $currentDate;
+    }
+
+    public function setDate(?\DateTime $date): void
+    {
+        $this->date = $date;
+    }
+
+    public function getDate(): ?\DateTime
+    {
+        return $this->date;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\CodingStyle\Tests\Rector\Namespace_\ImportFullyQualifiedNamesRector\Fixture;
+
+use DateTime;
+final class ImportRootNamespaceClassesEnabled
+{
+    /**
+     * @var DateTime
+     */
+    private $date;
+
+    public function __construct()
+    {
+        /** @var DateTime $currentDate */
+        $currentDate = new DateTime();
+
+        $this->date = $currentDate;
+    }
+
+    public function setDate(?DateTime $date): void
+    {
+        $this->date = $date;
+    }
+
+    public function getDate(): ?DateTime
+    {
+        return $this->date;
+    }
+}
+?>

--- a/packages/CodingStyle/tests/Rector/Namespace_/ImportFullyQualifiedNamesRector/ImportFullyQualifiedNamesRectorTest.php
+++ b/packages/CodingStyle/tests/Rector/Namespace_/ImportFullyQualifiedNamesRector/ImportFullyQualifiedNamesRectorTest.php
@@ -58,6 +58,8 @@ final class ImportFullyQualifiedNamesRectorTest extends AbstractRectorTestCase
         yield [__DIR__ . '/Fixture/keep_static_method.php.inc'];
         yield [__DIR__ . '/Fixture/keep_various_request.php.inc'];
         yield [__DIR__ . '/Fixture/instance_of.php.inc'];
+
+        yield [__DIR__ . '/Fixture/import_root_namespace_classes_enabled.php.inc'];
     }
 
     public function provideFunctions(): Iterator

--- a/packages/CodingStyle/tests/Rector/Namespace_/ImportFullyQualifiedNamesRector/ImportRootNamespaceClassesDisabledTest.php
+++ b/packages/CodingStyle/tests/Rector/Namespace_/ImportFullyQualifiedNamesRector/ImportRootNamespaceClassesDisabledTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CodingStyle\Tests\Rector\Namespace_\ImportFullyQualifiedNamesRector;
+
+use Rector\CodingStyle\Rector\Namespace_\ImportFullyQualifiedNamesRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ImportRootNamespaceClassesDisabledTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideDataForTest()
+     */
+    public function test(string $file): void
+    {
+        $this->doTestFile($file);
+    }
+
+    public function provideDataForTest(): iterable
+    {
+        yield [__DIR__ . '/Fixture/import_root_namespace_classes_disabled.php.inc'];
+    }
+
+    protected function getRectorsWithConfiguration(): array
+    {
+        return [
+            ImportFullyQualifiedNamesRector::class => [
+                '$shouldImportRootNamespaceClasses' => false,
+            ],
+        ];
+    }
+}

--- a/packages/NodeTypeResolver/src/PhpDoc/NodeAnalyzer/DocBlockManipulator.php
+++ b/packages/NodeTypeResolver/src/PhpDoc/NodeAnalyzer/DocBlockManipulator.php
@@ -345,14 +345,18 @@ final class DocBlockManipulator
         }
     }
 
-    public function importNames(Node $node): void
+    public function importNames(Node $node, bool $shouldImportRootNamespaceClasses = true): void
     {
         if ($node->getDocComment() === null) {
             return;
         }
 
         $phpDocInfo = $this->createPhpDocInfoFromNode($node);
-        $hasNodeChanged = $this->docBlockNameImporter->importNames($phpDocInfo, $node);
+        $hasNodeChanged = $this->docBlockNameImporter->importNames(
+            $phpDocInfo,
+            $node,
+            $shouldImportRootNamespaceClasses
+        );
 
         if ($hasNodeChanged) {
             $this->updateNodeWithPhpDocInfo($node, $phpDocInfo);

--- a/packages/NodeTypeResolver/src/PhpDoc/NodeAnalyzer/DocBlockNameImporter.php
+++ b/packages/NodeTypeResolver/src/PhpDoc/NodeAnalyzer/DocBlockNameImporter.php
@@ -97,6 +97,7 @@ final class DocBlockNameImporter
                 return $docNode;
             }
 
+            // Importing root namespace classes (like \DateTime) is optional
             if (! $shouldImportRootNamespaceClasses && substr_count($staticType->getClassName(), '\\') === 0) {
                 return $docNode;
             }

--- a/packages/NodeTypeResolver/src/PhpDoc/NodeAnalyzer/DocBlockNameImporter.php
+++ b/packages/NodeTypeResolver/src/PhpDoc/NodeAnalyzer/DocBlockNameImporter.php
@@ -77,12 +77,16 @@ final class DocBlockNameImporter
         $this->importSkipper = $importSkipper;
     }
 
-    public function importNames(PhpDocInfo $phpDocInfo, Node $phpParserNode): bool
-    {
+    public function importNames(
+        PhpDocInfo $phpDocInfo,
+        Node $phpParserNode,
+        bool $shouldImportRootNamespaceClasses = true
+    ): bool {
         $phpDocNode = $phpDocInfo->getPhpDocNode();
 
         $this->phpDocNodeTraverser->traverseWithCallable($phpDocNode, function (PhpDocParserNode $docNode) use (
-            $phpParserNode
+            $phpParserNode,
+            $shouldImportRootNamespaceClasses
         ): PhpDocParserNode {
             if (! $docNode instanceof IdentifierTypeNode) {
                 return $docNode;
@@ -90,6 +94,10 @@ final class DocBlockNameImporter
 
             $staticType = $this->staticTypeMapper->mapPHPStanPhpDocTypeNodeToPHPStanType($docNode, $phpParserNode);
             if (! $staticType instanceof FullyQualifiedObjectType) {
+                return $docNode;
+            }
+
+            if (! $shouldImportRootNamespaceClasses && substr_count($staticType->getClassName(), '\\') === 0) {
                 return $docNode;
             }
 


### PR DESCRIPTION
Trying to fix https://github.com/rectorphp/rector/issues/1911#issuecomment-525642537

```yaml
services:
    Rector\CodingStyle\Rector\Namespace_\ImportFullyQualifiedNamesRector:
        $shouldImportRootNamespaceClasses: false
```

I still need to prevent changing DocBlock annotations like `@var \DateTime`... which seems way harder, looking at the code.