### PR TITLE
Fixed issue with sed command:

### DIFF
--- a/ci/clean_trailing_spaces.sh
+++ b/ci/clean_trailing_spaces.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 # trailing whitespaces
-sed -i -E 's#\s+$##g' config/set/*/*.yaml docs/*.md README.md
+sed -i '' -E 's#\\s+$##g' config/set/*/*.yaml docs/*.md README.md

--- a/composer.json
+++ b/composer.json
@@ -199,8 +199,8 @@
             "changelog-linker cleanup"
         ],
         "check-docs": [
-            "bin/rector dump-rectors -o markdown | diff docs/AllRectorsOverview.md - ",
-            "bin/rector dump-nodes -o markdown | diff docs/NodesOverview.md - "
+            "bin/rector dump-rectors -o markdown | diff --ignore-space-change docs/AllRectorsOverview.md - ",
+            "bin/rector dump-nodes -o markdown | diff --ignore-space-change docs/NodesOverview.md - "
         ],
         "docs": [
             "bin/rector dump-rectors -o markdown > docs/AllRectorsOverview.md",


### PR DESCRIPTION
on macOs the -E option was taken as the argument of the -i option causing backups to be made with the addional extension -E.
also the backslash of the \s needed additional escaping