### PR TITLE
Add rules for ConsoleIo::styles()

### DIFF
--- a/config/set/cakephp/cakephp40.yaml
+++ b/config/set/cakephp/cakephp40.yaml
@@ -61,3 +61,13 @@ services:
             withParam:
               match_parameter: 'paging'
               replace_with: 'withAttribute'
+
+    Rector\CakePHP\Rector\MethodCall\ModalToGetSetRector:
+        Cake\Console\ConsoleIo:
+            styles:
+                set: 'setStyle'
+                get: 'getStyle'
+        Cake\Console\ConsoleOutput:
+            styles:
+                set: 'setStyle'
+                get: 'getStyle'


### PR DESCRIPTION
This method is getting a split get/set which can be handled by rector.