### PR TITLE
chore: use php 7.4 cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY stubs stubs
 RUN  composer install --no-dev --optimize-autoloader --prefer-dist
 
 
-FROM php:7.3-cli
+FROM php:7.4-cli
 WORKDIR /rector
 
 COPY . .


### PR DESCRIPTION
This PR uses PHP 7..4 in the docker image. Otherwise after using (for example) `Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector`, rector will be unable to process the changed files.

```
[ERROR] Could not process
"/project/MyClass.php" file, due to:
"Analyze error: "ParseError (syntax error, unexpected '=>'
(T_DOUBLE_ARROW), expecting ')') thrown while autoloading class
MyClass.". Include your files in
"parameters > autoload_paths".
See https://github.com/rectorphp/rector#extra-autoloading".
```