### PR TITLE
Use non-root user for docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,14 @@ RUN  composer install --no-dev --optimize-autoloader --prefer-dist
 FROM php:7.4-cli
 WORKDIR /rector
 
-COPY . .
-COPY --from=composer /app .
+RUN groupadd -g 1000 rector
+RUN useradd -u 1000 -ms /bin/bash -g rector rector
+
+COPY . /rector
+COPY --from=composer /app /rector
+
+COPY --chown=rector:rector . /rector
+
+USER rector
 
 ENTRYPOINT [ "bin/rector" ]


### PR DESCRIPTION
When running Rector inside a Docker container my project throws an error that we are running the code as a root user. It's specific issue with my project but I think it's a sensible change not to run rector under a root process inside the container regardless