### PR TITLE
[AddDoesNotPerformAssertionToNonAssertingTestRector] Add failing test for Prophecy assertions.

### DIFF
--- a/packages/PHPUnit/tests/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/skip_prophecy_assertions.php.inc
+++ b/packages/PHPUnit/tests/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Fixture/skip_prophecy_assertions.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector\Fixture;
+
+use Rector\PHPUnit\Tests\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector\Source\Denormalizer;
+use Rector\PHPUnit\Tests\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector\Source\DenormalizerInterface;
+
+class SkipProphecyAssertions extends \PHPUnit\Framework\TestCase
+{
+    public function testDenormalize(): void
+    {
+        $badData = ['42'];
+        $fixedData = [42];
+
+        $type = 'anything';
+
+        /** @var DenormalizerInterface $denormalizer */
+        $denormalizer = $this->prophesize(DenormalizerInterface::class);
+        $denormalizer
+            ->denormalize($fixedData, $type)
+            ->shouldBeCalled(); // this is an assertion here
+
+        (new Denormalizer($denormalizer))->handle($badData, $type);
+    }
+}

--- a/packages/PHPUnit/tests/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Source/Denormalizer.php
+++ b/packages/PHPUnit/tests/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Source/Denormalizer.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector\Source;
+
+final class Denormalizer
+{
+    /**
+     * @var DenormalizerInterface
+     */
+    private $denormalizer;
+
+    public function __construct(DenormalizerInterface $denormalizer)
+    {
+        $this->denormalizer = $denormalizer;
+    }
+
+    public function handle(array $data, string $type): ?array
+    {
+        try {
+            return $this->denormalizer->denormalize($data, $type);
+        } catch (\Throwable $throwable) {
+            return null;
+        }
+    }
+}

--- a/packages/PHPUnit/tests/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Source/DenormalizerInterface.php
+++ b/packages/PHPUnit/tests/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector/Source/DenormalizerInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector\Source;
+
+interface DenormalizerInterface
+{
+    /**
+     * Denormalizes data back into an object of the given class.
+     *
+     * @param mixed  $data    Data to restore
+     * @param string $type    The expected class to instantiate
+     * @param string $format  Format the given data was extracted from
+     * @param array  $context Options available to the denormalizer
+     *
+     * @return object|array
+     */
+    public function denormalize($data, $type, $format = null, array $context = []);
+}


### PR DESCRIPTION
> [gnutix] Is this Rector developed with other testing framework than PHPUnit in mind ? (like Prophecy)
> [Tomas] Sure, whatever real case this rule should cover.
(from https://github.com/rectorphp/rector/issues/2634)

Here's a failing test case for this (currently it adds the annotation to the method yet it should not).

However, I'm not interested in implementing a fix myself, as it's ignored from my project anyway and I already wasted way too much time on this one : I'd rather focus on other issues (or take a break :smile: ). I could upgrade this Rector's documentation to state that it currently does not support Prophecy and any help in implementing it is welcome though.