### PR TITLE
[PHPUnit 8.0] Add ReplaceAssertArraySubsetWithDmsPolyfillRector

### DIFF
--- a/config/set/phpunit/phpunit80-dms.yaml
+++ b/config/set/phpunit/phpunit80-dms.yaml
@@ -1,0 +1,2 @@
+services:
+    Rector\PHPUnit\Rector\MethodCall\ReplaceAssertArraySubsetRector: ~

--- a/packages/PHPUnit/src/Rector/MethodCall/ReplaceAssertArraySubsetWithDmsPolyfillRector.php
+++ b/packages/PHPUnit/src/Rector/MethodCall/ReplaceAssertArraySubsetWithDmsPolyfillRector.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use Rector\Rector\AbstractPHPUnitRector;
+use Rector\RectorDefinition\CodeSample;
+use Rector\RectorDefinition\RectorDefinition;
+
+/**
+ * @see https://github.com/sebastianbergmann/phpunit/issues/3494#issuecomment-480283612
+ */
+
+/**
+ * @see \Rector\PHPUnit\Tests\Rector\MethodCall\ReplaceAssertArraySubsetWithDmsPolyfillRector\ReplaceAssertArraySubsetWithDmsPolyfillRectorTest
+ */
+final class ReplaceAssertArraySubsetWithDmsPolyfillRector extends AbstractPHPUnitRector
+{
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition(
+            'Change assertArraySubset() to static call of DMS\PHPUnitExtensions\ArraySubset\Assert',
+            [
+                new CodeSample(
+                    <<<'PHP'
+use PHPUnit\Framework\TestCase;
+
+class SomeClass extends TestCase
+{
+    public function test()
+    {
+        self::assertArraySubset(['bar' => 0], ['bar' => '0'], true);
+
+        $this->assertArraySubset(['bar' => 0], ['bar' => '0'], true);
+    }
+}
+PHP
+,
+                    <<<'PHP'
+use PHPUnit\Framework\TestCase;
+
+class SomeClass extends TestCase
+{
+    public function test()
+    {
+        \DMS\PHPUnitExtensions\ArraySubset\Assert::assertArraySubset(['bar' => 0], ['bar' => '0'], true);
+
+        \DMS\PHPUnitExtensions\ArraySubset\Assert::assertArraySubset(['bar' => 0], ['bar' => '0'], true);
+    }
+}
+PHP
+
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class, StaticCall::class];
+    }
+
+    /**
+     * @param MethodCall|StaticCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isPHPUnitMethodName($node, 'assertArraySubset')) {
+            return null;
+        }
+
+        return $this->createStaticCall('DMS\PHPUnitExtensions\ArraySubset\Assert', 'assertArraySubset',
+            $node->args
+        );
+    }
+}

--- a/packages/PHPUnit/tests/Rector/MethodCall/ReplaceAssertArraySubsetWithDmsPolyfillRector/Fixture/fixture.php.inc
+++ b/packages/PHPUnit/tests/Rector/MethodCall/ReplaceAssertArraySubsetWithDmsPolyfillRector/Fixture/fixture.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\MethodCall\ReplaceAssertArraySubsetWithDmsPolyfillRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+class SomeClass extends TestCase
+{
+    public function test()
+    {
+        self::assertArraySubset(['bar' => 0], ['bar' => '0'], true);
+
+        $this->assertArraySubset(['bar' => 0], ['bar' => '0'], true);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\MethodCall\ReplaceAssertArraySubsetWithDmsPolyfillRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+class SomeClass extends TestCase
+{
+    public function test()
+    {
+        \DMS\PHPUnitExtensions\ArraySubset\Assert::assertArraySubset(['bar' => 0], ['bar' => '0'], true);
+
+        \DMS\PHPUnitExtensions\ArraySubset\Assert::assertArraySubset(['bar' => 0], ['bar' => '0'], true);
+    }
+}
+
+?>

--- a/packages/PHPUnit/tests/Rector/MethodCall/ReplaceAssertArraySubsetWithDmsPolyfillRector/ReplaceAssertArraySubsetWithDmsPolyfillRectorTest.php
+++ b/packages/PHPUnit/tests/Rector/MethodCall/ReplaceAssertArraySubsetWithDmsPolyfillRector/ReplaceAssertArraySubsetWithDmsPolyfillRectorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\Rector\MethodCall\ReplaceAssertArraySubsetWithDmsPolyfillRector;
+
+use Iterator;
+use Rector\PHPUnit\Rector\MethodCall\ReplaceAssertArraySubsetWithDmsPolyfillRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ReplaceAssertArraySubsetWithDmsPolyfillRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideDataForTest()
+     */
+    public function test(string $file): void
+    {
+        $this->doTestFile($file);
+    }
+
+    public function provideDataForTest(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    protected function getRectorClass(): string
+    {
+        return ReplaceAssertArraySubsetWithDmsPolyfillRector::class;
+    }
+}


### PR DESCRIPTION
Closes #2138 

## Do you miss `assertArraySubset` method in PHPUnit 8+?

We got you covered:

```bash
composer require --dev dms/phpunit-arraysubset-asserts
vendor/bin/rector process tests --set phpunit80-dms
```

## Instant Migration

```diff
 <?php

 use PHPUnit\Framework\TestCase;
+use DMS\PHPUnitExtensions\ArraySubset\Assert;

 final class SomeTest extends TestCase
 {
     public function testPreviouslyStaticCall(): void
     {
-        $this->assertArraySubset(['bar' => 0], ['bar' => '0'], true);
+        Assert::assertArraySubset(['bar' => 0], ['bar' => '0'], true);
     }
 }
```

:+1: 