### PR TITLE
Fix ECS for windows

### DIFF
--- a/ecs.yaml
+++ b/ecs.yaml
@@ -177,3 +177,5 @@ parameters:
 
         # conflicts with "PhpCsFixer\Fixer\Operator\NotOperatorWithSuccessorSpaceFixer"
         PhpCsFixer\Fixer\Operator\UnaryOperatorSpacesFixer: ~
+
+    line_ending: "\n"


### PR DESCRIPTION
I added a line feed parameter to ecs.yaml to enforce \n as line feed. It fixes the LineEndingFixer issue on windows.