### PR TITLE
Exludes stubs on package install to prevent PHPStorm confussion

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -29,3 +29,4 @@ phpstan.neon export-ignore
 phpunit.xml export-ignore
 rector.yaml export-ignore
 utils export-ignore
+stubs export-ignore

--- a/src/PhpParser/Node/Manipulator/PropertyManipulator.php
+++ b/src/PhpParser/Node/Manipulator/PropertyManipulator.php
@@ -151,12 +151,14 @@ final class PropertyManipulator
         return $this->getProperty($propertyProperty)->isPrivate();
     }
 
-    protected function getProperty(PropertyProperty $propertyProperty): Property
+    private function getProperty(PropertyProperty $propertyProperty): Property
     {
         $property = $propertyProperty->getAttribute(AttributeKey::PARENT_NODE);
+
         if (! $property instanceof Property) {
             throw new ShouldNotHappenException('PropertyProperty should always have Property as parent');
         }
+
         return $property;
     }
 

--- a/src/Stubs/StubLoader.php
+++ b/src/Stubs/StubLoader.php
@@ -25,6 +25,12 @@ final class StubLoader
 
         $stubDirectory = __DIR__ . '/../../stubs';
 
+        // stubs might not exists on composer install, to prevent PHPStorm duplicated confusion
+        // @see https://github.com/rectorphp/rector/issues/1899
+        if (! file_exists($stubDirectory)) {
+            return;
+        }
+
         $robotLoader = new RobotLoader();
         $robotLoader->addDirectory($stubDirectory);
         $robotLoader->setTempDirectory(sys_get_temp_dir() . '/_rector_stubs');


### PR DESCRIPTION
Closes #1899

cc @gnutix

In the end, I come to conclussion it's better to have PHPStorm 100 % working and one PHPUnit migration with extra class, rather then the other way.

Thanks for your feedback