### PR TITLE
Decouple PHPStanStaticTypeMapper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,6 +71,7 @@
             "Rector\\Nette\\": "packages/Nette/src",
             "Rector\\NodeTypeResolver\\": "packages/NodeTypeResolver/src",
             "Rector\\PHPStan\\": "packages/PHPStan/src",
+            "Rector\\PHPStanStaticTypeMapper\\": "packages/PHPStanStaticTypeMapper/src",
             "Rector\\PHPUnitSymfony\\": "packages/PHPUnitSymfony/src",
             "Rector\\PHPUnit\\": "packages/PHPUnit/src",
             "Rector\\PSR4\\": "packages/PSR4/src",

--- a/ecs.yaml
+++ b/ecs.yaml
@@ -93,7 +93,10 @@ parameters:
             - 'packages/NodeTypeResolver/src/PhpDoc/NodeAnalyzer/FqnNamePhpDocNodeDecorator.php'
             - 'packages/NodeTypeResolver/src/PHPStan/Type/StaticTypeAnalyzer.php'
             - 'src/NodeContainer/ParsedNodesByType.php'
+
+            - 'packages/PHPStanStaticTypeMapper/src/PHPStanStaticTypeMapper.php'
             - 'packages/NodeTypeResolver/src/StaticTypeMapper.php'
+
             - 'packages/PHPStan/src/Rector/Node/RemoveNonExistingVarAnnotationRector.php'
             - 'packages/Architecture/src/Rector/Class_/ConstructorInjectionToActionInjectionRector.php'
             - 'src/PhpParser/Node/Commander/NodeRemovingCommander.php'

--- a/packages/NodeTypeResolver/config/config.yaml
+++ b/packages/NodeTypeResolver/config/config.yaml
@@ -33,3 +33,6 @@ services:
 
     PHPStan\DependencyInjection\Type\OperatorTypeSpecifyingExtensionRegistryProvider:
         factory: ['@Rector\NodeTypeResolver\DependencyInjection\PHPStanServicesFactory', 'createOperatorTypeSpecifyingExtensionRegistryProvider']
+
+    PHPStan\PhpDoc\TypeNodeResolver:
+        factory: ['@Rector\NodeTypeResolver\DependencyInjection\PHPStanServicesFactory', 'createTypeNodeResolver']

--- a/packages/NodeTypeResolver/src/DependencyInjection/PHPStanServicesFactory.php
+++ b/packages/NodeTypeResolver/src/DependencyInjection/PHPStanServicesFactory.php
@@ -13,8 +13,13 @@ use PHPStan\DependencyInjection\Container;
 use PHPStan\DependencyInjection\ContainerFactory;
 use PHPStan\DependencyInjection\Type\DynamicReturnTypeExtensionRegistryProvider;
 use PHPStan\DependencyInjection\Type\OperatorTypeSpecifyingExtensionRegistryProvider;
+use PHPStan\PhpDoc\TypeNodeResolver;
 use PHPStan\Reflection\ReflectionProvider;
 
+/**
+ * Factory so Symfony app can use services from PHPStan container
+ * @see packages/NodeTypeResolver/config/config.yaml:17
+ */
 final class PHPStanServicesFactory
 {
     /**
@@ -100,5 +105,10 @@ final class PHPStanServicesFactory
     public function createOperatorTypeSpecifyingExtensionRegistryProvider(): OperatorTypeSpecifyingExtensionRegistryProvider
     {
         return $this->container->getByType(OperatorTypeSpecifyingExtensionRegistryProvider::class);
+    }
+
+    public function createTypeNodeResolver(): TypeNodeResolver
+    {
+        return $this->container->getByType(TypeNodeResolver::class);
     }
 }

--- a/packages/NodeTypeResolver/src/Finder/PHPStanTypeClassFinder.php
+++ b/packages/NodeTypeResolver/src/Finder/PHPStanTypeClassFinder.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\NodeTypeResolver\Finder;
+
+use Nette\Loaders\RobotLoader;
+use Nette\Utils\Strings;
+
+final class PHPStanTypeClassFinder
+{
+    /**
+     * @return string[]
+     */
+    public function find(): array
+    {
+        $robotLoader = new RobotLoader();
+        $robotLoader->addDirectory($this->getPhpstanPharSrcTypeDirectoryPath());
+
+        $robotLoader->setTempDirectory(sys_get_temp_dir() . '/_phpstan_types');
+        $robotLoader->acceptFiles = ['*Type.php'];
+        $robotLoader->rebuild();
+
+        $classLikesToFilePaths = $robotLoader->getIndexedClasses();
+        $classLikes = array_keys($classLikesToFilePaths);
+
+        return $this->filterClassesOnly($classLikes);
+    }
+
+    /**
+     * @param string[] $classLikes
+     * @return string[]
+     */
+    private function filterClassesOnly(array $classLikes): array
+    {
+        $classes = [];
+        foreach ($classLikes as $classLike) {
+            if (! class_exists($classLike)) {
+                continue;
+            }
+
+            if (Strings::match($classLike, '#\\\\Accessory\\\\#')) {
+                continue;
+            }
+
+            $classes[] = $classLike;
+        }
+        return $classes;
+    }
+
+    /**
+     * @see https://github.com/dg/nette-robot-loader/blob/593c0e40e511c0b0700610a6a3964a210219139f/tests/Loaders/RobotLoader.phar.phpt#L33
+     */
+    private function getPhpstanPharSrcTypeDirectoryPath(): string
+    {
+        $phpstanPharRealpath = realpath(__DIR__ . '/../../../../vendor/phpstan/phpstan/phpstan.phar');
+
+        return 'phar://' . $phpstanPharRealpath . '/src/Type';
+    }
+}

