### PR TITLE
Update compiler with PHPStan 0.12.4 workflow change

### DIFF
--- a/compiler/build/scoper.inc.php
+++ b/compiler/build/scoper.inc.php
@@ -3,12 +3,12 @@
 declare(strict_types=1);
 
 // this file will need update sometimes: https://github.com/phpstan/phpstan-src/commits/master/compiler/build/scoper.inc.php
-// automate in the future, if needed
+// automate in the future, if needed - @see https://github.com/rectorphp/rector/pull/2575#issuecomment-571133000
 
 require __DIR__ . '/../vendor/autoload.php';
 
-use Isolated\Symfony\Component\Finder\Finder;
 use Nette\Neon\Neon;
+use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
 $stubs = [];

--- a/compiler/build/scoper.inc.php
+++ b/compiler/build/scoper.inc.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 require __DIR__ . '/../vendor/autoload.php';
 
 use Isolated\Symfony\Component\Finder\Finder;
+use Nette\Neon\Neon;
+use Symfony\Component\Finder\SplFileInfo;
 
 $stubs = [];
 
@@ -17,7 +19,7 @@ $stubFinder->files()->name('*.php')
     ->in(__DIR__ . '/../../vendor/jetbrains/phpstorm-stubs');
 
 foreach ($stubFinder->getIterator() as $fileInfo) {
-    /** @var \Symfony\Component\Finder\SplFileInfo $fileInfo */
+    /** @var SplFileInfo $fileInfo */
     $stubs[] = $fileInfo->getPathName();
 }
 
@@ -108,7 +110,7 @@ return [
                 }
                 return $prefix . '\\' . $class;
             };
-            $neon = \Nette\Neon\Neon::decode($content);
+            $neon = Neon::decode($content);
             $updatedNeon = $neon;
             if (array_key_exists('services', $neon)) {
                 foreach ($neon['services'] as $key => $service) {
@@ -121,7 +123,7 @@ return [
                     $updatedNeon['services'][$key] = $service;
                 }
             }
-            return \Nette\Neon\Neon::encode($updatedNeon, \Nette\Neon\Neon::BLOCK);
+            return Neon::encode($updatedNeon, Neon::BLOCK);
         },
 
         // mimics https://github.com/phpstan/phpstan-src/commit/fd8f0a852207a1724ae4a262f47d9a449de70da4#diff-463a36e4a5687fb2366b5ee56cdad92d
@@ -130,9 +132,8 @@ return [
                 return $content;
             }
             $content = str_replace(sprintf('\'%s\\\\r\\\\n\'', $prefix), '\'\\\\r\\\\n\'', $content);
-            $content = str_replace(sprintf('\'%s\\\\', $prefix), '\'', $content);
-            return $content;
-        }
+            return str_replace(sprintf('\'%s\\\\', $prefix), '\'', $content);
+        },
     ],
     'whitelist' => ['Rector\*', 'PHPStan\*', 'PhpParser\*'],
 ];

--- a/compiler/composer.json
+++ b/compiler/composer.json
@@ -4,6 +4,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.2",
+        "nette/neon": "^3.0",
         "symfony/console": "^4.4|^5.0",
         "symfony/process": "^4.4|^5.0",
         "symfony/filesystem": "^4.4|^5.0",

--- a/composer.json
+++ b/composer.json
@@ -28,18 +28,20 @@
         "symfony/dependency-injection": "^4.4|^5.0",
         "symfony/finder": "^4.4|^5.0",
         "symfony/process": "^4.4|^5.0",
-        "symplify/package-builder": "^7.1",
-        "symplify/set-config-resolver": "^7.1"
+        "symplify/package-builder": "^7.2",
+        "symplify/set-config-resolver": "^7.2",
+        "symplify/autowire-array-parameter": "^7.2",
+        "symplify/auto-bind-parameter": "^7.2"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16",
         "jetbrains/phpstorm-stubs": "^2019.2",
         "ocramius/package-versions": "^1.4|^1.5",
         "phpunit/phpunit": "^8.4",
-        "symplify/changelog-linker": "^7.1",
-        "symplify/easy-coding-standard": "^7.1",
-        "symplify/monorepo-builder": "^7.1",
-        "symplify/phpstan-extensions": "^7.1",
+        "symplify/changelog-linker": "^7.2",
+        "symplify/easy-coding-standard": "^7.2",
+        "symplify/monorepo-builder": "^7.2",
+        "symplify/phpstan-extensions": "^7.2",
         "thecodingmachine/phpstan-strict-rules": "^0.12",
         "tracy/tracy": "^2.7"
     },

