### PR TITLE
[VarConstantCommentRector] Allow mixed[] in place of Rector's setting wrong infered types

### DIFF
--- a/packages/CodingStyle/tests/Rector/ClassConst/VarConstantCommentRector/Fixture/correct_mixed_to_specific_types.php.inc
+++ b/packages/CodingStyle/tests/Rector/ClassConst/VarConstantCommentRector/Fixture/correct_mixed_to_specific_types.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\CodingStyle\Tests\Rector\ClassConst\VarConstantCommentRector\Fixture;
+
+class CorrectMixedToSpecificTypes
+{
+    /**
+     * @var mixed[]
+     */
+    public const ARRAY_CONST = [
+        'key' => 'value',
+        'key2' => ['value2', 1234],
+        1 => null,
+    ];
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CodingStyle\Tests\Rector\ClassConst\VarConstantCommentRector\Fixture;
+
+class CorrectMixedToSpecificTypes
+{
+    /**
+     * @var array<int|string, string|array<int|string>|null>
+     */
+    public const ARRAY_CONST = [
+        'key' => 'value',
+        'key2' => ['value2', 1234],
+        1 => null,
+    ];
+}
+
+?>

--- a/packages/CodingStyle/tests/Rector/ClassConst/VarConstantCommentRector/Fixture/skip_already_has.php.inc
+++ b/packages/CodingStyle/tests/Rector/ClassConst/VarConstantCommentRector/Fixture/skip_already_has.php.inc
@@ -16,13 +16,4 @@ final class SkipAlreadyHas
      * - "[Aliased\PackageName]      "Message => Aliased\PackageName
      */
     public const PACKAGE_NAME_PATTERN = '#\[(?<package>[-\w\\\\]+)\]( ){1,}#';
-
-    /**
-     * @var mixed[]
-     */
-    public const ARRAY_CONST = [
-        'key' => 'value',
-        'key2' => ['value2', 1234],
-        1 => null,
-    ];
 }

--- a/packages/CodingStyle/tests/Rector/ClassConst/VarConstantCommentRector/Fixture/skip_already_has.php.inc
+++ b/packages/CodingStyle/tests/Rector/ClassConst/VarConstantCommentRector/Fixture/skip_already_has.php.inc
@@ -16,4 +16,13 @@ final class SkipAlreadyHas
      * - "[Aliased\PackageName]      "Message => Aliased\PackageName
      */
     public const PACKAGE_NAME_PATTERN = '#\[(?<package>[-\w\\\\]+)\]( ){1,}#';
+
+    /**
+     * @var mixed[]
+     */
+    public const ARRAY_CONST = [
+        'key' => 'value',
+        'key2' => ['value2', 1234],
+        1 => null,
+    ];
 }


### PR DESCRIPTION
I investigated a while but got stuck when I stumbled upon `PHPStan\Type\UnionType` on [`$newType->getItemType()`](https://github.com/rectorphp/rector/blob/master/packages/NodeTypeResolver/src/PhpDoc/NodeAnalyzer/DocBlockManipulator.php#L260). Any idea how to use that ?