--- a/packages/NodeTypeResolver/src/StaticTypeMapper.php
+++ b/packages/NodeTypeResolver/src/StaticTypeMapper.php
@@ -49,7 +49,6 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeWithClassName;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VoidType;
-use Rector\AttributeAwarePhpDoc\Ast\Type\AttributeAwareUnionTypeNode;
 use Rector\BetterPhpDocParser\Type\PreSlashStringType;
 use Rector\Exception\NotImplementedException;
 use Rector\Exception\ShouldNotHappenException;
@@ -61,9 +60,8 @@ use Rector\PHPStan\Type\FullyQualifiedObjectType;
 use Rector\PHPStan\Type\ParentStaticType;
 use Rector\PHPStan\Type\SelfObjectType;
 use Rector\PHPStan\Type\ShortenedObjectType;
+use Rector\PHPStanStaticTypeMapper\PHPStanStaticTypeMapper;
 use Rector\TypeDeclaration\PHPStan\Type\ObjectTypeSpecifier;
-use Rector\ValueObject\PhpVersionFeature;
-use Traversable;
 
 /**
  * Maps PhpParser <=> PHPStan <=> PHPStan doc <=> string type nodes to between all possible formats
@@ -85,76 +83,26 @@ final class StaticTypeMapper
      */
     private $objectTypeSpecifier;
 
