### PR TITLE
[PHP 7.4] Add @var removal to TypedPropertyRector

### DIFF
--- a/packages/NodeTypeResolver/src/StaticTypeMapper.php
+++ b/packages/NodeTypeResolver/src/StaticTypeMapper.php
@@ -554,6 +554,13 @@ final class StaticTypeMapper
         throw new NotImplementedException(sprintf('%s for "%s"', __METHOD__, $type));
     }
 
+    public function mapPHPStanPhpDocTypeNodeToPhpDocString(TypeNode $typeNode, Node $node): string
+    {
+        $phpStanType = $this->mapPHPStanPhpDocTypeNodeToPHPStanType($typeNode, $node);
+
+        return $this->mapPHPStanTypeToDocString($phpStanType);
+    }
+
     public function mapPHPStanPhpDocTypeNodeToPHPStanType(TypeNode $typeNode, Node $node): Type
     {
         if ($typeNode instanceof IdentifierTypeNode) {

--- a/packages/NodeTypeResolver/src/StaticTypeMapper.php
+++ b/packages/NodeTypeResolver/src/StaticTypeMapper.php
@@ -662,6 +662,10 @@ final class StaticTypeMapper
                         return new ArrayType(new MixedType(), $genericType);
                     }
 
+                    if ($typeName === 'Traversable') {
+                        return new ObjectType('Traversable');
+                    }
+
                     return new IterableType(new MixedType(), $genericType);
                 }
             }

--- a/packages/NodeTypeResolver/src/StaticTypeMapper.php
+++ b/packages/NodeTypeResolver/src/StaticTypeMapper.php
@@ -31,6 +31,7 @@ use PHPStan\Type\CallableType;
 use PHPStan\Type\ClosureType;
 use PHPStan\Type\ConstantType;
 use PHPStan\Type\FloatType;
+use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\IterableType;
@@ -645,7 +646,11 @@ final class StaticTypeMapper
         if ($typeNode instanceof GenericTypeNode) {
             if ($typeNode->type instanceof IdentifierTypeNode) {
                 $typeName = $typeNode->type->name;
-                if (in_array($typeName, ['array', 'iterable'], true)) {
+
+                // remove extra prefix
+                $typeName = ltrim($typeName, '\\');
+
+                if (in_array($typeName, ['array', 'iterable', 'Traversable'], true)) {
                     $genericTypes = [];
                     foreach ($typeNode->genericTypes as $genericTypeNode) {
                         $genericTypes[] = $this->mapPHPStanPhpDocTypeNodeToPHPStanType($genericTypeNode, $node);
@@ -660,6 +665,20 @@ final class StaticTypeMapper
                     return new IterableType(new MixedType(), $genericType);
                 }
             }
+
+            $mainType = $this->mapPHPStanPhpDocTypeNodeToPHPStanType($typeNode->type, $node);
+            if ($mainType instanceof TypeWithClassName) {
+                $className = $mainType->getClassName();
+            } else {
+                throw new NotImplementedException();
+            }
+
+            $genericTypes = [];
+            foreach ($typeNode->genericTypes as $genericType) {
+                $genericTypes[] = $this->mapPHPStanPhpDocTypeNodeToPHPStanType($genericType, $node);
+            }
+
+            return new GenericObjectType($className, $genericTypes);
         }
 
         throw new NotImplementedException(__METHOD__ . ' for ' . get_class($typeNode));

--- a/packages/Php74/src/Rector/Property/TypedPropertyRector.php
+++ b/packages/Php74/src/Rector/Property/TypedPropertyRector.php
@@ -9,7 +9,6 @@ use PhpParser\Node\Stmt\Property;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
-use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\Type\MixedType;
 use Rector\Rector\AbstractRector;
 use Rector\RectorDefinition\CodeSample;
@@ -129,6 +128,11 @@ PHP
             return;
         }
 
+        // keep generic types
+        if ($varTagValueNode->type instanceof GenericTypeNode) {
+            return;
+        }
+
         // keep string[] etc.
         if ($this->isNonBasicArrayType($property, $varTagValueNode)) {
             return;
@@ -140,7 +144,7 @@ PHP
 
     private function isNonBasicArrayType(Property $property, VarTagValueNode $varTagValueNode): bool
     {
-        if (! $this->isArrayGenericTypeNode($varTagValueNode) && ! $this->isArrayTypeNode($varTagValueNode)) {
+        if (! $this->isArrayTypeNode($varTagValueNode)) {
             return false;
         }
 
@@ -150,19 +154,6 @@ PHP
         );
 
         return $varTypeDocString !== 'array';
-    }
-
-    private function isArrayGenericTypeNode(VarTagValueNode $varTagValueNode): bool
-    {
-        if (! $varTagValueNode->type instanceof GenericTypeNode) {
-            return false;
-        }
-
-        if (! $varTagValueNode->type->type instanceof IdentifierTypeNode) {
-            return false;
-        }
-
-        return $varTagValueNode->type->type->name === 'array';
     }
 
     private function isArrayTypeNode(VarTagValueNode $varTagValueNode): bool

--- a/packages/Php74/src/Rector/Property/TypedPropertyRector.php
+++ b/packages/Php74/src/Rector/Property/TypedPropertyRector.php
@@ -6,6 +6,7 @@ namespace Rector\Php74\Rector\Property;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Property;
+use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
 use PHPStan\Type\MixedType;
 use Rector\Rector\AbstractRector;
 use Rector\RectorDefinition\CodeSample;
@@ -56,9 +57,6 @@ PHP
                     <<<'PHP'
 final class SomeClass
 {
-    /**
-     * @var int
-     */
     private int count;
 }
 PHP
@@ -103,8 +101,32 @@ PHP
             return null;
         }
 
+        $this->removeVarPhpTagValueNodeIfNotComment($node);
+
         $node->type = $propertyTypeNode;
 
         return $node;
+    }
+
+    private function removeVarPhpTagValueNodeIfNotComment(Property $property): void
+    {
+        $propertyPhpDocInfo = $this->getPhpDocInfo($property);
+        // nothing to remove
+        if ($propertyPhpDocInfo === null) {
+            return;
+        }
+
+        $varTagValueNode = $propertyPhpDocInfo->getByType(VarTagValueNode::class);
+        if ($varTagValueNode === null) {
+            return;
+        }
+
+        // has description? keep it
+        if ($varTagValueNode->description !== '') {
+            return;
+        }
+
+        $propertyPhpDocInfo->removeByType(VarTagValueNode::class);
+        $this->docBlockManipulator->updateNodeWithPhpDocInfo($property, $propertyPhpDocInfo);
     }
 }

