### PR TITLE
Fix for Issue2173

### DIFF
--- a/packages/Php73/src/Rector/FuncCall/RegexDashEscapeRector.php
+++ b/packages/Php73/src/Rector/FuncCall/RegexDashEscapeRector.php
@@ -24,13 +24,13 @@ final class RegexDashEscapeRector extends AbstractRector
     /**
      * @var string
      */
-    private const LEFT_HAND_UNESCAPED_DASH_PATTERN = '#(\\\\(w|s|d))-(?!\])#i';
+    private const LEFT_HAND_UNESCAPED_DASH_PATTERN = '#(\[.*?\\\\(w|s|d))-(?!\])#i';
 
     /**
      * @var string
      * @see https://regex101.com/r/TBVme9/1
      */
-    private const RIGHT_HAND_UNESCAPED_DASH_PATTERN = '#(?<!\[)-\\\\(w|s|d)#i';
+    private const RIGHT_HAND_UNESCAPED_DASH_PATTERN = '#(?<!\[)-(\\\\(w|s|d).*?)\]#i';
 
     /**
      * @var RegexPatternArgumentManipulator
@@ -97,7 +97,7 @@ PHP
         }
 
         if (Strings::match($stringValue, self::RIGHT_HAND_UNESCAPED_DASH_PATTERN)) {
-            $stringNode->value = Strings::replace($stringValue, self::RIGHT_HAND_UNESCAPED_DASH_PATTERN, '\-$2');
+            $stringNode->value = Strings::replace($stringValue, self::RIGHT_HAND_UNESCAPED_DASH_PATTERN, '\-$1]');
             // helped needed to skip re-escaping regular expression
             $stringNode->setAttribute('is_regular_pattern', true);
         }

--- a/packages/Php73/tests/Rector/FuncCall/RegexDashEscapeRector/Fixture/false_positive.php.inc
+++ b/packages/Php73/tests/Rector/FuncCall/RegexDashEscapeRector/Fixture/false_positive.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Php73\Tests\Rector\FuncCall\RegexDashEscapeRector\Fixture;
+
+function regexFalsePositive()
+{
+    // keep
+    preg_match("#^\d{4}-\d{2}-\d{2}$#", 'some text');
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Php73\Tests\Rector\FuncCall\RegexDashEscapeRector\Fixture;
+
+function regexFalsePositive()
+{
+    // keep
+    preg_match("#^\d{4}-\d{2}-\d{2}$#", 'some text');
+}
+
+?>

--- a/packages/Php73/tests/Rector/FuncCall/RegexDashEscapeRector/RegexDashEscapeRectorTest.php
+++ b/packages/Php73/tests/Rector/FuncCall/RegexDashEscapeRector/RegexDashEscapeRectorTest.php
@@ -26,6 +26,7 @@ final class RegexDashEscapeRectorTest extends AbstractRectorTestCase
         yield [__DIR__ . '/Fixture/external_const.php.inc'];
         yield [__DIR__ . '/Fixture/variable.php.inc'];
         yield [__DIR__ . '/Fixture/multiple_variables.php.inc'];
+        yield [__DIR__ . '/Fixture/false_positive.php.inc'];
     }
 
     protected function getRectorClass(): string


### PR DESCRIPTION
This patch fixes this issue. But I suspect that there will be more edge cases which will not be fixed with this small patch. Perhaps it will be better to assure, that the escaping will only executed on hyphen in character classes.