### PR TITLE
[DeadCode] Make RemoveDefaultArgumentValueRector skip native functions

### DIFF
--- a/packages/DeadCode/tests/Rector/MethodCall/RemoveDefaultArgumentValueRector/Fixture/skip_system_function.php.inc
+++ b/packages/DeadCode/tests/Rector/MethodCall/RemoveDefaultArgumentValueRector/Fixture/skip_system_function.php.inc
@@ -9,19 +9,3 @@ class SystemFunction
         trigger_error('Error message', E_USER_NOTICE);
     }
 }
-
-?>
------
-<?php
-
-namespace Rector\DeadCode\Tests\Rector\MethodCall\RemoveDefaultArgumentValueRector\Fixture;
-
-class SystemFunction
-{
-    public function run()
-    {
-        trigger_error('Error message');
-    }
-}
-
-?>

--- a/packages/DeadCode/tests/Rector/MethodCall/RemoveDefaultArgumentValueRector/RemoveDefaultArgumentValueRectorTest.php
+++ b/packages/DeadCode/tests/Rector/MethodCall/RemoveDefaultArgumentValueRector/RemoveDefaultArgumentValueRectorTest.php
@@ -22,7 +22,7 @@ final class RemoveDefaultArgumentValueRectorTest extends AbstractRectorTestCase
         yield [__DIR__ . '/Fixture/skip_previous_order.php.inc'];
         yield [__DIR__ . '/Fixture/function.php.inc'];
         yield [__DIR__ . '/Fixture/user_vendor_function.php.inc'];
-        yield [__DIR__ . '/Fixture/system_function.php.inc'];
+        yield [__DIR__ . '/Fixture/skip_system_function.php.inc'];
     }
 
     protected function getRectorClass(): string

--- a/packages/NodeTypeResolver/config/config.yaml
+++ b/packages/NodeTypeResolver/config/config.yaml
@@ -25,3 +25,6 @@ services:
 
     PHPStan\Analyser\ScopeFactory:
         factory: ['@Rector\NodeTypeResolver\DependencyInjection\PHPStanServicesFactory', 'createScopeFactory']
+
+    PHPStan\Reflection\SignatureMap\SignatureMapProvider:
+        factory: ['@Rector\NodeTypeResolver\DependencyInjection\PHPStanServicesFactory', 'createSignatureMapProvider']

--- a/packages/NodeTypeResolver/src/DependencyInjection/PHPStanServicesFactory.php
+++ b/packages/NodeTypeResolver/src/DependencyInjection/PHPStanServicesFactory.php
@@ -8,6 +8,7 @@ use PHPStan\Analyser\ScopeFactory;
 use PHPStan\Analyser\TypeSpecifier;
 use PHPStan\Broker\Broker;
 use PHPStan\DependencyInjection\ContainerFactory;
+use PHPStan\Reflection\SignatureMap\SignatureMapProvider;
 
 final class PHPStanServicesFactory
 {
@@ -45,6 +46,11 @@ final class PHPStanServicesFactory
     public function createTypeSpecifier(): TypeSpecifier
     {
         return $this->container->getByType(TypeSpecifier::class);
+    }
+
+    public function createSignatureMapProvider(): SignatureMapProvider
+    {
+        return $this->container->getByType(SignatureMapProvider::class);
     }
 
     public function createScopeFactory(): ScopeFactory

--- a/src/Reflection/FunctionReflectionResolver.php
+++ b/src/Reflection/FunctionReflectionResolver.php
@@ -2,65 +2,22 @@
 
 namespace Rector\Reflection;
 
-use PhpParser\Node;
-use PhpParser\Node\Stmt\Function_;
-use Rector\Exception\ShouldNotHappenException;
-use Rector\PhpParser\Node\BetterNodeFinder;
-use Rector\PhpParser\Parser\Parser;
+use PHPStan\Reflection\SignatureMap\SignatureMapProvider;
 
 final class FunctionReflectionResolver
 {
     /**
-     * @var string[]
+     * @var SignatureMapProvider
      */
-    private const POSSIBLE_CORE_STUB_LOCATIONS = [
-        __DIR__ . '/../../../../jetbrains/phpstorm-stubs/Core/Core.php',
-        __DIR__ . '/../../vendor/jetbrains/phpstorm-stubs/Core/Core.php',
-    ];
+    private $signatureMapProvider;
 
-    /**
-     * @var Parser
-     */
-    private $parser;
-
-    /**
-     * @var BetterNodeFinder
-     */
-    private $betterNodeFinder;
-
-    public function __construct(Parser $parser, BetterNodeFinder $betterNodeFinder)
+    public function __construct(SignatureMapProvider $signatureMapProvider)
     {
-        $this->parser = $parser;
-        $this->betterNodeFinder = $betterNodeFinder;
+        $this->signatureMapProvider = $signatureMapProvider;
     }
 
-    public function resolveCoreStubFunctionNode(string $nodeName): ?Function_
+    public function isPhpNativeFunction(string $functionName): bool
     {
-        $stubFileLocation = $this->resolveCoreStubLocation();
-
-        $nodes = $this->parser->parseFile($stubFileLocation);
-
-        /** @var Function_|null $function */
-        $function = $this->betterNodeFinder->findFirst($nodes, function (Node $node) use ($nodeName): bool {
-            if (! $node instanceof Function_) {
-                return false;
-            }
-
-            return (string) $node->name === $nodeName;
-        });
-
-        return $function;
-    }
-
-    private function resolveCoreStubLocation(): string
-    {
-        foreach (self::POSSIBLE_CORE_STUB_LOCATIONS as $possibleCoreStubLocation) {
-            if (file_exists($possibleCoreStubLocation)) {
-                /** @var string $possibleCoreStubLocation */
-                return $possibleCoreStubLocation;
-            }
-        }
-
-        throw new ShouldNotHappenException();
+        return $this->signatureMapProvider->hasFunctionSignature($functionName);
     }
 }


### PR DESCRIPTION
That prevents full-PHP-stub loading to get that their default value