### PR TITLE
improve generic type conversion

### DIFF
--- a/packages/NodeTypeResolver/tests/StaticTypeMapper/StaticTypeMapperTest.php
+++ b/packages/NodeTypeResolver/tests/StaticTypeMapper/StaticTypeMapperTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\NodeTypeResolver\Tests\StaticTypeMapper;
+
+use Iterator;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\IterableType;
+use Rector\HttpKernel\RectorKernel;
+use Rector\NodeTypeResolver\StaticTypeMapper;
+use Symplify\PackageBuilder\Tests\AbstractKernelTestCase;
+
+final class StaticTypeMapperTest extends AbstractKernelTestCase
+{
+    /**
+     * @var StaticTypeMapper
+     */
+    private $staticTypeMapper;
+
+    protected function setUp(): void
+    {
+        $this->bootKernel(RectorKernel::class);
+
+        $this->staticTypeMapper = self::$container->get(StaticTypeMapper::class);
+    }
+
+    /**
+     * @dataProvider provideDataForMapPHPStanPhpDocTypeNodeToPHPStanType()
+     */
+    public function testMapPHPStanPhpDocTypeNodeToPHPStanType(TypeNode $typeNode, string $expectedType): void
+    {
+        $node = new String_('hey');
+
+        $phpStanType = $this->staticTypeMapper->mapPHPStanPhpDocTypeNodeToPHPStanType($typeNode, $node);
+
+        $this->assertInstanceOf($expectedType, $phpStanType);
+    }
+
+    public function provideDataForMapPHPStanPhpDocTypeNodeToPHPStanType(): Iterator
+    {
+        $genericTypeNode = new GenericTypeNode(new IdentifierTypeNode('Traversable'), []);
+        yield [$genericTypeNode, GenericObjectType::class];
+
+        $genericTypeNode = new GenericTypeNode(new IdentifierTypeNode('iterable'), []);
+        yield [$genericTypeNode, IterableType::class];
+    }
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -243,7 +243,7 @@ parameters:
 
         - '#Method Rector\\BetterPhpDocParser\\PhpDocNodeFactory\\Gedmo\\(.*?)\:\:createFromNodeAndTokens\(\) should return Rector\\BetterPhpDocParser\\PhpDocNode\\Gedmo\\(.*?)\|null but returns PHPStan\\PhpDocParser\\Ast\\PhpDoc\\PhpDocTagValueNode\|null#'
 
-
-
         - '#Access to an undefined property PhpParser\\Node\\Identifier\|PhpParser\\Node\\Name\|PhpParser\\Node\\NullableType\:\:\$type#'
         - '#Call to an undefined method PhpParser\\Node\\Identifier\|PhpParser\\Node\\Name\|PhpParser\\Node\\NullableType\:\:toString\(\)#'
+        - '#Parameter \#1 \$expected of method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) expects class\-string<object\>, string given#'
+        - '#Unable to resolve the template type ExpectedType in call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\)#'


### PR DESCRIPTION
@enumag Apperently, only edge-case is generic `array`, that needs to be converted to array. It's treated as object without that, e.g. FQN by default `\array` and other problems.

Maybe there is more space for improvement. What do you think?