### PR TITLE
more reliable way getting last stmt

### DIFF
--- a/packages/DeadCode/src/Rector/FunctionLike/RemoveDeadReturnRector.php
+++ b/packages/DeadCode/src/Rector/FunctionLike/RemoveDeadReturnRector.php
@@ -73,7 +73,7 @@ PHP
             return null;
         }
 
-        $lastStmt = $node->stmts[count($node->stmts) - 1];
+        $lastStmt = array_values(array_slice($node->stmts, -1))[0];
         if (! $lastStmt instanceof Return_) {
             return null;
         }

--- a/packages/DeadCode/src/Rector/FunctionLike/RemoveDeadReturnRector.php
+++ b/packages/DeadCode/src/Rector/FunctionLike/RemoveDeadReturnRector.php
@@ -73,7 +73,8 @@ PHP
             return null;
         }
 
-        $lastStmt = array_values(array_slice($node->stmts, -1))[0];
+        $stmtValues = array_values($node->stmts);
+        $lastStmt = end($stmtValues);
         if (! $lastStmt instanceof Return_) {
             return null;
         }


### PR DESCRIPTION
This is a more reliable way of getting the last array element (preserving the internal pointer), especially when the keys of the stmt gets scrambled by unsetting items.