### PR TITLE
Add test case for removing paranthesis in TernaryToElvisRector

### DIFF
--- a/packages/Php53/tests/Rector/Ternary/TernaryToElvisRector/Fixture/parenthesis.php.inc
+++ b/packages/Php53/tests/Rector/Ternary/TernaryToElvisRector/Fixture/parenthesis.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+function elvisRemoveParenthesis()
+{
+    $value = ($a - $b) ? ($a - $b) : $c;
+}
+
+?>
+-----
+<?php
+
+function elvisRemoveParenthesis()
+{
+    $value = ($a - $b) ?: $c;
+}
+
+?>

--- a/src/Rector/New_/NewToStaticCallRector.php
+++ b/src/Rector/New_/NewToStaticCallRector.php
@@ -53,7 +53,7 @@ class SomeClass
 PHP
                 ,
                 [
-                    'Cookie' => [['Cookie', 'create']],
+                    'Cookie' => ['Cookie', 'create'],
                 ]
             ),
         ]);


### PR DESCRIPTION
Add test case for removing paranthesis when replacing ternary operator with elvis operator