--- a/docs/AllRectorsOverview.md
+++ b/docs/AllRectorsOverview.md
@@ -1,4 +1,4 @@
-# All 419 Rectors Overview
+# All 422 Rectors Overview
 
 - [Projects](#projects)
 - [General](#general)
@@ -44,6 +44,7 @@
 - [Php80](#php80)
 - [PhpDeglobalize](#phpdeglobalize)
 - [PhpSpecToPHPUnit](#phpspectophpunit)
+- [Polyfill](#polyfill)
 - [Refactoring](#refactoring)
 - [RemovingStatic](#removingstatic)
 - [Renaming](#renaming)
@@ -6311,6 +6312,32 @@ Rename "*Spec.php" file to "*Test.php" file
 
 <br>
 
+## Polyfill
+
+### `UnwrapFutureCompatibleIfRector`
+
+- class: `Rector\Polyfill\Rector\If_\UnwrapFutureCompatibleIfRector`
+
+Remove functions exists if with else for always existing
+
+```diff
+ class SomeClass
+ {
+     public function run()
+     {
+         // session locking trough other addons
+-        if (function_exists('session_abort')) {
+-            session_abort();
+-        } else {
+-            session_write_close();
+-        }
++        session_abort();
+     }
+ }
+```
+
+<br>
+
 ## Refactoring
 
 ### `MoveAndRenameClassRector`
@@ -6812,6 +6839,62 @@ Convert missing class reference to string
 <br>
 
 ## SOLID
+
+### `ChangeIfElseValueAssignToEarlyReturnRector`
+
+- class: `Rector\SOLID\Rector\If_\ChangeIfElseValueAssignToEarlyReturnRector`
+
+Change if/else value to early return
+
+```diff
+ class SomeClass
+ {
+     public function run()
+     {
+         if ($this->hasDocBlock($tokens, $index)) {
+-            $docToken = $tokens[$this->getDocBlockIndex($tokens, $index)];
+-        } else {
+-            $docToken = null;
++            return $tokens[$this->getDocBlockIndex($tokens, $index)];
+         }
+-
+-        return $docToken;
++        return null;
+     }
+ }
+```
+
+<br>
+
+### `ChangeNestedIfsToEarlyReturnRector`
+
+- class: `Rector\SOLID\Rector\If_\ChangeNestedIfsToEarlyReturnRector`
+
+Change nested ifs to early return
+
+```diff
+ class SomeClass
+ {
+     public function run()
+     {
+-        if ($value === 5) {
+-            if ($value2 === 10) {
+-                return 'yes';
+-            }
++        if ($value !== 5) {
++            return 'no';
++        }
++
++        if ($value2 === 10) {
++            return 'yes';
+         }
+
+         return 'no';
+     }
+ }
+```
+
+<br>
 
 ### `FinalizeClassesWithoutChildrenRector`
 

--- a/packages/NetteToSymfony/src/Rector/MethodCall/FromHttpRequestGetHeaderToHeadersGetRector.php
+++ b/packages/NetteToSymfony/src/Rector/MethodCall/FromHttpRequestGetHeaderToHeadersGetRector.php
@@ -77,7 +77,7 @@ PHP
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isObjectType($node, Request::class)) {
+        if (! $this->isObjectType($node->var, Request::class)) {
             return null;
         }
 

--- a/packages/NetteToSymfony/tests/Rector/ClassMethod/RouterListToControllerAnnotationsRetor/Fixture/with_parameter.php.inc
+++ b/packages/NetteToSymfony/tests/Rector/ClassMethod/RouterListToControllerAnnotationsRetor/Fixture/with_parameter.php.inc
@@ -3,6 +3,7 @@
 namespace Rector\NetteToSymfony\Tests\Rector\MethodCall\RouterListToControllerAnnotationsRetor\Fixture;
 
 use Nette\Application\IPresenter;
+use Nette\Application\IResponse;
 use Nette\Application\Routers\Route;
 use Nette\Application\Routers\RouteList;
 
@@ -23,7 +24,7 @@ final class WithParameterSomePresenter implements IPresenter
     /**
      * @todo
      */
-    public function run()
+    public function run(\Nette\Application\Request $request): IResponse
     {
     }
 }
@@ -36,6 +37,7 @@ namespace Rector\NetteToSymfony\Tests\Rector\MethodCall\RouterListToControllerAn
 
 use Symfony\Component\Routing\Annotation\Route;
 use Nette\Application\IPresenter;
+use Nette\Application\IResponse;
 use Nette\Application\Routers\RouteList;
 
 final class WithParameterRouterFactory
@@ -54,7 +56,7 @@ final class WithParameterSomePresenter implements IPresenter
      * @todo
      * @Route(path="some-path/{id}")
      */
-    public function run()
+    public function run(\Nette\Application\Request $request): IResponse
     {
     }
 }

--- a/packages/NetteToSymfony/tests/Rector/Class_/NetteFormToSymfonyFormRector/Source/NettePresenter.php
+++ b/packages/NetteToSymfony/tests/Rector/Class_/NetteFormToSymfonyFormRector/Source/NettePresenter.php
@@ -5,8 +5,13 @@ declare(strict_types=1);
 namespace Rector\NetteToSymfony\Tests\Rector\Class_\NetteFormToSymfonyFormRector\Source;
 
 use Nette\Application\IPresenter;
+use Nette\Application\IResponse;
+use Nette\Application\Request;
 
 abstract class NettePresenter implements IPresenter
 {
+    public function run(Request $request): IResponse
+    {
 
+    }
 }

--- a/packages/NetteToSymfony/tests/Rector/MethodCall/FromHttpRequestGetHeaderToHeadersGetRector/Fixture/fixture.php.inc
+++ b/packages/NetteToSymfony/tests/Rector/MethodCall/FromHttpRequestGetHeaderToHeadersGetRector/Fixture/fixture.php.inc
@@ -11,7 +11,7 @@ final class SomeController
      */
     private $httpRequest;
 
-    public static function someAction(Request $request)
+    public function someAction(Request $request)
     {
         $header = $this->httpRequest->getHeader('x');
     }
@@ -32,7 +32,7 @@ final class SomeController
      */
     private $httpRequest;
 
-    public static function someAction(Request $request)
+    public function someAction(Request $request)
     {
         $header = $request->headers->get('x');
     }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -251,3 +251,6 @@ parameters:
         - '#Right side of \|\| is always false#'
 
         - '#Method Rector\\NodeContainer\\ParsedNodesByType\:\:findNewNodesByClass\(\) should return array<PhpParser\\Node\\Expr\\New_\> but returns array<int, PhpParser\\Node\>#'
+
+        # fix Symplify 7.2 later
+        - '#Method (.*?) returns bool type, so the name should start with is/has/was#'

--- a/src/HttpKernel/RectorKernel.php
+++ b/src/HttpKernel/RectorKernel.php
@@ -18,10 +18,10 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\Config\FileLocator;
 use Symfony\Component\HttpKernel\Kernel;
+use Symplify\AutoBindParameter\DependencyInjection\CompilerPass\AutoBindParameterCompilerPass;
+use Symplify\AutowireArrayParameter\DependencyInjection\CompilerPass\AutowireArrayParameterCompilerPass;
 use Symplify\PackageBuilder\Contract\HttpKernel\ExtraConfigAwareKernelInterface;
-use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutoBindParametersCompilerPass;
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutoReturnFactoryCompilerPass;
-use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutowireArrayParameterCompilerPass;
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutowireInterfacesCompilerPass;
 
 final class RectorKernel extends Kernel implements ExtraConfigAwareKernelInterface
@@ -90,7 +90,7 @@ final class RectorKernel extends Kernel implements ExtraConfigAwareKernelInterfa
         // autowire Rectors by default (mainly for 3rd party code)
         $containerBuilder->addCompilerPass(new AutowireInterfacesCompilerPass([RectorInterface::class]));
 
-        $containerBuilder->addCompilerPass(new AutoBindParametersCompilerPass());
+        $containerBuilder->addCompilerPass(new AutoBindParameterCompilerPass());
 
         // add all merged arguments of Rector services
         $containerBuilder->addCompilerPass(

--- a/stubs/Nette/Forms/Form.php
+++ b/stubs/Nette/Forms/Form.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Nette\Application\UI;
+namespace Nette\Forms;
 
 if (class_exists('Nette\Forms\Form')) {
     return;
 }
 
-class Form extends \Nette\Forms\Form
+class Form
 {
 
 }

--- a/tests/DependencyInjection/RectorContainerFactoryTest.php
+++ b/tests/DependencyInjection/RectorContainerFactoryTest.php
@@ -7,7 +7,7 @@ namespace Rector\Tests\DependencyInjection;
 use PHPUnit\Framework\TestCase;
 use Rector\DependencyInjection\RectorContainerFactory;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symplify\EasyCodingStandard\Exception\Configuration\SetNotFoundException;
+use Symplify\SetConfigResolver\Exception\SetNotFoundException;
 
 final class RectorContainerFactoryTest extends TestCase
 {


### PR DESCRIPTION
This might need to automate in the future. Something like merge PHPStan's `scoper.php.inc` with Rector's or unpack/pack PHSPtan phar.

See conversation https://github.com/rectorphp/rector/pull/2575#issuecomment-571133000