### PR TITLE
More reliable way getting first stmt item

### DIFF
--- a/packages/DeadCode/src/Rector/ClassMethod/RemoveDelegatingParentCallRector.php
+++ b/packages/DeadCode/src/Rector/ClassMethod/RemoveDelegatingParentCallRector.php
@@ -86,7 +86,7 @@ PHP
             return null;
         }
 
-        if (count((array) $node->stmts) !== 1) {
+        if ($node->stmts === null || count((array) $node->stmts) !== 1) {
             return null;
         }
 

--- a/packages/DeadCode/src/Rector/ClassMethod/RemoveDelegatingParentCallRector.php
+++ b/packages/DeadCode/src/Rector/ClassMethod/RemoveDelegatingParentCallRector.php
@@ -90,7 +90,8 @@ PHP
             return null;
         }
 
-        $onlyStmt = $this->unwrapExpression($node->stmts[0]);
+        $stmtsValues = array_values($node->stmts);
+        $onlyStmt = $this->unwrapExpression($stmtsValues[0]);
 
         // are both return?
         if ($this->isMethodReturnType($node, 'void') && ! $onlyStmt instanceof Return_) {


### PR DESCRIPTION
The key values are not reliable, this problem is caused by unsetting the values in the stmts array of a node without resetting them. It's not only in this rector file and might need a bigger fix, but this one was bugging me whole day.