+    /**
+     * @var PHPStanStaticTypeMapper
+     */
+    private $phpStanStaticTypeMapper;
+
     public function __construct(
         PhpVersionProvider $phpVersionProvider,
         TypeFactory $typeFactory,
-        ObjectTypeSpecifier $objectTypeSpecifier
+        ObjectTypeSpecifier $objectTypeSpecifier,
+        PHPStanStaticTypeMapper $phpStanStaticTypeMapper
     ) {
         $this->phpVersionProvider = $phpVersionProvider;
         $this->typeFactory = $typeFactory;
         $this->objectTypeSpecifier = $objectTypeSpecifier;
+        $this->phpStanStaticTypeMapper = $phpStanStaticTypeMapper;
     }
 
     public function mapPHPStanTypeToPHPStanPhpDocTypeNode(Type $phpStanType): TypeNode
     {
-        if ($phpStanType instanceof MixedType) {
-            return new IdentifierTypeNode('mixed');
-        }
-
-        if ($phpStanType instanceof UnionType) {
-            $unionTypesNodes = [];
-            foreach ($phpStanType->getTypes() as $unionedType) {
-                $unionTypesNodes[] = $this->mapPHPStanTypeToPHPStanPhpDocTypeNode($unionedType);
-            }
-
-            $unionTypesNodes = array_unique($unionTypesNodes);
-
-            return new AttributeAwareUnionTypeNode($unionTypesNodes);
-        }
-
-        if ($phpStanType instanceof ArrayType || $phpStanType instanceof IterableType) {
-            $itemTypeNode = $this->mapPHPStanTypeToPHPStanPhpDocTypeNode($phpStanType->getItemType());
-
-            if ($itemTypeNode instanceof UnionTypeNode) {
-                return $this->convertUnionArrayTypeNodesToArrayTypeOfUnionTypeNodes($itemTypeNode);
-            }
-
-            return new ArrayTypeNode($itemTypeNode);
-        }
-
-        if ($phpStanType instanceof IntegerType) {
-            return new IdentifierTypeNode('int');
-        }
-
-        if ($phpStanType instanceof ClassStringType) {
-            return new IdentifierTypeNode('class-string');
-        }
-
-        if ($phpStanType instanceof StringType) {
-            return new IdentifierTypeNode('string');
-        }
-
-        if ($phpStanType instanceof BooleanType) {
-            return new IdentifierTypeNode('bool');
-        }
-
-        if ($phpStanType instanceof FloatType) {
-            return new IdentifierTypeNode('float');
-        }
-
-        if ($phpStanType instanceof ObjectType) {
-            return new IdentifierTypeNode('\\' . $phpStanType->getClassName());
-        }
-
-        if ($phpStanType instanceof NullType) {
-            return new IdentifierTypeNode('null');
-        }
-
-        if ($phpStanType instanceof NeverType) {
-            return new IdentifierTypeNode('mixed');
-        }
-
-        throw new NotImplementedException(__METHOD__ . ' for ' . get_class($phpStanType));
+        return $this->phpStanStaticTypeMapper->mapToPHPStanPhpDocTypeNode($phpStanType);
     }
 
     /**
@@ -162,160 +110,7 @@ final class StaticTypeMapper
      */
     public function mapPHPStanTypeToPhpParserNode(Type $phpStanType, ?string $kind = null): ?Node
     {
-        if ($phpStanType instanceof VoidType) {
-            if ($this->phpVersionProvider->isAtLeast(PhpVersionFeature::VOID_TYPE)) {
-                if (in_array($kind, ['param', 'property'], true)) {
-                    // param cannot be void
-                    return null;
-                }
-
-                return new Identifier('void');
-            }
-
-            return null;
-        }
-
-        if ($phpStanType instanceof SelfObjectType) {
-            return new Identifier('self');
-        }
-
-        if ($phpStanType instanceof IntegerType) {
-            if ($this->phpVersionProvider->isAtLeast(PhpVersionFeature::SCALAR_TYPES)) {
-                return new Identifier('int');
-            }
-
-            return null;
-        }
-
-        if ($phpStanType instanceof StringType) {
-            if ($this->phpVersionProvider->isAtLeast(PhpVersionFeature::SCALAR_TYPES)) {
-                return new Identifier('string');
-            }
-
-            return null;
-        }
-
-        if ($phpStanType instanceof BooleanType) {
-            if ($this->phpVersionProvider->isAtLeast(PhpVersionFeature::SCALAR_TYPES)) {
-                return new Identifier('bool');
-            }
-
-            return null;
-        }
-
-        if ($phpStanType instanceof FloatType) {
-            if ($this->phpVersionProvider->isAtLeast(PhpVersionFeature::SCALAR_TYPES)) {
-                return new Identifier('float');
-            }
-
-            return null;
-        }
-
-        if ($phpStanType instanceof ArrayType) {
-            return new Identifier('array');
-        }
-
-        if ($phpStanType instanceof IterableType) {
-            return new Identifier('iterable');
-        }
-
-        if ($phpStanType instanceof ThisType) {
-            return new Identifier('self');
-        }
-
-        if ($phpStanType instanceof ParentStaticType) {
-            return new Identifier('parent');
-        }
-
-        if ($phpStanType instanceof StaticType) {
-            return null;
-        }
-
-        if ($phpStanType instanceof CallableType || $phpStanType instanceof ClosureType) {
-            if ($kind === 'property') {
-                return null;
-            }
-
-            return new Identifier('callable');
-        }
-
-        if ($phpStanType instanceof ShortenedObjectType) {
-            return new FullyQualified($phpStanType->getFullyQualifiedName());
-        }
-
-        if ($phpStanType instanceof AliasedObjectType) {
-            return new Name($phpStanType->getClassName());
-        }
-
-        if ($phpStanType instanceof TypeWithClassName) {
-            $lowerCasedClassName = strtolower($phpStanType->getClassName());
-            if ($lowerCasedClassName === 'callable') {
-                return new Identifier('callable');
-            }
-
-            if ($lowerCasedClassName === 'self') {
-                return new Identifier('self');
-            }
-
-            if ($lowerCasedClassName === 'static') {
-                return null;
-            }
-
-            if ($lowerCasedClassName === 'mixed') {
-                return null;
-            }
-
-            return new FullyQualified($phpStanType->getClassName());
-        }
-
-        if ($phpStanType instanceof UnionType) {
-            // match array types
-            $arrayNode = $this->matchArrayTypes($phpStanType);
-            if ($arrayNode !== null) {
-                return $arrayNode;
-            }
-
-            // special case for nullable
-            $nullabledType = $this->matchTypeForNullableUnionType($phpStanType);
-            if ($nullabledType === null) {
-                // use first unioned type in case of unioned object types
-                return $this->matchTypeForUnionedObjectTypes($phpStanType);
-            }
-
-            $nullabledTypeNode = $this->mapPHPStanTypeToPhpParserNode($nullabledType);
-            if ($nullabledTypeNode === null) {
-                return null;
-            }
-
-            if ($nullabledTypeNode instanceof NullableType) {
-                return $nullabledTypeNode;
-            }
-
-            if ($nullabledTypeNode instanceof PhpParserUnionType) {
-                throw new ShouldNotHappenException();
-            }
-
-            return new NullableType($nullabledTypeNode);
-        }
-
-        if ($phpStanType instanceof NeverType ||
-            $phpStanType instanceof VoidType ||
-            $phpStanType instanceof MixedType ||
-            $phpStanType instanceof ResourceType ||
-            $phpStanType instanceof NullType
-        ) {
-            return null;
-        }
-
-        if ($phpStanType instanceof ObjectWithoutClassType) {
-            if ($this->phpVersionProvider->isAtLeast(PhpVersionFeature::OBJECT_TYPE)) {
-                return new Identifier('object');
-            }
-
-            return null;
-        }
-
-        throw new NotImplementedException(__METHOD__ . ' for ' . get_class($phpStanType));
+        return $this->phpStanStaticTypeMapper->mapToPhpParserNode($phpStanType, $kind);
     }
 
     public function mapPHPStanTypeToDocString(Type $phpStanType, ?Type $parentType = null): string
