### PR TITLE
[AddDoesNotPerformAssertionToNonAssertingTestRector] fix skipping if annotation already exists (fixes infinite loop too)

### DIFF
--- a/packages/PHPUnit/src/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector.php
+++ b/packages/PHPUnit/src/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector.php
@@ -131,7 +131,7 @@ PHP
 
         if ($classMethod->getDocComment() !== null) {
             $text = $classMethod->getDocComment();
-            if (Strings::match($text->getText(), '#@expectedException\b#')) {
+            if (Strings::match($text->getText(), '#@(doesNotPerformAssertion|expectedException\b)#')) {
                 return true;
             }
         }

--- a/packages/PHPUnit/tests/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/skip_existing_annotation.php.inc
+++ b/packages/PHPUnit/tests/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/skip_existing_annotation.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector\Fixture;
+
+class SkipExistingAnnotation extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @doesNotPerformAssertion
+     */
+    public function testSomething(): void
+    {
+    }
+}


### PR DESCRIPTION
Fixes #2634.