### PR TITLE
[StrictCodeQuality] Add freshly created node support to var inline assert

### DIFF
--- a/packages/StrictCodeQuality/tests/Rector/Stmt/VarInlineAnnotationToAssertRector/Fixture/assign_fresh_var.php.inc
+++ b/packages/StrictCodeQuality/tests/Rector/Stmt/VarInlineAnnotationToAssertRector/Fixture/assign_fresh_var.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\StrictCodeQuality\Tests\Rector\Stmt\VarInlineAnnotationToAssertRector\Fixture;
+
+class AssignFreshVar
+{
+    public function run($value)
+    {
+        /** @var int $int */
+        $int = $value;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\StrictCodeQuality\Tests\Rector\Stmt\VarInlineAnnotationToAssertRector\Fixture;
+
+class AssignFreshVar
+{
+    public function run($value)
+    {
+        /** @var int $int */
+        $int = $value;
+        assert(is_int($int));
+    }
+}
+
+?>

--- a/packages/StrictCodeQuality/tests/Rector/Stmt/VarInlineAnnotationToAssertRector/Fixture/skip_missing_variable.php.inc
+++ b/packages/StrictCodeQuality/tests/Rector/Stmt/VarInlineAnnotationToAssertRector/Fixture/skip_missing_variable.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\StrictCodeQuality\Tests\Rector\Stmt\VarInlineAnnotationToAssertRector\Fixture;
+
+class SkipMissingVariable
+{
+    public function run($value)
+    {
+        /** @var int */
+        $int = $value;
+    }
+}

--- a/packages/StrictCodeQuality/tests/Rector/Stmt/VarInlineAnnotationToAssertRector/Fixture/skip_property.php.inc
+++ b/packages/StrictCodeQuality/tests/Rector/Stmt/VarInlineAnnotationToAssertRector/Fixture/skip_property.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\StrictCodeQuality\Tests\Rector\Stmt\VarInlineAnnotationToAssertRector\Fixture;
+
+class SkipProperty
+{
+    /**
+     * @var int $id
+     */
+    public $id;
+}

--- a/packages/StrictCodeQuality/tests/Rector/Stmt/VarInlineAnnotationToAssertRector/VarInlineAnnotationToAssertRectorTest.php
+++ b/packages/StrictCodeQuality/tests/Rector/Stmt/VarInlineAnnotationToAssertRector/VarInlineAnnotationToAssertRectorTest.php
@@ -20,6 +20,7 @@ final class VarInlineAnnotationToAssertRectorTest extends AbstractRectorTestCase
     {
         yield [__DIR__ . '/Fixture/fixture.php.inc'];
         yield [__DIR__ . '/Fixture/scalar.php.inc'];
+        yield [__DIR__ . '/Fixture/assign_fresh_var.php.inc'];
     }
 
     protected function getRectorClass(): string

--- a/packages/StrictCodeQuality/tests/Rector/Stmt/VarInlineAnnotationToAssertRector/VarInlineAnnotationToAssertRectorTest.php
+++ b/packages/StrictCodeQuality/tests/Rector/Stmt/VarInlineAnnotationToAssertRector/VarInlineAnnotationToAssertRectorTest.php
@@ -21,6 +21,8 @@ final class VarInlineAnnotationToAssertRectorTest extends AbstractRectorTestCase
         yield [__DIR__ . '/Fixture/fixture.php.inc'];
         yield [__DIR__ . '/Fixture/scalar.php.inc'];
         yield [__DIR__ . '/Fixture/assign_fresh_var.php.inc'];
+        yield [__DIR__ . '/Fixture/skip_missing_variable.php.inc'];
+        yield [__DIR__ . '/Fixture/skip_property.php.inc'];
     }
 
     protected function getRectorClass(): string

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -203,3 +203,4 @@ parameters:
 
         # known value
         - '#Parameter \#1 \$node of method Rector\\DeadCode\\Rector\\ClassMethod\\RemoveDelegatingParentCallRector\:\:unwrapExpression\(\) expects PhpParser\\Node, PhpParser\\Node\\Stmt\|null given#'
+        - '#Method Rector\\StrictCodeQuality\\Rector\\Stmt\\VarInlineAnnotationToAssertRector\:\:findVariableByName\(\) should return PhpParser\\Node\\Expr\\Variable\|null but returns PhpParser\\Node\|null#'


### PR DESCRIPTION
Closes #2118

```diff
-/** @var int $value */
 $int = $some->get();
+assert(is_int($value));
```