### PR TITLE
[docs] Fix codesample in TypedPropertyRector

### DIFF
--- a/docs/AllRectorsOverview.md
+++ b/docs/AllRectorsOverview.md
@@ -5733,9 +5733,9 @@ Changes property `@var` annotations from annotation to type.
 ```diff
  final class SomeClass
  {
--    /**
--     * @var int
--     */
+     /**
+      * @var int
+      */
 -    private count;
 +    private int count;
  }


### PR DESCRIPTION
This rector does not remove the PHPDoc.