--- a/packages/Php74/tests/Rector/Property/TypedPropertyRector/Fixture/bool_property.php.inc
+++ b/packages/Php74/tests/Rector/Property/TypedPropertyRector/Fixture/bool_property.php.inc
@@ -20,7 +20,6 @@ namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
 final class BoolProperty
 {
     /**
-     * @var bool
      * another comment
      */
     private bool $isTrue = false;

--- a/packages/Php74/tests/Rector/Property/TypedPropertyRector/Fixture/class_property.php.inc
+++ b/packages/Php74/tests/Rector/Property/TypedPropertyRector/Fixture/class_property.php.inc
@@ -22,9 +22,6 @@ use Rector\TypeDeclaration\Tests\Rector\Property\TypedPropertyRector\Source\Anot
 
 final class ClassWithClassProperty
 {
-    /**
-     * @var AnotherClass
-     */
     private \Rector\TypeDeclaration\Tests\Rector\Property\TypedPropertyRector\Source\AnotherClass $anotherClass;
 }
 

--- a/packages/Php74/tests/Rector/Property/TypedPropertyRector/Fixture/complex_array.php.inc
+++ b/packages/Php74/tests/Rector/Property/TypedPropertyRector/Fixture/complex_array.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
+
+use Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Source\SomeParent;
+
+final class ComplexArray
+{
+    /**
+     * @var array<int, string>
+     */
+    private $foo;
+
+    /**
+     * @var int[]
+     */
+    private $foos;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
+
+use Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Source\SomeParent;
+
+final class ComplexArray
+{
+    /**
+     * @var array<int, string>
+     */
+    private array $foo;
+
+    /**
+     * @var int[]
+     */
+    private array $foos;
+}
+
+?>

--- a/packages/Php74/tests/Rector/Property/TypedPropertyRector/Fixture/default_values.php.inc
+++ b/packages/Php74/tests/Rector/Property/TypedPropertyRector/Fixture/default_values.php.inc
@@ -68,59 +68,26 @@ namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
 
 final class DefaultValues
 {
-    /**
-     * @var bool
-     */
     private string $name = 'not_a_bool';
 
-    /**
-     * @var bool
-     */
     private bool $isItRealName = false;
 
-    /**
-     * @var bool
-     */
     private ?bool $isItRealNameNull = null;
 
-    /**
-     * @var string
-     */
     private bool $size = false;
 
-    /**
-     * @var float
-     */
     private float $a = 42.42;
 
-    /**
-     * @var float
-     */
     private int $b = 42;
 
-    /**
-     * @var float
-     */
     private string $c = 'hey';
 
-    /**
-     * @var int
-     */
     private float $e = 42.42;
 
-    /**
-     * @var int
-     */
     private int $f = 42;
 
-    /**
-     * @var array
-     */
     private array $g = [1, 2, 3];
 
-    /**
-     * @var iterable
-     */
     private array $h = [1, 2, 3];
 }
 

--- a/packages/Php74/tests/Rector/Property/TypedPropertyRector/Fixture/default_values_for_nullable_iterables.php.inc
+++ b/packages/Php74/tests/Rector/Property/TypedPropertyRector/Fixture/default_values_for_nullable_iterables.php.inc
@@ -28,19 +28,10 @@ namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
 
 final class DefaultValuesForNullableIterables
 {
-    /**
-     * @var array
-     */
     private ?array $items = null;
 
-    /**
-     * @var iterable
-     */
     private ?iterable $itemsB = null;
 
-    /**
-     * @var array|null
-     */
     private ?array $nullableItems = null;
 }
 

--- a/packages/Php74/tests/Rector/Property/TypedPropertyRector/Fixture/match_types.php.inc
+++ b/packages/Php74/tests/Rector/Property/TypedPropertyRector/Fixture/match_types.php.inc
@@ -58,49 +58,22 @@ namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
 
 final class MatchTypes
 {
-    /**
-     * @var bool
-     */
     private bool $a;
 
-    /**
-     * @var boolean
-     */
     private bool $b;
 
-    /**
-     * @var int
-     */
     private int $c;
 
-    /**
-     * @var integer
-     */
     private int $d;
 
-    /**
-     * @var float
-     */
     private float $e;
 
-    /**
-     * @var string
-     */
     private string $f;
 
-    /**
-     * @var object
-     */
     private object $g;
 
-    /**
-     * @var iterable
-     */
     private iterable $h;
 
-    /**
-     * @var self
-     */
     private self $i;
 }
 

--- a/packages/Php74/tests/Rector/Property/TypedPropertyRector/Fixture/match_types_parent.php.inc
+++ b/packages/Php74/tests/Rector/Property/TypedPropertyRector/Fixture/match_types_parent.php.inc
@@ -28,9 +28,6 @@ class PropperParent
 
 final class MatchTypesParent extends PropperParent
 {
-    /**
-     * @var parent
-     */
     private parent $j;
 }
 

--- a/packages/Php74/tests/Rector/Property/TypedPropertyRector/Fixture/non_array_generic_types.php.inc
+++ b/packages/Php74/tests/Rector/Property/TypedPropertyRector/Fixture/non_array_generic_types.php.inc
@@ -1,0 +1,53 @@
+<?php
+
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
+
+class Promise
+{
+}
+
+class Foo
+{
+}
+
+final class NonArrayGenericTypes
+{
+    /**
+     * @var \Traversable<int, string>
+     */
+    private $foo;
+
+    /**
+     * @var Promise<Foo>
+     */
+    private $bar;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
+
+class Promise
+{
+}
+
+class Foo
+{
+}
+
+final class NonArrayGenericTypes
+{
+    /**
+     * @var \Traversable<int, string>
+     */
+    private \Traversable $foo;
+
+    /**
+     * @var Promise<Foo>
+     */
+    private \Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture\Promise $bar;
+}
+
+?>

--- a/packages/Php74/tests/Rector/Property/TypedPropertyRector/Fixture/nullable_property.php.inc
+++ b/packages/Php74/tests/Rector/Property/TypedPropertyRector/Fixture/nullable_property.php.inc
@@ -27,14 +27,8 @@ use Rector\TypeDeclaration\Tests\Rector\Property\TypedPropertyRector\Source\Anot
 
 final class ClassWithNullableProperty
 {
-    /**
-     * @var AnotherClass|null
-     */
     private ?\Rector\TypeDeclaration\Tests\Rector\Property\TypedPropertyRector\Source\AnotherClass $nullableClassWithDefaultNull = null;
 
-    /**
-     * @var null|AnotherClass
-     */
     private ?\Rector\TypeDeclaration\Tests\Rector\Property\TypedPropertyRector\Source\AnotherClass $yetAnotherClass;
 }
 

--- a/packages/Php74/tests/Rector/Property/TypedPropertyRector/Fixture/nullable_property_scalar.php.inc
+++ b/packages/Php74/tests/Rector/Property/TypedPropertyRector/Fixture/nullable_property_scalar.php.inc
@@ -23,9 +23,6 @@ namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
 
 final class NullablePropertyScalar
 {
-    /**
-     * @var int|null
-     */
     private ?int $countOrNull;
 
     public function countOrNull(): ?int

--- a/packages/Php74/tests/Rector/Property/TypedPropertyRector/Fixture/parent_has_untyped_property.php.inc
+++ b/packages/Php74/tests/Rector/Property/TypedPropertyRector/Fixture/parent_has_untyped_property.php.inc
@@ -14,5 +14,5 @@ final class Child extends SomeParent
     /**
      * @var string
      */
-    protected string $typedName = 'child';
+    protected $typedName = 'child';
 }

--- a/packages/Php74/tests/Rector/Property/TypedPropertyRector/Fixture/parent_of_parent_has_untyped_property.php.inc
+++ b/packages/Php74/tests/Rector/Property/TypedPropertyRector/Fixture/parent_of_parent_has_untyped_property.php.inc
@@ -18,5 +18,5 @@ final class Child2 extends Middle
     /**
      * @var string
      */
-    protected string $typedName = 'child';
+    protected $typedName = 'child';
 }

--- a/packages/Php74/tests/Rector/Property/TypedPropertyRector/Fixture/property.php.inc
+++ b/packages/Php74/tests/Rector/Property/TypedPropertyRector/Fixture/property.php.inc
@@ -33,9 +33,6 @@ namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
 
 final class ClassWithProperty
 {
-    /**
-     * @var int
-     */
     private int $count;
 
     /**

--- a/packages/Php74/tests/Rector/Property/TypedPropertyRector/Fixture/simple_array.php.inc
+++ b/packages/Php74/tests/Rector/Property/TypedPropertyRector/Fixture/simple_array.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
+
+final class SimpleArray
+{
+    /**
+     * @var array
+     */
+    private $foo;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
+
+final class SimpleArray
+{
+    private array $foo;
+}
+
+?>

--- a/packages/Php74/tests/Rector/Property/TypedPropertyRector/Fixture/static_property.php.inc
+++ b/packages/Php74/tests/Rector/Property/TypedPropertyRector/Fixture/static_property.php.inc
@@ -22,9 +22,6 @@ use Rector\TypeDeclaration\Tests\Rector\Property\TypedPropertyRector\Source\Anot
 
 final class ClassWithStaticProperty
 {
-    /**
-     * @var iterable
-     */
     private static iterable $iterable;
 }
 

--- a/packages/Php74/tests/Rector/Property/TypedPropertyRector/FixturePhp74/parent_has_untyped_property.php.inc
+++ b/packages/Php74/tests/Rector/Property/TypedPropertyRector/FixturePhp74/parent_has_untyped_property.php.inc
@@ -16,5 +16,3 @@ final class Child extends SomeParent
      */
     protected string $typedName = 'child';
 }
-
-?>

--- a/packages/Php74/tests/Rector/Property/TypedPropertyRector/FixturePhp74/parent_of_parent_has_untyped_property.php.inc
+++ b/packages/Php74/tests/Rector/Property/TypedPropertyRector/FixturePhp74/parent_of_parent_has_untyped_property.php.inc
@@ -20,5 +20,3 @@ final class Child2 extends Middle
      */
     protected string $typedName = 'child';
 }
-
-?>

--- a/packages/Php74/tests/Rector/Property/TypedPropertyRector/FixtureUnionTypes/two_types.php.inc
+++ b/packages/Php74/tests/Rector/Property/TypedPropertyRector/FixtureUnionTypes/two_types.php.inc
@@ -18,9 +18,6 @@ namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\FixtureUnionTyp
 
 final class TwoTypes
 {
-    /**
-     * @var bool|string
-     */
     private bool|string $unionValue;
 }
 

--- a/packages/Php74/tests/Rector/Property/TypedPropertyRector/Source/SomeParent.php
+++ b/packages/Php74/tests/Rector/Property/TypedPropertyRector/Source/SomeParent.php
@@ -14,5 +14,5 @@ abstract class SomeParent
     /**
      * @var string
      */
-    protected string $typedName;
+    protected $typedName;
 }

--- a/packages/Php74/tests/Rector/Property/TypedPropertyRector/TypedPropertyRectorTest.php
+++ b/packages/Php74/tests/Rector/Property/TypedPropertyRector/TypedPropertyRectorTest.php
@@ -23,20 +23,6 @@ final class TypedPropertyRectorTest extends AbstractRectorTestCase
         return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
     }
 
-    /**
-     * @requires PHP >= 7.4
-     * @dataProvider provideDataForTest()
-     */
-    public function testPhp74(string $file): void
-    {
-        $this->doTestFile($file);
-    }
-
-    public function provideDataForTestPhp74(): Iterator
-    {
-        return $this->yieldFilesFromDirectory(__DIR__ . '/FixturePhp74');
-    }
-
     protected function getRectorClass(): string
     {
         return TypedPropertyRector::class;


### PR DESCRIPTION
Closes #2367 propperly

## Before

```diff
 /**
  * @var int
  */
-public $count;
+public int $count;
```

## Now

```diff
-/**
- * @var int
- */
-public $count;
+public int $count;
```

/cc @brendt @enumag @collapso @mallardduck @ruudk