### PR TITLE
Do not suggest typed property when defined in vendored parent

### DIFF
--- a/packages/Php74/src/Rector/Property/TypedPropertyRector.php
+++ b/packages/Php74/src/Rector/Property/TypedPropertyRector.php
@@ -11,6 +11,7 @@ use Rector\Rector\AbstractRector;
 use Rector\RectorDefinition\CodeSample;
 use Rector\RectorDefinition\RectorDefinition;
 use Rector\TypeDeclaration\TypeInferer\PropertyTypeInferer;
+use Rector\TypeDeclaration\VendorLock\VendorLockResolver;
 use Rector\ValueObject\PhpVersionFeature;
 
 /**
@@ -25,9 +26,15 @@ final class TypedPropertyRector extends AbstractRector
      */
     private $propertyTypeInferer;
 
-    public function __construct(PropertyTypeInferer $propertyTypeInferer)
+    /**
+     * @var VendorLockResolver
+     */
+    private $vendorLockResolver;
+
+    public function __construct(PropertyTypeInferer $propertyTypeInferer, VendorLockResolver $vendorLockResolver)
     {
         $this->propertyTypeInferer = $propertyTypeInferer;
+        $this->vendorLockResolver = $vendorLockResolver;
     }
 
     public function getDefinition(): RectorDefinition
@@ -89,6 +96,10 @@ PHP
 
         $propertyTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($varType, 'property');
         if ($propertyTypeNode === null) {
+            return null;
+        }
+
+        if ($this->vendorLockResolver->isPropertyChangeVendorLockedIn($node)) {
             return null;
         }
 

--- a/packages/Php74/tests/Rector/Property/TypedPropertyRector/Fixture/parent_has_untyped_property.php.inc
+++ b/packages/Php74/tests/Rector/Property/TypedPropertyRector/Fixture/parent_has_untyped_property.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
+
+use Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Source\SomeParent;
+
+final class Child extends SomeParent
+{
+    /**
+     * @var string
+     */
+    protected $name = 'child';
+
+    /**
+     * @var string
+     */
+    protected string $typedName = 'child';
+}
+
+?>

--- a/packages/Php74/tests/Rector/Property/TypedPropertyRector/Fixture/parent_of_parent_has_untyped_property.php.inc
+++ b/packages/Php74/tests/Rector/Property/TypedPropertyRector/Fixture/parent_of_parent_has_untyped_property.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
+
+use Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Source\SomeParent;
+
+abstract class Middle extends SomeParent
+{
+}
+
+final class Child2 extends Middle
+{
+    /**
+     * @var string
+     */
+    protected $name = 'child';
+
+    /**
+     * @var string
+     */
+    protected string $typedName = 'child';
+}
+
+?>

--- a/packages/Php74/tests/Rector/Property/TypedPropertyRector/Source/SomeParent.php
+++ b/packages/Php74/tests/Rector/Property/TypedPropertyRector/Source/SomeParent.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Source;
+
+abstract class SomeParent
+{
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var string
+     */
+    protected string $typedName;
+}

--- a/packages/Php74/tests/Rector/Property/TypedPropertyRector/TypedPropertyRectorTest.php
+++ b/packages/Php74/tests/Rector/Property/TypedPropertyRector/TypedPropertyRectorTest.php
@@ -11,6 +11,7 @@ use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 final class TypedPropertyRectorTest extends AbstractRectorTestCase
 {
     /**
+     * @requires PHP >= 7.4
      * @dataProvider provideDataForTest()
      */
     public function test(string $file): void


### PR DESCRIPTION
When the property is defined in vendored code, it doesn't make sense to suggest typed properties on classes that extend from it.

Fixes https://github.com/rectorphp/rector/issues/2506