### PR TITLE
Add option to keep declared constant visibility

### DIFF
--- a/docs/AllRectorsOverview.md
+++ b/docs/AllRectorsOverview.md
@@ -5716,7 +5716,7 @@ Classes that have no children nor are used, should have abstract
 
 - class: `Rector\SOLID\Rector\ClassConst\PrivatizeLocalClassConstantRector`
 
-Finalize every class constant that is used only locally
+Privatize every class constant that is used only locally
 
 ```diff
  class ClassWithConstantUsedOnlyHere
@@ -5727,6 +5727,29 @@ Finalize every class constant that is used only locally
      public function isLocalOnly()
      {
          return self::LOCAL_ONLY;
+     }
+ }
+```
+
+Use `$keepDeclaredVisibility` to keep explicitly declared constant visibility, to that only
+constants missing the visibility declaration will be changed.
+
+```yaml
+services:
+    Rector\SOLID\Rector\ClassConst\PrivatizeLocalClassConstantRector:
+        $keepDeclaredVisibility: true
+```
+
+```diff
+ class ClassWithConstantUsedOnlyHere
+ {
+     public LOCAL_ONLY_BUT_DECLARED_PUBLIC = true;
+-    const LOCAL_ONLY = true;
++    private const LOCAL_ONLY = true;
+
+     public function isLocalOnly()
+     {
+         return self::LOCAL_ONLY && self::LOCAL_ONLY_BUT_DECLARED_PUBLIC;
      }
  }
 ```

--- a/packages/SOLID/src/Rector/ClassConst/PrivatizeLocalClassConstantRector.php
+++ b/packages/SOLID/src/Rector/ClassConst/PrivatizeLocalClassConstantRector.php
@@ -3,6 +3,7 @@
 namespace Rector\SOLID\Rector\ClassConst;
 
 use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassConst;
 use Rector\NodeContainer\ParsedNodesByType;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -31,12 +32,19 @@ final class PrivatizeLocalClassConstantRector extends AbstractRector
      */
     private $classConstantFetchAnalyzer;
 
+    /**
+     * @var bool
+     */
+    private $keepDeclaredVisibility;
+
     public function __construct(
         ParsedNodesByType $parsedNodesByType,
-        ClassConstantFetchAnalyzer $classConstantFetchAnalyzer
+        ClassConstantFetchAnalyzer $classConstantFetchAnalyzer,
+        bool $keepDeclaredVisibility = false
     ) {
         $this->parsedNodesByType = $parsedNodesByType;
         $this->classConstantFetchAnalyzer = $classConstantFetchAnalyzer;
+        $this->keepDeclaredVisibility = $keepDeclaredVisibility;
     }
 
     public function getDefinition(): RectorDefinition
@@ -214,6 +222,10 @@ PHP
         }
 
         if (! $this->isAtLeastPhpVersion('7.1')) {
+            return true;
+        }
+
+        if ($this->keepDeclaredVisibility && ($classConst->flags & Class_::VISIBILITY_MODIFIER_MASK) !== 0) {
             return true;
         }
 

--- a/packages/SOLID/tests/Rector/ClassConst/PrivatizeLocalClassConstantRector/Fixture/keep_declared_visibility.php.inc
+++ b/packages/SOLID/tests/Rector/ClassConst/PrivatizeLocalClassConstantRector/Fixture/keep_declared_visibility.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\SOLID\Tests\Rector\ClassConst\PrivatizeLocalClassConstantRector\Fixture;
+
+class ClassWithConstantVisibilityDeclared
+{
+    public const LOCAL_ONLY = true;
+
+    public function isLocalOnly()
+    {
+        return self::LOCAL_ONLY;
+    }
+}
+
+?>

--- a/packages/SOLID/tests/Rector/ClassConst/PrivatizeLocalClassConstantRector/KeepDeclaredVisibilityTest.php
+++ b/packages/SOLID/tests/Rector/ClassConst/PrivatizeLocalClassConstantRector/KeepDeclaredVisibilityTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace Rector\SOLID\Tests\Rector\ClassConst\PrivatizeLocalClassConstantRector;
+
+use Iterator;
+use Rector\SOLID\Rector\ClassConst\PrivatizeLocalClassConstantRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class KeepDeclaredVisibilityTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideDataForTest()
+     */
+    public function test(string $file): void
+    {
+        $this->doTestFile($file);
+    }
+
+    public function provideDataForTest(): Iterator
+    {
+        yield [__DIR__ . '/Fixture/fixture.php.inc'];
+        yield [__DIR__ . '/Fixture/keep_public.php.inc'];
+        yield [__DIR__ . '/Fixture/keep_declared_visibility.php.inc'];
+    }
+
+    protected function getRectorsWithConfiguration(): array
+    {
+        return [
+            PrivatizeLocalClassConstantRector::class => [
+                '$keepDeclaredVisibility' => true,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This PR adds an option for `PrivatizeLocalClassConstantRector` to keep the constant visibility when it has been explicitly declared, instead of calculating it from usages in the codebase and potentially changing it.