@@ -705,96 +500,6 @@ final class StaticTypeMapper
         throw new NotImplementedException(__METHOD__ . ' for ' . get_class($typeNode));
     }
 
-    private function matchArrayTypes(UnionType $unionType): ?Identifier
-    {
-        $isNullableType = false;
-        $hasIterable = false;
-
-        foreach ($unionType->getTypes() as $unionedType) {
-            if ($unionedType instanceof IterableType) {
-                $hasIterable = true;
-                continue;
-            }
-
-            if ($unionedType instanceof ArrayType) {
-                continue;
-            }
-
-            if ($unionedType instanceof NullType) {
-                $isNullableType = true;
-                continue;
-            }
-
-            if ($unionedType instanceof ObjectType) {
-                if ($unionedType->getClassName() === Traversable::class) {
-                    $hasIterable = true;
-                    continue;
-                }
-            }
-
-            return null;
-        }
-
-        $type = $hasIterable ? 'iterable' : 'array';
-        if ($isNullableType) {
-            return new Identifier('?' . $type);
-        }
-
-        return new Identifier($type);
-    }
-
-    private function matchTypeForNullableUnionType(UnionType $unionType): ?Type
-    {
-        if (count($unionType->getTypes()) !== 2) {
-            return null;
-        }
-
-        $firstType = $unionType->getTypes()[0];
-        $secondType = $unionType->getTypes()[1];
-
-        if ($firstType instanceof NullType) {
-            return $secondType;
-        }
-
-        if ($secondType instanceof NullType) {
-            return $firstType;
-        }
-
-        return null;
-    }
-
-    /**
-     * @return Name|FullyQualified|PhpParserUnionType|null
-     */
-    private function matchTypeForUnionedObjectTypes(UnionType $unionType): ?Node
-    {
-        $phpParserUnionType = $this->matchPhpParserUnionType($unionType);
-        if ($phpParserUnionType !== null) {
-            return $phpParserUnionType;
-        }
-
-        // do the type should be compatible with all other types, e.g. A extends B, B
-        foreach ($unionType->getTypes() as $unionedType) {
-            if (! $unionedType instanceof TypeWithClassName) {
-                return null;
-            }
-
-            foreach ($unionType->getTypes() as $nestedUnionedType) {
-                if (! $nestedUnionedType instanceof TypeWithClassName) {
-                    return null;
-                }
-
-                if (! $this->areTypeWithClassNamesRelated($unionedType, $nestedUnionedType)) {
-                    continue 2;
-                }
-            }
-
-            return new FullyQualified($unionedType->getClassName());
-        }
-
-        return null;
-    }
-
     private function mapScalarStringToType(string $scalarName): ?Type
     {
         $loweredScalarName = Strings::lower($scalarName);
@@ -843,54 +548,5 @@ final class StaticTypeMapper
         }
 
         return null;
