### PR TITLE
Remove travis-CI jobs which were moved to GithubAction

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,8 +1,10 @@
 name: PHP Checks
 
 on:
-  - push
-  - pull_request
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   phpstan:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,6 +2,7 @@ name: PHP Checks
 
 on:
   - push
+  - pull_request
 
 jobs:
   phpstan:

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,23 +67,6 @@ jobs:
                 - composer update --prefer-lowest --no-progress
 
         -
-            name: PHPStan
-            php: 7.2
-            script:
-                - composer phpstan
-
-        -
-            php: 7.2
-            name: ECS
-            script:
-                - composer check-cs
-
-        -
-            php: 7.3
-            name: Rector
-            script:
-                - composer rector
-        -
             php: 7.3
             name: "Scan Fatal Errors"
             script:


### PR DESCRIPTION
You should configure the new checks to be required in case those were required before (in github branch protection).


In case it is essentiell that the „compile phar“ travis job only runs after all (including those beeing removed with this PR) previous jobs went green/successfull we should think about the job design.. (I guess travis ci does not know about status of single github actions and vice versa)