### PR TITLE
[Symfony] Fix ConsoleExecuteReturnInt for nested functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ phpstan-paths.txt
 /laravel-dir
 
 uuid-migration.json
+
+# compiler
+/compiler/composer.lock
+/compiler/vendor
+/tmp

--- a/packages/Symfony/tests/Rector/Console/ConsoleExecuteReturnIntRector/Fixture/skip_function_nested_return.php.inc
+++ b/packages/Symfony/tests/Rector/Console/ConsoleExecuteReturnIntRector/Fixture/skip_function_nested_return.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\Console\ConsoleExecuteReturnIntRector\Fixture;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class SkipFunctionNestedReturn extends Command
+{
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        function go() {
+            return null;
+        }
+
+        return 0;
+    }
+}

--- a/packages/Symfony/tests/Rector/Console/ConsoleExecuteReturnIntRector/Fixture/skip_nested_return.php.inc
+++ b/packages/Symfony/tests/Rector/Console/ConsoleExecuteReturnIntRector/Fixture/skip_nested_return.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\Console\ConsoleExecuteReturnIntRector\Fixture;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class SkipNestedReturn extends Command
+{
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        array_filter([0, 1], function ($a, $b) {
+            return false;
+        });
+
+        return 1;
+    }
+}


### PR DESCRIPTION
Closes #2365