### PR TITLE
[PHP 8.0] Add union types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -100,7 +100,8 @@
             "Rector\\Utils\\RectorGenerator\\": "utils/RectorGenerator/src",
             "Rector\\StrictCodeQuality\\": "packages/StrictCodeQuality/src",
             "Rector\\DynamicTypeAnalysis\\": "packages/DynamicTypeAnalysis/src",
-            "Rector\\PhpDeglobalize\\": "packages/PhpDeglobalize/src"
+            "Rector\\PhpDeglobalize\\": "packages/PhpDeglobalize/src",
+            "Rector\\Php80\\": "packages/Php80/src"
         }
     },
     "autoload-dev": {
@@ -157,7 +158,8 @@
             "Rector\\ZendToSymfony\\Tests\\": "packages/ZendToSymfony/tests",
             "Rector\\StrictCodeQuality\\Tests\\": "packages/StrictCodeQuality/tests",
             "Rector\\DynamicTypeAnalysis\\Tests\\": "packages/DynamicTypeAnalysis/tests",
-            "Rector\\PhpDeglobalize\\Tests\\": "packages/PhpDeglobalize/tests"
+            "Rector\\PhpDeglobalize\\Tests\\": "packages/PhpDeglobalize/tests",
+            "Rector\\Php80\\Tests\\": "packages/Php80/tests"
         },
         "classmap": [
             "packages/Symfony/tests/Rector/FrameworkBundle/AbstractToConstructorInjectionRectorSource",

--- a/packages/CodeQuality/tests/Rector/Class_/CompleteDynamicPropertiesRector/FixtureUnionTypes/multiple_types.php.inc
+++ b/packages/CodeQuality/tests/Rector/Class_/CompleteDynamicPropertiesRector/FixtureUnionTypes/multiple_types.php.inc
@@ -1,0 +1,36 @@
+<?php
+
+namespace Rector\CodeQuality\Tests\Rector\Class_\CompleteDynamicPropertiesRector\FixtureUnionTypes;
+
+class MultipleTypes
+{
+    public function set()
+    {
+        $this->value = 5;
+
+        $this->value = 'hey';
+
+        $this->value = false;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CodeQuality\Tests\Rector\Class_\CompleteDynamicPropertiesRector\FixtureUnionTypes;
+
+class MultipleTypes
+{
+    public int|string|bool $value;
+    public function set()
+    {
+        $this->value = 5;
+
+        $this->value = 'hey';
+
+        $this->value = false;
+    }
+}
+
+?>

--- a/packages/CodeQuality/tests/Rector/Class_/CompleteDynamicPropertiesRector/UnionTypeCompleteDynamicPropertiesRectorTest.php
+++ b/packages/CodeQuality/tests/Rector/Class_/CompleteDynamicPropertiesRector/UnionTypeCompleteDynamicPropertiesRectorTest.php
@@ -8,7 +8,7 @@ use Iterator;
 use Rector\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
-final class CompleteDynamicPropertiesRectorTest extends AbstractRectorTestCase
+final class UnionTypeCompleteDynamicPropertiesRectorTest extends AbstractRectorTestCase
 {
     /**
      * @dataProvider provideDataForTest()
@@ -20,17 +20,11 @@ final class CompleteDynamicPropertiesRectorTest extends AbstractRectorTestCase
 
     public function provideDataForTest(): Iterator
     {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+        return $this->yieldFilesFromDirectory(__DIR__ . '/FixtureUnionTypes');
     }
 
     protected function getRectorClass(): string
     {
         return CompleteDynamicPropertiesRector::class;
-    }
-
-    protected function getPhpVersion(): string
-    {
-        // prevents union types
-        return '7.4';
     }
 }

--- a/packages/Php74/src/Rector/Property/TypedPropertyRector.php
+++ b/packages/Php74/src/Rector/Property/TypedPropertyRector.php
@@ -36,19 +36,19 @@ final class TypedPropertyRector extends AbstractRector
             [
                 new CodeSample(
                     <<<'PHP'
-final class SomeClass 
+final class SomeClass
 {
-    /** 
-     * @var int 
+    /**
+     * @var int
      */
-    private count; 
+    private count;
 }
 PHP
                     ,
                     <<<'PHP'
-final class SomeClass 
+final class SomeClass
 {
-    private int count; 
+    private int count;
 }
 PHP
                 ),

--- a/packages/Php74/tests/Rector/Property/TypedPropertyRector/FixtureUnionTypes/two_types.php.inc
+++ b/packages/Php74/tests/Rector/Property/TypedPropertyRector/FixtureUnionTypes/two_types.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\FixtureUnionTypes;
+
+final class TwoTypes
+{
+    /**
+     * @var bool|string
+     */
+    private $unionValue;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\FixtureUnionTypes;
+
+final class TwoTypes
+{
+    /**
+     * @var bool|string
+     */
+    private bool|string $unionValue;
+}
+
+?>

--- a/packages/Php74/tests/Rector/Property/TypedPropertyRector/UnionTypedPropertyRectorTest.php
+++ b/packages/Php74/tests/Rector/Property/TypedPropertyRector/UnionTypedPropertyRectorTest.php
@@ -2,13 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Rector\TypeDeclaration\Tests\Rector\FunctionLike\ParamTypeDeclarationRector;
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector;
 
 use Iterator;
+use Rector\Php74\Rector\Property\TypedPropertyRector;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
-use Rector\TypeDeclaration\Rector\FunctionLike\ParamTypeDeclarationRector;
+use Rector\ValueObject\PhpVersionFeature;
 
-final class ParamTypeDeclarationRectorTest extends AbstractRectorTestCase
+final class UnionTypedPropertyRectorTest extends AbstractRectorTestCase
 {
     /**
      * @dataProvider provideDataForTest()
@@ -20,17 +21,16 @@ final class ParamTypeDeclarationRectorTest extends AbstractRectorTestCase
 
     public function provideDataForTest(): Iterator
     {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+        return $this->yieldFilesFromDirectory(__DIR__ . '/FixtureUnionTypes');
     }
 
     protected function getRectorClass(): string
     {
-        return ParamTypeDeclarationRector::class;
+        return TypedPropertyRector::class;
     }
 
     protected function getPhpVersion(): string
     {
-        // prevent union types
-        return '7.4';
+        return PhpVersionFeature::UNION_TYPES;
     }
 }

--- a/packages/Php80/src/Rector/FunctionLike/UnionTypesRector.php
+++ b/packages/Php80/src/Rector/FunctionLike/UnionTypesRector.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Php80\Rector\FunctionLike;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\UnionType as PhpParserUnionType;
+use PHPStan\Type\UnionType;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\Rector\AbstractRector;
+use Rector\RectorDefinition\CodeSample;
+use Rector\RectorDefinition\RectorDefinition;
+
+/**
+ * @see \Rector\Php80\Tests\Rector\FunctionLike\UnionTypesRector\UnionTypesRectorTest
+ */
+final class UnionTypesRector extends AbstractRector
+{
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition(
+            'Change docs types to union types, where possible (properties are covered by TypedPropertiesRector)',
+            [
+                new CodeSample(
+                    <<<'PHP'
+class SomeClass {
+    /**
+     * @param array|int $number
+     * @return bool|float
+     */
+    public function go($number)
+    {
+    }
+}
+PHP
+,
+                    <<<'PHP'
+class SomeClass {
+    /**
+     * @param array|int $number
+     * @return bool|float
+     */
+    public function go(array|int $number): bool|float
+    {
+    }
+}
+PHP
+
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [FunctionLike::class];
+    }
+
+    /**
+     * @param ClassMethod|Function_|Node\Expr\Closure|ArrowFunction $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $phpDocInfo = $this->getPhpDocInfo($node);
+        if ($phpDocInfo === null) {
+            return null;
+        }
+
+        $this->refactorParamTypes($node, $phpDocInfo);
+        $this->refactorReturnType($node, $phpDocInfo);
+
+        return $node;
+    }
+
+    /**
+     * @param ClassMethod|Function_|Node\Expr\Closure|ArrowFunction $functionLike
+     */
+    private function refactorReturnType(FunctionLike $functionLike, PhpDocInfo $phpDocInfo): void
+    {
+        // do not override existing return type
+        if ($functionLike->getReturnType() !== null) {
+            return;
+        }
+
+        $returnType = $phpDocInfo->getReturnType();
+        if (! $returnType instanceof UnionType) {
+            return;
+        }
+
+        $phpParserUnionType = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($returnType);
+        if (! $phpParserUnionType instanceof PhpParserUnionType) {
+            return;
+        }
+
+        $functionLike->returnType = $phpParserUnionType;
+    }
+
+    /**
+     * @param ClassMethod|Function_|Node\Expr\Closure|ArrowFunction $functionLike
+     */
+    private function refactorParamTypes(FunctionLike $functionLike, PhpDocInfo $phpDocInfo): void
+    {
+        foreach ($functionLike->params as $param) {
+            if ($param->type !== null) {
+                continue;
+            }
+
+            /** @var string $paramName */
+            $paramName = $this->getName($param->var);
+            $paramType = $phpDocInfo->getParamType($paramName);
+            if (! $paramType instanceof UnionType) {
+                continue;
+            }
+
+            $phpParserUnionType = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($paramType);
+            if (! $phpParserUnionType instanceof PhpParserUnionType) {
+                continue;
+            }
+
+            $param->type = $phpParserUnionType;
+        }
+    }
+}

--- a/packages/Php80/tests/Rector/FunctionLike/UnionTypesRector/Fixture/fixture.php.inc
+++ b/packages/Php80/tests/Rector/FunctionLike/UnionTypesRector/Fixture/fixture.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Php80\Tests\Rector\FunctionLike\UnionTypesRector\Fixture;
+
+class SomeClass {
+    /**
+     * @param array|int $number
+     * @return bool|float
+     */
+    public function go($number)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Php80\Tests\Rector\FunctionLike\UnionTypesRector\Fixture;
+
+class SomeClass {
+    /**
+     * @param array|int $number
+     * @return bool|float
+     */
+    public function go(array|int $number): bool|float
+    {
+    }
+}
+
+?>

--- a/packages/Php80/tests/Rector/FunctionLike/UnionTypesRector/UnionTypesRectorTest.php
+++ b/packages/Php80/tests/Rector/FunctionLike/UnionTypesRector/UnionTypesRectorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Php80\Tests\Rector\FunctionLike\UnionTypesRector;
+
+use Iterator;
+use Rector\Php80\Rector\FunctionLike\UnionTypesRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class UnionTypesRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideDataForTest()
+     */
+    public function test(string $file): void
+    {
+        $this->doTestFile($file);
+    }
+
+    public function provideDataForTest(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    protected function getRectorClass(): string
+    {
+        return UnionTypesRector::class;
+    }
+}

--- a/packages/TypeDeclaration/src/Rector/FunctionLike/AbstractTypeDeclarationRector.php
+++ b/packages/TypeDeclaration/src/Rector/FunctionLike/AbstractTypeDeclarationRector.php
@@ -167,7 +167,7 @@ abstract class AbstractTypeDeclarationRector extends AbstractRector
     }
 
     /**
-     * @return Name|NullableType|Identifier|null
+     * @return Name|NullableType|Identifier|UnionType|null
      */
     protected function resolveChildTypeNode(Type $type): ?Node
     {

--- a/packages/TypeDeclaration/tests/Rector/ClassMethod/AddMethodCallBasedParamTypeRector/AddMethodCallBasedParamTypeRectorTest.php
+++ b/packages/TypeDeclaration/tests/Rector/ClassMethod/AddMethodCallBasedParamTypeRector/AddMethodCallBasedParamTypeRectorTest.php
@@ -27,4 +27,10 @@ final class AddMethodCallBasedParamTypeRectorTest extends AbstractRectorTestCase
     {
         return AddMethodCallBasedParamTypeRector::class;
     }
+
+    protected function getPhpVersion(): string
+    {
+        // prevents union types
+        return '7.4';
+    }
 }

--- a/packages/TypeDeclaration/tests/Rector/Closure/AddClosureReturnTypeRector/AddClosureReturnTypeRectorTest.php
+++ b/packages/TypeDeclaration/tests/Rector/Closure/AddClosureReturnTypeRector/AddClosureReturnTypeRectorTest.php
@@ -27,4 +27,10 @@ final class AddClosureReturnTypeRectorTest extends AbstractRectorTestCase
     {
         return AddClosureReturnTypeRector::class;
     }
+
+    protected function getPhpVersion(): string
+    {
+        // prevent union types
+        return '7.4';
+    }
 }

--- a/packages/TypeDeclaration/tests/Rector/FunctionLike/ParamTypeDeclarationRector/Fixture/undesired.php.inc
+++ b/packages/TypeDeclaration/tests/Rector/FunctionLike/ParamTypeDeclarationRector/Fixture/undesired.php.inc
@@ -9,6 +9,7 @@ namespace Rector\TypeDeclaration\Tests\Rector\ClassMethod\ParamTypeDeclarationRe
  */
 function someFunction($a, $b, $c) {
 }
+
 ?>
 -----
 <?php
@@ -22,4 +23,5 @@ namespace Rector\TypeDeclaration\Tests\Rector\ClassMethod\ParamTypeDeclarationRe
  */
 function someFunction($a, int $b, $c) {
 }
+
 ?>

--- a/packages/TypeDeclaration/tests/Rector/FunctionLike/ParamTypeDeclarationRector/FixtureUnionType/undesired.php.inc
+++ b/packages/TypeDeclaration/tests/Rector/FunctionLike/ParamTypeDeclarationRector/FixtureUnionType/undesired.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\TypeDeclaration\Tests\Rector\ClassMethod\ParamTypeDeclarationRector\FixtureUnionType;
+
+/**
+ * @param real|int $a
+ * @param int $b
+ * @param int|void $c
+ */
+function someFunction($a, $b, $c) {
+}
+
+?>
+-----
+<?php
+
+namespace Rector\TypeDeclaration\Tests\Rector\ClassMethod\ParamTypeDeclarationRector\FixtureUnionType;
+
+/**
+ * @param real|int $a
+ * @param int $b
+ * @param int|void $c
+ */
+function someFunction(float|int $a, int $b, int|void $c) {
+}
+
+?>

--- a/packages/TypeDeclaration/tests/Rector/FunctionLike/ParamTypeDeclarationRector/UnionTypeParamTypeDeclarationRectorTest.php
+++ b/packages/TypeDeclaration/tests/Rector/FunctionLike/ParamTypeDeclarationRector/UnionTypeParamTypeDeclarationRectorTest.php
@@ -8,7 +8,7 @@ use Iterator;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 use Rector\TypeDeclaration\Rector\FunctionLike\ParamTypeDeclarationRector;
 
-final class ParamTypeDeclarationRectorTest extends AbstractRectorTestCase
+final class UnionTypeParamTypeDeclarationRectorTest extends AbstractRectorTestCase
 {
     /**
      * @dataProvider provideDataForTest()
@@ -20,17 +20,11 @@ final class ParamTypeDeclarationRectorTest extends AbstractRectorTestCase
 
     public function provideDataForTest(): Iterator
     {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+        return $this->yieldFilesFromDirectory(__DIR__ . '/FixtureUnionType');
     }
 
     protected function getRectorClass(): string
     {
         return ParamTypeDeclarationRector::class;
-    }
-
-    protected function getPhpVersion(): string
-    {
-        // prevent union types
-        return '7.4';
     }
 }

--- a/packages/TypeDeclaration/tests/Rector/FunctionLike/ReturnTypeDeclarationRector/CorrectionTest.php
+++ b/packages/TypeDeclaration/tests/Rector/FunctionLike/ReturnTypeDeclarationRector/CorrectionTest.php
@@ -27,4 +27,10 @@ final class CorrectionTest extends AbstractRectorTestCase
     {
         return ReturnTypeDeclarationRector::class;
     }
+
+    protected function getPhpVersion(): string
+    {
+        // to prevent union types
+        return '7.4';
+    }
 }

--- a/packages/TypeDeclaration/tests/Rector/FunctionLike/ReturnTypeDeclarationRector/ReturnTypeDeclarationRectorTest.php
+++ b/packages/TypeDeclaration/tests/Rector/FunctionLike/ReturnTypeDeclarationRector/ReturnTypeDeclarationRectorTest.php
@@ -27,4 +27,10 @@ final class ReturnTypeDeclarationRectorTest extends AbstractRectorTestCase
     {
         return ReturnTypeDeclarationRector::class;
     }
+
+    protected function getPhpVersion(): string
+    {
+        // to prevent union types
+        return '7.4';
+    }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -224,3 +224,5 @@ parameters:
 
         # known value
         - '#Parameter \#1 \$name of method Rector\\CodingStyle\\Naming\\ClassNaming\:\:getShortName\(\) expects PhpParser\\Node\\Identifier\|PhpParser\\Node\\Name\|string, PhpParser\\Node\\Identifier\|null given#'
+
+        - '#Parameter \#1 \$type of method PhpParser\\Builder\\Param\:\:setType\(\) expects PhpParser\\Node\\Name\|PhpParser\\Node\\NullableType\|string, PhpParser\\Node\\Identifier\|PhpParser\\Node\\Name\|PhpParser\\Node\\NullableType\|PhpParser\\Node\\UnionType given#'

--- a/src/ValueObject/PhpVersionFeature.php
+++ b/src/ValueObject/PhpVersionFeature.php
@@ -35,4 +35,9 @@ final class PhpVersionFeature
      * @var string
      */
     public const OBJECT_TYPE = '7.2';
+
+    /**
+     * @var string
+     */
+    public const UNION_TYPES = '8.0';
 }

--- a/utils/RectorGenerator/src/Configuration/ConfigurationFactory.php
+++ b/utils/RectorGenerator/src/Configuration/ConfigurationFactory.php
@@ -7,6 +7,7 @@ namespace Rector\Utils\RectorGenerator\Configuration;
 use Nette\Utils\Strings;
 use PhpParser\Node;
 use Rector\Exception\FileSystem\FileNotFoundException;
+use Rector\Exception\ShouldNotHappenException;
 use Rector\Set\Set;
 use Rector\Utils\RectorGenerator\Exception\ConfigurationException;
 use Rector\Utils\RectorGenerator\Node\NodeClassProvider;
@@ -114,6 +115,8 @@ final class ConfigurationFactory
                     continue 2;
                 }
             }
+
+            throw new ShouldNotHappenException(sprintf('Node endings with "%s" was not found', $nodeType));
         }
 
         return array_unique($fqnNodeTypes);


### PR DESCRIPTION
Closes #2290

```diff
 <?php

 class SomeClass
 {
-    /**
-     * @param array|int $number
-     * @return bool|float
-     */
-    public function go($number)
+    public function go(array|int $number): bool|float
     {
     }
 }
```
