### PR TITLE
[CountOnNullRector] Should understand array/countable variable in trait method

### DIFF
--- a/packages/Php71/tests/Rector/FuncCall/CountOnNullRector/Fixture/property_within_trait_method.php.inc
+++ b/packages/Php71/tests/Rector/FuncCall/CountOnNullRector/Fixture/property_within_trait_method.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Php71\Tests\Rector\FuncCall\CountOnNullRector\Fixture;
+
+trait PropertyWithinTraitMethod
+{
+    /**
+     * @var array
+     */
+    private $array = [];
+
+    public function run()
+    {
+        return count($this->array);
+    }
+}

--- a/packages/Php71/tests/Rector/FuncCall/CountOnNullRector/Fixture/variable_within_trait_method.php.inc
+++ b/packages/Php71/tests/Rector/FuncCall/CountOnNullRector/Fixture/variable_within_trait_method.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Php71\Tests\Rector\FuncCall\CountOnNullRector\Fixture;
+
+use Rector\Php71\Tests\Rector\FuncCall\CountOnNullRector\Source\CountableClass;
+
+trait VariableWithinTraitMethod
+{
+    public function run()
+    {
+        $array = [];
+        $countable = new CountableClass();
+
+        return
+            count($array)
+            +
+            count($countable)
+        ;
+    }
+}


### PR DESCRIPTION
This PR adds two fixtures relating to `trait` handling by `CountOnNullRector`. Currently : 

* `PropertyWithinTraitMethod` : passes :+1:
* `VariableWithinTraitMethod` : fails :-1: 

If I change the Fixture from a `trait` to a `class` they both pass, so this is related to how a variable within a trait is handled.

I spent some time digging and tried to use `\Rector\NodeTypeResolver\PerNodeTypeResolver\VariableTypeResolver::resolve()` that seems to be written to handle resolution of variables (though it's used nowhere in Rector's code, only in its own Test file :thinking: ) by calling : 

* `resolveTypesFromScope($node)`, which calls...
* `resolveNodeScope($node)`, which calls on `\Rector\NodeTypeResolver\PHPStan\Collector\TraitNodeScopeCollector`...
* `getScopeForTraitAndNode($traitName, $node)`)

But it returned `null`, which was resolved to `MixedType` in `resolveTypesFromScope` and bubbled up back to `\Rector\Php71\Rector\FuncCall\CountOnNullRector::refactor` which passes the `isNullableType` check and thus refactors the code.

@TomasVotruba Any idea how to deal with this one ?