### PR TITLE
ParamTypeDeclarationRector with [optional] tag behind variable name

### DIFF
--- a/packages/TypeDeclaration/tests/Rector/FunctionLike/ParamTypeDeclarationRector/Fixture/optional_tag_behind_variable_name.php.inc
+++ b/packages/TypeDeclaration/tests/Rector/FunctionLike/ParamTypeDeclarationRector/Fixture/optional_tag_behind_variable_name.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\TypeDeclaration\Tests\Rector\FunctionLike\ParamTypeDeclarationRector\Fixture;
+
+/**
+ * @var string $string[optional]
+ */
+function test($string = null){
+
+}
+
+?>
+-----
+<?php
+
+namespace Rector\TypeDeclaration\Tests\Rector\FunctionLike\ParamTypeDeclarationRector\Fixture;
+
+/**
+ * @var string $string[optional]
+ */
+function test(string $string = null){
+
+}
+
+?>
+

--- a/packages/TypeDeclaration/tests/Rector/FunctionLike/ParamTypeDeclarationRector/Fixture/optional_tag_behind_variable_name.php.inc
+++ b/packages/TypeDeclaration/tests/Rector/FunctionLike/ParamTypeDeclarationRector/Fixture/optional_tag_behind_variable_name.php.inc
@@ -3,7 +3,7 @@
 namespace Rector\TypeDeclaration\Tests\Rector\FunctionLike\ParamTypeDeclarationRector\Fixture;
 
 /**
- * @var string $string[optional]
+ * @param string $string[optional]
  */
 function test($string = null){
 
@@ -16,7 +16,7 @@ function test($string = null){
 namespace Rector\TypeDeclaration\Tests\Rector\FunctionLike\ParamTypeDeclarationRector\Fixture;
 
 /**
- * @var string $string[optional]
+ * @param string $string[optional]
  */
 function test(string $string = null){
 


### PR DESCRIPTION
Hi,

I saw an issue while using Rector in a project.

It seems that when there is a [optional] tag behind the variable name, the type is not added in the signature.

I couldn't launch the tests on my computer(I'm on windows and all my paths are broken).

So, I'm trying to add a failing test to show the issue on github. I will modify this PR if it doesn't fail the tests.

Thanks