### PR TITLE
ImportFullyQualifiedNamesRector : add a failing test about modified annotations that shouldn't be

### DIFF
--- a/packages/CodingStyle/tests/Rector/Namespace_/ImportFullyQualifiedNamesRector/Fixture/should_keep_all_doc_blocks_annotations_parameters.php.inc
+++ b/packages/CodingStyle/tests/Rector/Namespace_/ImportFullyQualifiedNamesRector/Fixture/should_keep_all_doc_blocks_annotations_parameters.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\CodingStyle\Tests\Rector\Namespace_\ImportFullyQualifiedNamesRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * @ORM\Table("Table_Name")
+ * @ORM\Entity()
+ * @ORM\InheritanceType("SINGLE_TABLE")
+ */
+class ShouldKeepAllDocBlocksAnnotationsParameters
+{
+    /**
+     * @Route(
+     *     "/{arg1}/{arg2}",
+     *     defaults={"arg1"=null, "arg2"=""},
+     *     requirements={"arg1"="\d+", "arg2"=".*"}
+     * )
+     */
+    public function nothing(): void
+    {
+    }
+}

--- a/packages/CodingStyle/tests/Rector/Namespace_/ImportFullyQualifiedNamesRector/ImportFullyQualifiedNamesRectorTest.php
+++ b/packages/CodingStyle/tests/Rector/Namespace_/ImportFullyQualifiedNamesRector/ImportFullyQualifiedNamesRectorTest.php
@@ -60,6 +60,7 @@ final class ImportFullyQualifiedNamesRectorTest extends AbstractRectorTestCase
         yield [__DIR__ . '/Fixture/keep_static_method.php.inc'];
         yield [__DIR__ . '/Fixture/keep_various_request.php.inc'];
         yield [__DIR__ . '/Fixture/instance_of.php.inc'];
+        yield [__DIR__ . '/Fixture/should_keep_all_doc_blocks_annotations_parameters.php.inc'];
 
         yield [__DIR__ . '/Fixture/import_root_namespace_classes_enabled.php.inc'];
     }


### PR DESCRIPTION
I've finally been able to add `ImportFullyQualifiedNamesRector` to our project thanks to the new "skip root namespace" option. And I've noticed 3 nasty bugs in there (losing `@ORM\Table` argument, de-doubling of `@ORM\InheritanceType` argument, removing `@Route` arguments).

So I've added a test case with all these annotations, which resulted in : 

```diff
1) Rector\CodingStyle\Tests\Rector\Namespace_\ImportFullyQualifiedNamesRector\ImportFullyQualifiedNamesRectorTest::test with data set #22 ('/home/gnutix/dev/oss/rectorph...hp.inc')
Caused by /home/gnutix/dev/oss/rectorphp/rector/packages/CodingStyle/tests/Rector/Namespace_/ImportFullyQualifiedNamesRector/Fixture/should_keep_all_doc_blocks_annotations_parameters.php.inc
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @ORM\Table("Table_Name")
- * @ORM\Entity()
- * @ORM\InheritanceType("SINGLE_TABLE")
+ * @ORM\Table
+ * @ORM\Entity
+ * @ORM\InheritanceType("SINGLE_TABLE")("SINGLE_TABLE")
  */
 class ShouldKeepAllDocBlocksAnnotationsParameters
 {
     /**
-     * @Route(
-     *     "/{arg1}/{arg2}",
-     *     defaults={"arg1"=null, "arg2"=""},
-     *     requirements={"arg1"="\d+", "arg2"=".*"}
-     * )
+     * @Route    (     path="/{arg1}/{arg2}" )
      */
     public function nothing(): void
     {

/home/gnutix/dev/oss/rectorphp/rector/src/Testing/PHPUnit/AbstractRectorTestCase.php:182
/home/gnutix/dev/oss/rectorphp/rector/src/Testing/PHPUnit/AbstractRectorTestCase.php:136
/home/gnutix/dev/oss/rectorphp/rector/packages/CodingStyle/tests/Rector/Namespace_/ImportFullyQualifiedNamesRector/ImportFullyQualifiedNamesRectorTest.php:17
```