-    }
-
-    private function matchPhpParserUnionType(UnionType $unionType): ?PhpParserUnionType
-    {
-        if (! $this->phpVersionProvider->isAtLeast(PhpVersionFeature::UNION_TYPES)) {
-            return null;
-        }
-
-        $phpParserUnionedTypes = [];
-        foreach ($unionType->getTypes() as $unionedType) {
-            /** @var Identifier|Name|null $phpParserNode */
-            $phpParserNode = $this->mapPHPStanTypeToPhpParserNode($unionedType);
-            if ($phpParserNode === null) {
-                return null;
-            }
-
-            $phpParserUnionedTypes[] = $phpParserNode;
-        }
-
-        return new PhpParserUnionType($phpParserUnionedTypes);
-    }
-
-    private function areTypeWithClassNamesRelated(TypeWithClassName $firstType, TypeWithClassName $secondType): bool
-    {
-        if (is_a($firstType->getClassName(), $secondType->getClassName(), true)) {
-            return true;
-        }
-
-        return is_a($secondType->getClassName(), $firstType->getClassName(), true);
-    }
-
-    private function convertUnionArrayTypeNodesToArrayTypeOfUnionTypeNodes(
-        UnionTypeNode $unionTypeNode
-    ): AttributeAwareUnionTypeNode {
-        $unionedArrayType = [];
-        foreach ($unionTypeNode->types as $unionedType) {
-            if ($unionedType instanceof UnionTypeNode) {
-                foreach ($unionedType->types as $key => $subUnionedType) {
-                    $unionedType->types[$key] = new ArrayTypeNode($subUnionedType);
-                }
-
-                $unionedArrayType[] = $unionedType;
-                continue;
-            }
-
-            $unionedArrayType[] = new ArrayTypeNode($unionedType);
-        }
-
-        return new AttributeAwareUnionTypeNode($unionedArrayType);
     }
 }

--- a/packages/NodeTypeResolver/tests/StaticTypeMapper/StaticTypeMapperTest.php
+++ b/packages/NodeTypeResolver/tests/StaticTypeMapper/StaticTypeMapperTest.php
@@ -49,7 +49,10 @@ final class StaticTypeMapperTest extends AbstractKernelTestCase
         $genericTypeNode = new GenericTypeNode(new IdentifierTypeNode('Traversable'), []);
         yield [$genericTypeNode, GenericObjectType::class];
 
-        $genericTypeNode = new GenericTypeNode(new IdentifierTypeNode('iterable'), []);
+        $genericTypeNode = new GenericTypeNode(new IdentifierTypeNode('iterable'), [
+            new IdentifierTypeNode('string'),
+        ]);
+
         yield [$genericTypeNode, IterableType::class];
     }
 

--- a/packages/PHPStanStaticTypeMapper/config/config.yaml
+++ b/packages/PHPStanStaticTypeMapper/config/config.yaml
@@ -1,0 +1,8 @@
+services:
+    _defaults:
+        public: true
+        autowire: true
+
+    Rector\PHPStanStaticTypeMapper\:
+        resource: '../src'
+        exclude:

