### PR TITLE
ImportFullyQualifiedNamesRector breaks Doctrine annotations : add a failing test case

### DIFF
--- a/packages/CodingStyle/tests/Rector/Namespace_/ImportFullyQualifiedNamesRector/Fixture/should_not_break_doctrine_inverse_join_columns_annotations.php.inc
+++ b/packages/CodingStyle/tests/Rector/Namespace_/ImportFullyQualifiedNamesRector/Fixture/should_not_break_doctrine_inverse_join_columns_annotations.php.inc
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Page;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Table(name="page_template")
+ * @ORM\Entity()
+ */
+class Template
+{
+    /**
+     * @var int
+     *
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @var Area[]|ArrayCollection
+     *
+     * @ORM\ManyToMany(targetEntity="Area", cascade={"remove", "persist"}, inversedBy="templates")
+     * @ORM\JoinTable(name="page_template_area",
+     *      joinColumns={@ORM\JoinColumn(name="template_id", referencedColumnName="id", onDelete="CASCADE")},
+     *      inverseJoinColumns={@ORM\JoinColumn(name="area_id", referencedColumnName="id")}
+     * )
+     */
+    private $areas;
+
+    public function __construct()
+    {
+        $this->areas = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function addArea(Area $area): self
+    {
+        $this->areas[] = $area;
+
+        return $this;
+    }
+
+    public function removeArea(Area $area): self
+    {
+        $this->areas->removeElement($area);
+
+        return $this;
+    }
+
+    /**
+     * @return Area[]|ArrayCollection
+     */
+    public function getAreas()
+    {
+        return $this->areas;
+    }
+}
+
+/**
+ * @ORM\Table(name="Area",indexes={@ORM\Index(name="area_name_idx", columns={"name"})})
+ * @ORM\Entity()
+ */
+class Area
+{
+    /**
+     * @var Template[]|ArrayCollection
+     *
+     * @ORM\ManyToMany(targetEntity="Template", mappedBy="areas")
+     */
+    private $templates;
+
+    public function __construct()
+    {
+        $this->templates = new ArrayCollection();
+    }
+
+    public function addTemplate(Template $template): self
+    {
+        $this->templates[] = $template;
+
+        return $this;
+    }
+
+    public function removeTemplate(Template $template): self
+    {
+        $this->templates->removeElement($template);
+
+        return $this;
+    }
+
+    /**
+     * @return Template[]|ArrayCollection
+     */
+    public function getTemplates()
+    {
+        return $this->templates;
+    }
+}

--- a/packages/CodingStyle/tests/Rector/Namespace_/ImportFullyQualifiedNamesRector/ImportFullyQualifiedNamesRectorTest.php
+++ b/packages/CodingStyle/tests/Rector/Namespace_/ImportFullyQualifiedNamesRector/ImportFullyQualifiedNamesRectorTest.php
@@ -61,6 +61,7 @@ final class ImportFullyQualifiedNamesRectorTest extends AbstractRectorTestCase
         yield [__DIR__ . '/Fixture/keep_various_request.php.inc'];
         yield [__DIR__ . '/Fixture/instance_of.php.inc'];
         yield [__DIR__ . '/Fixture/should_keep_all_doc_blocks_annotations_parameters.php.inc'];
+        yield [__DIR__ . '/Fixture/should_not_break_doctrine_inverse_join_columns_annotations.php.inc'];
 
         yield [__DIR__ . '/Fixture/import_root_namespace_classes_enabled.php.inc'];
     }


### PR DESCRIPTION
I've noticed two more errors when running `ImportFullyQualifiedNamesRector` on our codebase : 

1) `inverseJoinColumns -> @ORM\JoinColumn -> name` is modified to match the one in `joinColumns -> @ORM\JoinColumn -> name` (which is wrong : it should be different, as one is the "owner side" and the other the inverse side of the relationship, so both properties have different names : here `template_id` (owner) and `area_id` (inversed))
2) The indentation is broken and the doc block's `*` characters are missing

Results in : 

```diff
vendor/bin/phpunit packages/CodingStyle/tests/Rector/Namespace_/ImportFullyQualifiedNamesRector/ImportFullyQualifiedNamesRectorTest.php 
PHPUnit 7.5.0 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.3.9-1+ubuntu18.04.1+deb.sury.org+1
Configuration: /home/gnutix/dev/oss/rectorphp/rector/phpunit.xml

.......................F...                                       27 / 27 (100%)

Time: 1.43 seconds, Memory: 58.50MB

There was 1 failure:

1) Rector\CodingStyle\Tests\Rector\Namespace_\ImportFullyQualifiedNamesRector\ImportFullyQualifiedNamesRectorTest::test with data set #23 ('/home/gnutix/dev/oss/rectorph...hp.inc')
Caused by /home/gnutix/dev/oss/rectorphp/rector/packages/CodingStyle/tests/Rector/Namespace_/ImportFullyQualifiedNamesRector/Fixture/should_not_break_doctrine_inverse_join_columns_annotations.php.inc
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
     private $id;
 
     /**
-     * @var Area[]|ArrayCollection
-     *
-     * @ORM\ManyToMany(targetEntity="Area", cascade={"remove", "persist"}, inversedBy="templates")
-     * @ORM\JoinTable(name="page_template_area",
-     *      joinColumns={@ORM\JoinColumn(name="template_id", referencedColumnName="id", onDelete="CASCADE")},
-     *      inverseJoinColumns={@ORM\JoinColumn(name="area_id", referencedColumnName="id")}
-     * )
-     */
+    * @var Area[]|ArrayCollection
+    *
+    * @ORM\ManyToMany(targetEntity="Area", cascade={"remove", "persist"}, inversedBy="templates")
+    * @ORM\JoinTable(name="page_template_area", joinColumns={
+        @ORM\JoinColumn(name="template_id", referencedColumnName="id", onDelete="CASCADE")
+    }, inverseJoinColumns={
+        @ORM\JoinColumn(name="template_id", referencedColumnName="id")
+    }
+    )
+    */
     private $areas;
 
     public function __construct()

/home/gnutix/dev/oss/rectorphp/rector/src/Testing/PHPUnit/AbstractRectorTestCase.php:182
/home/gnutix/dev/oss/rectorphp/rector/src/Testing/PHPUnit/AbstractRectorTestCase.php:136
/home/gnutix/dev/oss/rectorphp/rector/packages/CodingStyle/tests/Rector/Namespace_/ImportFullyQualifiedNamesRector/ImportFullyQualifiedNamesRectorTest.php:17

FAILURES!
Tests: 27, Assertions: 55, Failures: 1.
```