### PR TITLE
Added int to StaticTypeMapper

### DIFF
--- a/packages/NodeTypeResolver/src/StaticTypeMapper.php
+++ b/packages/NodeTypeResolver/src/StaticTypeMapper.php
@@ -512,6 +512,10 @@ final class StaticTypeMapper
             return new Identifier('string');
         }
 
+        if ($type === 'int') {
+            return new Identifier('int');
+        }
+
         if ($type === 'array') {
             return new Identifier('array');
         }


### PR DESCRIPTION
I've got this error
```
In StaticTypeMapper.php line 543:
                                                                                
  [Rector\Exception\NotImplementedException]                                    
  Rector\NodeTypeResolver\StaticTypeMapper::mapStringToPhpParserNode for "int"
```
when applying rule:
```
Rector\Rector\Typehint\ParentTypehintedArgumentRector:
    Nette\Forms\Container:
        addSelect:
            $size: 'int'
```