--- a/packages/PHPStanStaticTypeMapper/src/PHPStanStaticTypeMapper.php
+++ b/packages/PHPStanStaticTypeMapper/src/PHPStanStaticTypeMapper.php
@@ -1,0 +1,420 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPStanStaticTypeMapper;
+
+use PhpParser\Node;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\NullableType;
+use PhpParser\Node\UnionType as PhpParserUnionType;
+use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\BooleanType;
+use PHPStan\Type\CallableType;
+use PHPStan\Type\ClassStringType;
+use PHPStan\Type\ClosureType;
+use PHPStan\Type\FloatType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\IterableType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\NeverType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\ObjectWithoutClassType;
+use PHPStan\Type\ResourceType;
+use PHPStan\Type\StaticType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\ThisType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeWithClassName;
+use PHPStan\Type\UnionType;
+use PHPStan\Type\VoidType;
+use Rector\AttributeAwarePhpDoc\Ast\Type\AttributeAwareUnionTypeNode;
+use Rector\Exception\NotImplementedException;
+use Rector\Exception\ShouldNotHappenException;
+use Rector\Php\PhpVersionProvider;
+use Rector\PHPStan\Type\AliasedObjectType;
+use Rector\PHPStan\Type\ParentStaticType;
+use Rector\PHPStan\Type\SelfObjectType;
+use Rector\PHPStan\Type\ShortenedObjectType;
+use Rector\ValueObject\PhpVersionFeature;
+use Traversable;
+
+final class PHPStanStaticTypeMapper
+{
+    /**
+     * @var PhpVersionProvider
+     */
+    private $phpVersionProvider;
+
+    public function __construct(PhpVersionProvider $phpVersionProvider)
+    {
+        $this->phpVersionProvider = $phpVersionProvider;
+    }
+
+    public function mapToPHPStanPhpDocTypeNode(Type $phpStanType)
+    {
+        if ($phpStanType instanceof MixedType) {
+            return new IdentifierTypeNode('mixed');
+        }
+
+        if ($phpStanType instanceof UnionType) {
+            $unionTypesNodes = [];
+            foreach ($phpStanType->getTypes() as $unionedType) {
+                $unionTypesNodes[] = $this->mapToPHPStanPhpDocTypeNode($unionedType);
+            }
+
+            $unionTypesNodes = array_unique($unionTypesNodes);
+
+            return new AttributeAwareUnionTypeNode($unionTypesNodes);
+        }
+
+        if ($phpStanType instanceof ArrayType || $phpStanType instanceof IterableType) {
+            $itemTypeNode = $this->mapToPHPStanPhpDocTypeNode($phpStanType->getItemType());
+
+            if ($itemTypeNode instanceof UnionTypeNode) {
+                return $this->convertUnionArrayTypeNodesToArrayTypeOfUnionTypeNodes($itemTypeNode);
+            }
+
+            return new ArrayTypeNode($itemTypeNode);
+        }
+
+        if ($phpStanType instanceof IntegerType) {
+            return new IdentifierTypeNode('int');
+        }
+
+        if ($phpStanType instanceof ClassStringType) {
+            return new IdentifierTypeNode('class-string');
+        }
+
+        if ($phpStanType instanceof StringType) {
+            return new IdentifierTypeNode('string');
+        }
+
+        if ($phpStanType instanceof BooleanType) {
+            return new IdentifierTypeNode('bool');
+        }
+
+        if ($phpStanType instanceof FloatType) {
+            return new IdentifierTypeNode('float');
+        }
+
+        if ($phpStanType instanceof ObjectType) {
+            return new IdentifierTypeNode('\\' . $phpStanType->getClassName());
+        }
+
+        if ($phpStanType instanceof NullType) {
+            return new IdentifierTypeNode('null');
+        }
+
+        if ($phpStanType instanceof NeverType) {
+            return new IdentifierTypeNode('mixed');
+        }
+
+        throw new NotImplementedException(__METHOD__ . ' for ' . get_class($phpStanType));
+    }
+
+    /**
+     * @return Identifier|Name|NullableType|PhpParserUnionType|null
+     */
+    public function mapToPhpParserNode(Type $phpStanType, ?string $kind = null): ?Node
+    {
+        if ($phpStanType instanceof VoidType) {
+            if ($this->phpVersionProvider->isAtLeast(PhpVersionFeature::VOID_TYPE)) {
+                if (in_array($kind, ['param', 'property'], true)) {
+                    // param cannot be void
+                    return null;
+                }
+
+                return new Identifier('void');
+            }
+
+            return null;
+        }
+
+        if ($phpStanType instanceof SelfObjectType) {
+            return new Identifier('self');
+        }
+
+        if ($phpStanType instanceof IntegerType) {
+            if ($this->phpVersionProvider->isAtLeast(PhpVersionFeature::SCALAR_TYPES)) {
+                return new Identifier('int');
+            }
+
+            return null;
+        }
+
+        if ($phpStanType instanceof StringType) {
+            if ($this->phpVersionProvider->isAtLeast(PhpVersionFeature::SCALAR_TYPES)) {
+                return new Identifier('string');
+            }
+
+            return null;
+        }
+
+        if ($phpStanType instanceof BooleanType) {
+            if ($this->phpVersionProvider->isAtLeast(PhpVersionFeature::SCALAR_TYPES)) {
+                return new Identifier('bool');
+            }
+
+            return null;
+        }
+
+        if ($phpStanType instanceof FloatType) {
+            if ($this->phpVersionProvider->isAtLeast(PhpVersionFeature::SCALAR_TYPES)) {
+                return new Identifier('float');
+            }
+
+            return null;
+        }
+
+        if ($phpStanType instanceof ArrayType) {
+            return new Identifier('array');
+        }
+
+        if ($phpStanType instanceof IterableType) {
+            return new Identifier('iterable');
+        }
+
+        if ($phpStanType instanceof ThisType) {
+            return new Identifier('self');
+        }
+
+        if ($phpStanType instanceof ParentStaticType) {
+            return new Identifier('parent');
+        }
+
+        if ($phpStanType instanceof StaticType) {
+            return null;
+        }
+
+        if ($phpStanType instanceof CallableType || $phpStanType instanceof ClosureType) {
+            if ($kind === 'property') {
+                return null;
+            }
+
+            return new Identifier('callable');
+        }
+
+        if ($phpStanType instanceof ShortenedObjectType) {
+            return new Name\FullyQualified($phpStanType->getFullyQualifiedName());
+        }
+
+        if ($phpStanType instanceof AliasedObjectType) {
+            return new Name($phpStanType->getClassName());
+        }
+
+        if ($phpStanType instanceof TypeWithClassName) {
+            $lowerCasedClassName = strtolower($phpStanType->getClassName());
+            if ($lowerCasedClassName === 'callable') {
+                return new Identifier('callable');
+            }
+
+            if ($lowerCasedClassName === 'self') {
+                return new Identifier('self');
+            }
+
+            if ($lowerCasedClassName === 'static') {
+                return null;
+            }
+
+            if ($lowerCasedClassName === 'mixed') {
+                return null;
+            }
+
+            return new Name\FullyQualified($phpStanType->getClassName());
+        }
+
+        if ($phpStanType instanceof UnionType) {
+            // match array types
+            $arrayNode = $this->matchArrayTypes($phpStanType);
+            if ($arrayNode !== null) {
+                return $arrayNode;
+            }
+
+            // special case for nullable
+            $nullabledType = $this->matchTypeForNullableUnionType($phpStanType);
+            if ($nullabledType === null) {
+                // use first unioned type in case of unioned object types
+                return $this->matchTypeForUnionedObjectTypes($phpStanType);
+            }
+
+            $nullabledTypeNode = $this->mapToPhpParserNode($nullabledType);
+            if ($nullabledTypeNode === null) {
+                return null;
+            }
+
+            if ($nullabledTypeNode instanceof NullableType) {
+                return $nullabledTypeNode;
+            }
+
+            if ($nullabledTypeNode instanceof PhpParserUnionType) {
+                throw new ShouldNotHappenException();
+            }
+
+            return new NullableType($nullabledTypeNode);
+        }
+
+        if ($phpStanType instanceof NeverType ||
+            $phpStanType instanceof VoidType ||
+            $phpStanType instanceof MixedType ||
+            $phpStanType instanceof ResourceType ||
+            $phpStanType instanceof NullType
+        ) {
+            return null;
+        }
+
+        if ($phpStanType instanceof ObjectWithoutClassType) {
+            if ($this->phpVersionProvider->isAtLeast(PhpVersionFeature::OBJECT_TYPE)) {
+                return new Identifier('object');
+            }
+
+            return null;
+        }
+
+        throw new NotImplementedException(__METHOD__ . ' for ' . get_class($phpStanType));
+    }
+
+    private function convertUnionArrayTypeNodesToArrayTypeOfUnionTypeNodes(
+        UnionTypeNode $unionTypeNode
+    ): AttributeAwareUnionTypeNode {
+        $unionedArrayType = [];
+        foreach ($unionTypeNode->types as $unionedType) {
+            if ($unionedType instanceof UnionTypeNode) {
+                foreach ($unionedType->types as $key => $subUnionedType) {
+                    $unionedType->types[$key] = new ArrayTypeNode($subUnionedType);
+                }
+
+                $unionedArrayType[] = $unionedType;
+                continue;
+            }
+
+            $unionedArrayType[] = new ArrayTypeNode($unionedType);
+        }
+
+        return new AttributeAwareUnionTypeNode($unionedArrayType);
+    }
+
+    private function matchTypeForNullableUnionType(UnionType $unionType): ?Type
+    {
+        if (count($unionType->getTypes()) !== 2) {
+            return null;
+        }
+
+        $firstType = $unionType->getTypes()[0];
+        $secondType = $unionType->getTypes()[1];
+
+        if ($firstType instanceof NullType) {
+            return $secondType;
+        }
+
+        if ($secondType instanceof NullType) {
+            return $firstType;
+        }
+
+        return null;
+    }
+
+    /**
+     * @return Name|Name\FullyQualified|PhpParserUnionType|null
+     */
+    private function matchTypeForUnionedObjectTypes(UnionType $unionType): ?Node
+    {
+        $phpParserUnionType = $this->matchPhpParserUnionType($unionType);
+        if ($phpParserUnionType !== null) {
+            return $phpParserUnionType;
+        }
+
+        // do the type should be compatible with all other types, e.g. A extends B, B
+        foreach ($unionType->getTypes() as $unionedType) {
+            if (! $unionedType instanceof TypeWithClassName) {
+                return null;
+            }
+
+            foreach ($unionType->getTypes() as $nestedUnionedType) {
+                if (! $nestedUnionedType instanceof TypeWithClassName) {
+                    return null;
+                }
+
+                if (! $this->areTypeWithClassNamesRelated($unionedType, $nestedUnionedType)) {
+                    continue 2;
+                }
+            }
+
+            return new Name\FullyQualified($unionedType->getClassName());
+        }
+
+        return null;
+    }
+
+    private function areTypeWithClassNamesRelated(TypeWithClassName $firstType, TypeWithClassName $secondType): bool
+    {
+        if (is_a($firstType->getClassName(), $secondType->getClassName(), true)) {
+            return true;
+        }
+
+        return is_a($secondType->getClassName(), $firstType->getClassName(), true);
+    }
+
+    private function matchArrayTypes(UnionType $unionType): ?Identifier
+    {
+        $isNullableType = false;
+        $hasIterable = false;
+
+        foreach ($unionType->getTypes() as $unionedType) {
+            if ($unionedType instanceof IterableType) {
+                $hasIterable = true;
+                continue;
+            }
+
+            if ($unionedType instanceof ArrayType) {
+                continue;
+            }
+
+            if ($unionedType instanceof NullType) {
+                $isNullableType = true;
+                continue;
+            }
+
+            if ($unionedType instanceof ObjectType) {
+                if ($unionedType->getClassName() === Traversable::class) {
+                    $hasIterable = true;
+                    continue;
+                }
+            }
+
+            return null;
+        }
+
+        $type = $hasIterable ? 'iterable' : 'array';
+        if ($isNullableType) {
+            return new Identifier('?' . $type);
+        }
+
+        return new Identifier($type);
+    }
+
+    private function matchPhpParserUnionType(UnionType $unionType): ?PhpParserUnionType
+    {
+        if (! $this->phpVersionProvider->isAtLeast(PhpVersionFeature::UNION_TYPES)) {
+            return null;
+        }
+
+        $phpParserUnionedTypes = [];
+        foreach ($unionType->getTypes() as $unionedType) {
+            /** @var Identifier|Name|null $phpParserNode */
+            $phpParserNode = $this->mapToPhpParserNode($unionedType);
+            if ($phpParserNode === null) {
+                return null;
+            }
+
+            $phpParserUnionedTypes[] = $phpParserNode;
+        }
+
+        return new PhpParserUnionType($phpParserUnionedTypes);
+    }
+}

