### PR TITLE
FIX AddDoesNotPerformAssertionToNonAssertingTest

### DIFF
--- a/packages/PHPUnit/src/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector.php
+++ b/packages/PHPUnit/src/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector.php
@@ -283,6 +283,11 @@ PHP
                 return true;
             }
 
+            // setExpectException (deprecated method)
+            if ($this->isName($node->name, 'setExpectedException*')) {
+                return true;
+            }
+
             return false;
         });
     }

--- a/packages/PHPUnit/tests/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/keep_expected_exception.php.inc
+++ b/packages/PHPUnit/tests/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/keep_expected_exception.php.inc
@@ -18,4 +18,9 @@ class KeepExpectedException extends \PHPUnit\Framework\TestCase
         $this->expectException('Throwable');
         throw new InvalidArgumentException();
     }
+
+    public function testSetExpectedException()
+    {
+        $this->setExpectedException('Throwable');
+    }
 }


### PR DESCRIPTION
Fix bug where rector added @doesNotPerformAssertion when using `setExpectedException` 