### PR TITLE
Fixing 'return new static()' not being covered by MakeInheritedMethodVisibilitySameAsParentRector

### DIFF
--- a/packages/CodingStyle/src/Rector/ClassMethod/MakeInheritedMethodVisibilitySameAsParentRector.php
+++ b/packages/CodingStyle/src/Rector/ClassMethod/MakeInheritedMethodVisibilitySameAsParentRector.php
@@ -214,7 +214,15 @@ PHP
                 return false;
             }
 
-            return $this->isName($node->expr->class, 'self') || $this->isName($node->expr->class, 'static');
+            if ($this->isName($node->expr->class, 'self')) {
+                return true;
+            }
+
+            if ($this->isName($node->expr->class, 'static')) {
+                return true;
+            }
+
+            return false;
         });
     }
 }

--- a/packages/CodingStyle/src/Rector/ClassMethod/MakeInheritedMethodVisibilitySameAsParentRector.php
+++ b/packages/CodingStyle/src/Rector/ClassMethod/MakeInheritedMethodVisibilitySameAsParentRector.php
@@ -177,7 +177,7 @@ PHP
                 continue;
             }
 
-            $isStaticSelfFactory = $this->isStaticSelfFactory($iteratedClassMethod);
+            $isStaticSelfFactory = $this->isStaticNamedConstructor($iteratedClassMethod);
 
             if ($isStaticSelfFactory === false) {
                 continue;
@@ -193,7 +193,7 @@ PHP
      * Looks for:
      * public static someMethod() { return new self(); }
      */
-    private function isStaticSelfFactory(ClassMethod $classMethod): bool
+    private function isStaticNamedConstructor(ClassMethod $classMethod): bool
     {
         if (! $classMethod->isPublic()) {
             return false;
@@ -212,7 +212,7 @@ PHP
                 return false;
             }
 
-            return $this->isName($node->expr->class, 'self');
+            return $this->isName($node->expr->class, 'self') || $this->isName($node->expr->class, 'static');
         });
     }
 }

