### PR TITLE
Add test to ConsoleExecuteReturnIntRector for a not command class

### DIFF
--- a/packages/Symfony/tests/Rector/Console/ConsoleExecuteReturnIntRector/ConsoleExecuteReturnIntRectorTest.php
+++ b/packages/Symfony/tests/Rector/Console/ConsoleExecuteReturnIntRector/ConsoleExecuteReturnIntRectorTest.php
@@ -20,6 +20,7 @@ final class ConsoleExecuteReturnIntRectorTest extends AbstractRectorTestCase
 
     public function provideDataForTest(): Iterator
     {
+        yield [__DIR__ . '/Fixture/non-console-command.php.inc'];
         yield [__DIR__ . '/Fixture/explicit-return-null.php.inc'];
         yield [__DIR__ . '/Fixture/no-return.php.inc'];
         yield [__DIR__ . '/Fixture/empty-return.php.inc'];

--- a/packages/Symfony/tests/Rector/Console/ConsoleExecuteReturnIntRector/Fixture/non-console-command.php.inc
+++ b/packages/Symfony/tests/Rector/Console/ConsoleExecuteReturnIntRector/Fixture/non-console-command.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\Console\ConsoleExecuteReturnIntRector\Fixture;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class NonConsoleCommand extends NotACommand
+{
+    public function execute(string $foo, string $bar)
+    {
+        return null;
+    }
+}
+
+class NotACommand {}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Rector\Console\ConsoleExecuteReturnIntRector\Fixture;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class NonConsoleCommand extends NotACommand
+{
+    public function execute(string $foo, string $bar)
+    {
+        return null;
+    }
+}
+
+class NotACommand {}
+
+?>


### PR DESCRIPTION
When using `ConsoleExecuteReturnIntRector` on a class with an `execute` method that not extends from `Command` it adds the `return 0` and adds `: int`.