### PR TITLE
Fix - iterable type introduced in PHP 7.1

### DIFF
--- a/src/ValueObject/PhpVersionFeature.php
+++ b/src/ValueObject/PhpVersionFeature.php
@@ -19,12 +19,12 @@ final class PhpVersionFeature
     /**
      * @var string
      */
-    public const ITERABLE_TYPE = '7.0';
+    public const SPACESHIP = '7.0';
 
     /**
      * @var string
      */
-    public const SPACESHIP = '7.0';
+    public const ITERABLE_TYPE = '7.1';
 
     /**
      * @var string


### PR DESCRIPTION
Iterable type hint was introduced in PHP 7.1
https://www.php.net/manual/en/language.types.iterable.php