--- a/packages/CodingStyle/src/Rector/ClassMethod/MakeInheritedMethodVisibilitySameAsParentRector.php
+++ b/packages/CodingStyle/src/Rector/ClassMethod/MakeInheritedMethodVisibilitySameAsParentRector.php
@@ -192,6 +192,8 @@ PHP
     /**
      * Looks for:
      * public static someMethod() { return new self(); }
+     * or
+     * public static someMethod() { return new static(); }
      */
     private function isStaticNamedConstructor(ClassMethod $classMethod): bool
     {

--- a/packages/CodingStyle/tests/Rector/ClassMethod/MakeInheritedMethodVisibilitySameAsParentRector/Fixture/ParentWithPublicConstructor.php
+++ b/packages/CodingStyle/tests/Rector/ClassMethod/MakeInheritedMethodVisibilitySameAsParentRector/Fixture/ParentWithPublicConstructor.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CodingStyle\Tests\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsParentRector\Fixture;
+
+class ParentWithPublicConstructor
+{
+    public function __construct()
+    {
+    }
+}

--- a/packages/CodingStyle/tests/Rector/ClassMethod/MakeInheritedMethodVisibilitySameAsParentRector/Fixture/skip_self_ctor.php.inc
+++ b/packages/CodingStyle/tests/Rector/ClassMethod/MakeInheritedMethodVisibilitySameAsParentRector/Fixture/skip_self_ctor.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\CodingStyle\Tests\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsParentRector\Fixture;
+
+final class SkipSelfCtor extends ParentWithPublicConstructor
+{
+    private function __construct()
+    {
+    }
+
+    public static function create()
+    {
+        return new self();
+    }
+}

--- a/packages/CodingStyle/tests/Rector/ClassMethod/MakeInheritedMethodVisibilitySameAsParentRector/Fixture/skip_self_ctor.php.inc
+++ b/packages/CodingStyle/tests/Rector/ClassMethod/MakeInheritedMethodVisibilitySameAsParentRector/Fixture/skip_self_ctor.php.inc
@@ -2,6 +2,8 @@
 
 namespace Rector\CodingStyle\Tests\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsParentRector\Fixture;
 
+use Rector\CodingStyle\Tests\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsParentRector\Source\ParentWithPublicConstructor;
+
 final class SkipSelfCtor extends ParentWithPublicConstructor
 {
     private function __construct()

--- a/packages/CodingStyle/tests/Rector/ClassMethod/MakeInheritedMethodVisibilitySameAsParentRector/Fixture/skip_static_ctor.php.inc
+++ b/packages/CodingStyle/tests/Rector/ClassMethod/MakeInheritedMethodVisibilitySameAsParentRector/Fixture/skip_static_ctor.php.inc
@@ -2,19 +2,6 @@
 
 namespace Rector\CodingStyle\Tests\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsParentRector\Fixture;
 
-final class SkipSelfCtor extends ParentWithPublicConstructor
-{
-    private function __construct()
-    {
-        // do something
-    }
-
-    public static function create()
-    {
-        return new self();
-    }
-}
-
 abstract class SkipStaticCtor extends ParentWithPublicConstructor
 {
     protected function __construct()
@@ -32,13 +19,8 @@ class InheritedSkipCtor extends SkipStaticCtor
 {
     protected function __construct()
     {
-        // do something more
-    }
-}
+        parent::__construct();
 
-class ParentWithPublicConstructor
-{
-    public function __construct()
-    {
+        // do something more
     }
 }

--- a/packages/CodingStyle/tests/Rector/ClassMethod/MakeInheritedMethodVisibilitySameAsParentRector/Fixture/skip_static_ctor.php.inc
+++ b/packages/CodingStyle/tests/Rector/ClassMethod/MakeInheritedMethodVisibilitySameAsParentRector/Fixture/skip_static_ctor.php.inc
@@ -2,6 +2,8 @@
 
 namespace Rector\CodingStyle\Tests\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsParentRector\Fixture;
 
+use Rector\CodingStyle\Tests\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsParentRector\Source\ParentWithPublicConstructor;
+
 abstract class SkipStaticCtor extends ParentWithPublicConstructor
 {
     protected function __construct()

--- a/packages/CodingStyle/tests/Rector/ClassMethod/MakeInheritedMethodVisibilitySameAsParentRector/Fixture/skip_static_ctor.php.inc
+++ b/packages/CodingStyle/tests/Rector/ClassMethod/MakeInheritedMethodVisibilitySameAsParentRector/Fixture/skip_static_ctor.php.inc
@@ -2,15 +2,37 @@
 
 namespace Rector\CodingStyle\Tests\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsParentRector\Fixture;
 
-class SkipStaticCtor extends ParentWithPublicConstructor
+final class SkipSelfCtor extends ParentWithPublicConstructor
 {
-    protected function __construct()
+    private function __construct()
     {
+        // do something
     }
 
     public static function create()
     {
         return new self();
+    }
+}
+
+abstract class SkipStaticCtor extends ParentWithPublicConstructor
+{
+    protected function __construct()
+    {
+        // do something basic
+    }
+
+    public static function create()
+    {
+        return new static();
+    }
+}
+
+class InheritedSkipCtor extends SkipStaticCtor
+{
+    protected function __construct()
+    {
+        // do something more
     }
 }
 

--- a/packages/CodingStyle/tests/Rector/ClassMethod/MakeInheritedMethodVisibilitySameAsParentRector/SkipParentConstructOverrideInPHP72Test.php
+++ b/packages/CodingStyle/tests/Rector/ClassMethod/MakeInheritedMethodVisibilitySameAsParentRector/SkipParentConstructOverrideInPHP72Test.php
@@ -21,6 +21,7 @@ final class SkipParentConstructOverrideInPHP72Test extends AbstractRectorTestCas
 
     public function provideDataForTest(): Iterator
     {
+        yield [__DIR__ . '/Fixture/skip_self_ctor.php.inc'];
         yield [__DIR__ . '/Fixture/skip_static_ctor.php.inc'];
     }
 

--- a/packages/CodingStyle/tests/Rector/ClassMethod/MakeInheritedMethodVisibilitySameAsParentRector/Source/ParentWithPublicConstructor.php
+++ b/packages/CodingStyle/tests/Rector/ClassMethod/MakeInheritedMethodVisibilitySameAsParentRector/Source/ParentWithPublicConstructor.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\CodingStyle\Tests\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsParentRector\Fixture;
+namespace Rector\CodingStyle\Tests\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsParentRector\Source;
 
 class ParentWithPublicConstructor
 {


### PR DESCRIPTION
`return new self();` was correctly handled, while `return new static();` was not. Now both are.

Fixes #2057 