### PR TITLE
Add diff based execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,13 @@ parameters:
     auto_import_names: false
 ```
 
+### Limit Execution to Changed Files
+
+Execution can be limited to changed files using the `process` option `--must-match-git-diff`.
+This option will filter the files included by the configuration, creating an intersection with the files listed in `git diff`.
+
+This option is useful in CI.
+
 ## 3 Steps to Create Your Own Rector
 
 First, make sure it's not covered by [any existing Rectors](/docs/AllRectorsOverview.md).

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -45,12 +45,18 @@ final class Configuration
     private $areAnyPhpRectorsLoaded = false;
 
     /**
+     * @var bool
+     */
+    private $mustMatchGitDiff = false;
+
+    /**
      * Needs to run in the start of the life cycle, since the rest of workflow uses it.
      */
     public function resolveFromInput(InputInterface $input): void
     {
         $this->isDryRun = (bool) $input->getOption(Option::OPTION_DRY_RUN);
         $this->hideAutoloadErrors = (bool) $input->getOption(Option::HIDE_AUTOLOAD_ERRORS);
+        $this->mustMatchGitDiff = (bool) $input->getOption(Option::MUST_MATCH_GIT_DIFF);
         $this->showProgressBar = $this->canShowProgressBar($input);
 
         $this->setRule($input->getOption(Option::OPTION_RULE));
@@ -113,6 +119,11 @@ final class Configuration
     public function setAreAnyPhpRectorsLoaded(bool $areAnyPhpRectorsLoaded): void
     {
         $this->areAnyPhpRectorsLoaded = $areAnyPhpRectorsLoaded;
+    }
+
+    public function mustMatchGitDiff(): bool
+    {
+        return $this->mustMatchGitDiff;
     }
 
     private function canShowProgressBar(InputInterface $input): bool

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -65,4 +65,9 @@ final class Option
      * @var string
      */
     public const EXCLUDE_RECTORS_PARAMETER = 'exclude_rectors';
+
+    /**
+     * @var string
+     */
+    public const MUST_MATCH_GIT_DIFF = 'must-match-git-diff';
 }

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -177,7 +177,11 @@ final class ProcessCommand extends AbstractCommand
 
         $source = $this->resolvesSourcePaths($input);
 
-        $phpFileInfos = $this->filesFinder->findInDirectoriesAndFiles($source, $this->fileExtensions);
+        $phpFileInfos = $this->filesFinder->findInDirectoriesAndFiles(
+            $source,
+            $this->fileExtensions,
+            $this->configuration->mustMatchGitDiff()
+        );
 
         $this->additionalAutoloader->autoloadWithInputAndSource($input, $source);
 

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -148,6 +148,13 @@ final class ProcessCommand extends AbstractCommand
             'Hide autoload errors for the moment.'
         );
 
+        $this->addOption(
+            Option::MUST_MATCH_GIT_DIFF,
+            null,
+            InputOption::VALUE_NONE,
+            'Execute only on file matching the git diff.'
+        );
+
         $this->addOption(Option::OPTION_RULE, 'r', InputOption::VALUE_REQUIRED, 'Run only this single rule.');
 
         $availableOutputFormatters = $this->outputFormatterCollector->getNames();


### PR DESCRIPTION
This pull request adds the option `--must-match-git-diff` to the process command, this is useful for both local and CI execution.

It should be compatible with the rest of the configuration because creates an intersection with the `git diff` output.