### PR TITLE
EncapsedStringsToSprintfRector fails when using class properties

### DIFF
--- a/packages/CodingStyle/tests/Rector/Encapsed/EncapsedStringsToSprintfRector/EncapsedStringsToSprintfRectorTest.php
+++ b/packages/CodingStyle/tests/Rector/Encapsed/EncapsedStringsToSprintfRector/EncapsedStringsToSprintfRectorTest.php
@@ -19,6 +19,7 @@ final class EncapsedStringsToSprintfRectorTest extends AbstractRectorTestCase
     public function provideDataForTest(): Iterator
     {
         yield [__DIR__ . '/Fixture/fixture.php.inc'];
+        yield [__DIR__ . '/Fixture/fixture2.php.inc'];
         yield [__DIR__ . '/Fixture/numberz.php.inc'];
     }
 

--- a/packages/CodingStyle/tests/Rector/Encapsed/EncapsedStringsToSprintfRector/Fixture/fixture2.php.inc
+++ b/packages/CodingStyle/tests/Rector/Encapsed/EncapsedStringsToSprintfRector/Fixture/fixture2.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\CodingStyle\Tests\Rector\Encapsed\EncapsedStringsToSprintfRector\Fixture;
+
+final class SomeClassProperty
+{
+    private $format = 'json';
+
+    public function run(string $format)
+    {
+        return "Unsupported format {$this->format}";
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CodingStyle\Tests\Rector\Encapsed\EncapsedStringsToSprintfRector\Fixture;
+
+final class SomeClassProperty
+{
+    private $format = 'json';
+
+    public function run(string $format)
+    {
+        return sprintf('Unsupported format %s', $this->format);
+    }
+}
+
+?>


### PR DESCRIPTION
```
vendor/bin/phpunit packages/CodingStyle/tests/Rector/Encapsed/EncapsedStringsToSprintfRector/EncapsedStringsToSprintfRectorTest.php
PHPUnit 7.5.0 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.3.9-1+ubuntu18.04.1+deb.sury.org+1
Configuration: /home/gnutix/dev/oss/rectorphp/rector/phpunit.xml

.F.                                                                 3 / 3 (100%)

Time: 1.49 seconds, Memory: 56.50MB

There was 1 failure:

1) Rector\CodingStyle\Tests\Rector\Encapsed\EncapsedStringsToSprintfRector\EncapsedStringsToSprintfRectorTest::test with data set #1 ('/home/gnutix/dev/oss/rectorph...hp.inc')
Caused by /home/gnutix/dev/oss/rectorphp/rector/packages/CodingStyle/tests/Rector/Encapsed/EncapsedStringsToSprintfRector/Fixture/fixture2.php.inc
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
 
     public function run(string $format)
     {
-        return sprintf('Unsupported format %s', $this->format);
+        return sprintf('Unsupported format ');
     }
 }

/home/gnutix/dev/oss/rectorphp/rector/src/Testing/PHPUnit/AbstractRectorTestCase.php:182
/home/gnutix/dev/oss/rectorphp/rector/src/Testing/PHPUnit/AbstractRectorTestCase.php:136
/home/gnutix/dev/oss/rectorphp/rector/packages/CodingStyle/tests/Rector/Encapsed/EncapsedStringsToSprintfRector/EncapsedStringsToSprintfRectorTest.php:16
```