### PR TITLE
Prevent CI floods with progress bar

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "nette/robot-loader": "^3.1",
         "nette/utils": "^2.5|^3.0",
         "nikic/php-parser": "^4.2.4",
+        "ondram/ci-detector": "^3.1",
         "phpstan/phpdoc-parser": "^0.3.5",
         "phpstan/phpstan": "^0.11.13",
         "phpstan/phpstan-phpunit": "^0.11.2",

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -36,6 +36,8 @@ services:
     Symfony\Component\EventDispatcher\EventDispatcherInterface: '@Rector\EventDispatcher\AutowiredEventDispatcher'
     Rector\Bridge\Contract\AnalyzedApplicationContainerInterface: '@Rector\Symfony\Bridge\DefaultAnalyzedSymfonyApplicationContainer'
 
+    OndraM\CiDetector\CiDetector: ~
+
     # see https://github.com/symplify/packagebuilder#prevent-parameter-typos
     Symplify\PackageBuilder\EventSubscriber\ParameterTypoProofreaderEventSubscriber: ~
     Symplify\PackageBuilder\Parameter\ParameterTypoProofreader:

--- a/docs/AllRectorsOverview.md
+++ b/docs/AllRectorsOverview.md
@@ -3306,7 +3306,7 @@ Removes non-existing @var annotations above the code
 
 - class: `Rector\PHPUnit\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector`
 
-Tests without assertion will have @doesNotPerformAssertion 
+Tests without assertion will have @doesNotPerformAssertion
 
 ```diff
  class SomeClass extends PHPUnit\Framework\TestCase


### PR DESCRIPTION
This should prevent CI floods per line like these:

![flood](https://user-images.githubusercontent.com/924196/66898645-dd49b080-eff9-11e9-93e8-72c18f306326.png)


Now 20 steps are set