### PR TITLE
Changed ChangeMethodVisibilityRector yaml config

### DIFF
--- a/docs/AllRectorsOverview.md
+++ b/docs/AllRectorsOverview.md
@@ -8722,7 +8722,8 @@ Change visibility of method from parent class.
 ```yaml
 services:
     Rector\Rector\Visibility\ChangeMethodVisibilityRector:
-        FrameworkClass:
+        $methodToVisibilityByClass:
+            FrameworkClass:
             someMethod: protected
 ```
 

--- a/src/Rector/Visibility/ChangeMethodVisibilityRector.php
+++ b/src/Rector/Visibility/ChangeMethodVisibilityRector.php
@@ -67,8 +67,10 @@ class MyClass extends FrameworkClass
 PHP
                 ,
                 [
-                    'FrameworkClass' => [
-                        'someMethod' => 'protected',
+                    '$methodToVisibilityByClass' => [
+                        'FrameworkClass' => [
+                            'someMethod' => 'protected',
+                        ],
                     ],
                 ]
             )]


### PR DESCRIPTION
The example config resulted in an invalid yaml file with the current rector version.
`The configuration key "FrameworkClass" is unsupported for definition`