### PR TITLE
Fix codesample in TypedPropertyRector

### DIFF
--- a/packages/Php74/src/Rector/Property/TypedPropertyRector.php
+++ b/packages/Php74/src/Rector/Property/TypedPropertyRector.php
@@ -49,6 +49,9 @@ PHP
                     <<<'PHP'
 final class SomeClass
 {
+    /**
+     * @var int
+     */
     private int count;
 }
 PHP


### PR DESCRIPTION
This rector does not remove the PHPDoc.