--- a/packages/TypeDeclaration/tests/Rector/Property/CompleteVarDocTypePropertyRector/Fixture/symfony_console_helper_set.php.inc
+++ b/packages/TypeDeclaration/tests/Rector/Property/CompleteVarDocTypePropertyRector/Fixture/symfony_console_helper_set.php.inc
@@ -1,0 +1,76 @@
+<?php
+
+namespace Rector\TypeDeclaration\Tests\Rector\Property\CompleteVarDocTypePropertyRector\Fixture;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Helper\HelperSet;
+
+class SymfonyConsoleHelperSet
+{
+    private $helperSet;
+
+    public function setApplication(Application $application = null)
+    {
+        $this->application = $application;
+        if ($application) {
+            $this->setHelperSet($application->getHelperSet());
+        } else {
+            $this->helperSet = null;
+        }
+    }
+
+    public function setHelperSet(HelperSet $helperSet)
+    {
+        $this->helperSet = $helperSet;
+    }
+
+    /**
+     * @return HelperSet
+     */
+    public function getHelperSet()
+    {
+        return $this->helperSet;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\TypeDeclaration\Tests\Rector\Property\CompleteVarDocTypePropertyRector\Fixture;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Helper\HelperSet;
+
+class SymfonyConsoleHelperSet
+{
+    /**
+     * @var \Symfony\Component\Console\Helper\HelperSet
+     */
+    private $helperSet;
+
+    public function setApplication(Application $application = null)
+    {
+        $this->application = $application;
+        if ($application) {
+            $this->setHelperSet($application->getHelperSet());
+        } else {
+            $this->helperSet = null;
+        }
+    }
+
+    public function setHelperSet(HelperSet $helperSet)
+    {
+        $this->helperSet = $helperSet;
+    }
+
+    /**
+     * @return HelperSet
+     */
+    public function getHelperSet()
+    {
+        return $this->helperSet;
+    }
+}
+
+?>

--- a/rector.yaml
+++ b/rector.yaml
@@ -1,7 +1,5 @@
 services:
     Rector\CodingStyle\Rector\Namespace_\ImportFullyQualifiedNamesRector: null
-#    Rector\SOLID\Rector\If_\ChangeNestedIfsToEarlyReturnRector: null
-#    Rector\SOLID\Rector\If_\ChangeIfElseValueAssignToEarlyReturnRector: null
 
 imports:
     - { resource: "create-rector.yaml", ignore_errors: true }

--- a/stubs/Symfony/Component/Console/Helper/HelperSet.php
+++ b/stubs/Symfony/Component/Console/Helper/HelperSet.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Console\Helper;
+
+if (class_exists('Symfony\Component\Console\Helper')) {
+    return;
+}
+
+class HelperSet
+{
+
+}


### PR DESCRIPTION
Follow up to design cleanup in https://github.com/rectorphp/rector/pull/2649

Moving from god classes to collector pattern and CI checked compatbility with PHPStan types

Closes #2614

## Todo

- [ ] check with CI command compatibility
- [ ] change to collector pattern
- [ ] possibly re-use https://github.com/phpstan/phpstan-src/blob/master/src/PhpDoc/TypeNodeResolver.php