### PR TITLE
Transition some travis checks to GithubActions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,17 @@
+name: PHP Checks
+
+on:
+  push:
+
+jobs:
+  ecs:
+      name: ECS
+      runs-on: ubuntu-latest
+      steps:
+          - uses: actions/checkout@v2
+          - name: Setup PHP
+            uses: shivammathur/setup-php@verbose
+            with:
+                php-version: 7.2
+                coverage: none # disable xdebug, pcov
+          - run: composer check-cs

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,7 +10,7 @@ jobs:
       steps:
           - uses: actions/checkout@v2
           - name: Setup PHP
-            uses: shivammathur/setup-php@verbose
+            uses: shivammathur/setup-php@v1
             with:
                 php-version: 7.2
                 coverage: none # disable xdebug, pcov

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,7 +1,7 @@
 name: PHP Checks
 
 on:
-  push:
+  - push
 
 jobs:
   phpstan:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,4 +14,4 @@ jobs:
             with:
                 php-version: 7.2
                 coverage: none # disable xdebug, pcov
-          - run: composer check-cs
+          - run: composer install --no-progress && composer check-cs

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,6 +4,18 @@ on:
   push:
 
 jobs:
+  phpstan:
+      name: PHPStan
+      runs-on: ubuntu-latest
+      steps:
+          - uses: actions/checkout@v2
+          - name: Setup PHP
+            uses: shivammathur/setup-php@v1
+            with:
+                php-version: 7.2
+                coverage: none # disable xdebug, pcov
+          - run: composer install --no-progress && composer phpstan
+
   ecs:
       name: ECS
       runs-on: ubuntu-latest
@@ -15,3 +27,15 @@ jobs:
                 php-version: 7.2
                 coverage: none # disable xdebug, pcov
           - run: composer install --no-progress && composer check-cs
+
+  rector:
+      name: Rector
+      runs-on: ubuntu-latest
+      steps:
+          - uses: actions/checkout@v2
+          - name: Setup PHP
+            uses: shivammathur/setup-php@v1
+            with:
+                php-version: 7.3
+                coverage: none # disable xdebug, pcov
+          - run: composer install --no-progress && composer rector

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,17 +67,6 @@ jobs:
                 - composer update --prefer-lowest --no-progress
 
         -
-            name: PHPStan
-            php: 7.2
-            script:
-                - composer phpstan
-
-        -
-            php: 7.3
-            name: Rector
-            script:
-                - composer rector
-        -
             php: 7.3
             name: "Scan Fatal Errors"
             script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,12 +73,6 @@ jobs:
                 - composer phpstan
 
         -
-            php: 7.2
-            name: ECS
-            script:
-                - composer check-cs
-
-        -
             php: 7.3
             name: Rector
             script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,23 @@ jobs:
                 - composer update --prefer-lowest --no-progress
 
         -
+            name: PHPStan
+            php: 7.2
+            script:
+                - composer phpstan
+
+        -
+            php: 7.2
+            name: ECS
+            script:
+                - composer check-cs
+
+        -
+            php: 7.3
+            name: Rector
+            script:
+                - composer rector
+        -
             php: 7.3
             name: "Scan Fatal Errors"
             script:


### PR DESCRIPTION
parallize more jobs to speedup the overall CI build time.

In GithubActions we can get up to 8 parallel workers, while on travis its limited to 4.
current overall build time is ~17-18 min. distribution of the jobs should make it faster.