### PR TITLE
Add SetcookieRector

### DIFF
--- a/docs/AllRectorsOverview.md
+++ b/docs/AllRectorsOverview.md
@@ -1,4 +1,4 @@
-# All 442 Rectors Overview
+# All 443 Rectors Overview
 
 - [Projects](#projects)
 - [General](#general)
@@ -6197,6 +6197,24 @@ Changes heredoc/nowdoc that contains closing word to safe wrapper name
      A
 -A
 +A_WRAP
+```
+
+<br>
+
+### `SetcookieRector`
+
+- class: `Rector\Php73\Rector\FuncCall\SetcookieRector`
+
+Convert setcookie argument to PHP7.3 option array
+
+```diff
+-setcookie('name', $value, 360);
++setcookie('name', $value, ['expires' => 360]);
+```
+
+```diff
+-setcookie('name', $name, 0, '', '', true, true);
++setcookie('name', $name, ['expires' => 0, 'path' => '', 'domain' => '', 'secure' => true, 'httponly' => true]);
 ```
 
 <br>

--- a/packages/Php73/src/Rector/FuncCall/SetcookieRector.php
+++ b/packages/Php73/src/Rector/FuncCall/SetcookieRector.php
@@ -106,7 +106,7 @@ PHP
 
     private function shouldSkip(FuncCall $funcCall): bool
     {
-        if (! $this->isNames($funcCall, ['setcookie'])) {
+        if (! $this->isNames($funcCall, ['setcookie', 'setrawcookie'])) {
             return true;
         }
 

--- a/packages/Php73/src/Rector/FuncCall/SetcookieRector.php
+++ b/packages/Php73/src/Rector/FuncCall/SetcookieRector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Php73\Rector\FuncCall;
 
+use function count;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\Array_;
@@ -26,6 +27,7 @@ final class SetcookieRector extends AbstractRector
 {
     /**
      * Conversion table from argument index to options name
+     * @var string[]
      */
     private const KNOWN_OPTIONS = [
         2 => 'expires',
@@ -114,7 +116,7 @@ PHP
             return true;
         }
 
-        $args_count = \count($funcCall->args);
+        $args_count = count($funcCall->args);
 
         if ($args_count <= 2) {
             return true;

--- a/packages/Php73/src/Rector/FuncCall/SetcookieRector.php
+++ b/packages/Php73/src/Rector/FuncCall/SetcookieRector.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Php73\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Variable;
+use Rector\Rector\AbstractRector;
+use Rector\RectorDefinition\CodeSample;
+use Rector\RectorDefinition\RectorDefinition;
+use Rector\ValueObject\PhpVersionFeature;
+
+/**
+ * Convert legacy setcookie arguments to new array options
+ *
+ * @see https://www.php.net/setcookie
+ * @see https://wiki.php.net/rfc/same-site-cookie
+ */
+final class SetcookieRector extends AbstractRector
+{
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition(
+            'Convert setcookie argument to PHP7.3 option array',
+            [
+                new CodeSample(
+                    <<<'PHP'
+setcookie('name', $value, 360);
+PHP
+                    ,
+                    <<<'PHP'
+setcookie('name', $value, ['expires' => 360]);
+PHP
+                ),
+                new CodeSample(
+<<<'PHP'
+setcookie('name', $name, 0, '', '', true, true);
+PHP
+                    ,
+<<<'PHP'
+setcookie('name', $name, ['expires' => 0, 'path' => '', 'domain' => '', 'secure' => true, 'httponly' => true]);
+PHP
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    /**
+     * @param FuncCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($this->shouldSkip($node)) {
+            return null;
+        }
+
+        return $node;
+    }
+
+    private function shouldSkip(FuncCall $funcCall): bool
+    {
+        if (! $this->isNames($funcCall, ['setcookie'])) {
+            return true;
+        }
+
+        if (! $this->isAtLeastPhpVersion(PhpVersionFeature::SETCOOKIE_ACCEPT_ARRAY_OPTIONS)) {
+            return true;
+        }
+
+        $args_count = \count($funcCall->args);
+
+        if ($args_count <= 2) {
+            return true;
+        }
+
+        if ($funcCall->args[2]->value instanceof Array_) {
+            return true;
+        }
+
+        if ($args_count === 3) {
+            return $funcCall->args[2]->value instanceof Variable;
+        }
+
+        return false;
+    }
+}

--- a/packages/Php73/tests/Rector/FuncCall/SetcookieRector/Fixture/no_modified.php.inc
+++ b/packages/Php73/tests/Rector/FuncCall/SetcookieRector/Fixture/no_modified.php.inc
@@ -13,19 +13,3 @@ if (false) {
     setcookie(...$args);
 }
 ?>
------
-<?php
-if (false) {
-    setcookie('name');
-    setcookie('name', 'value');
-    $name = 'name';
-    $value = 'value';
-    $expire = 3600;
-    $args = [$name, $value, $expire];
-    setcookie($name);
-    setcookie($name, $value);
-    setcookie($name, $value, $expire);
-    setcookie($name, $value, ...$args);
-    setcookie(...$args);
-}
-?>

--- a/packages/Php73/tests/Rector/FuncCall/SetcookieRector/Fixture/no_modified.php.inc
+++ b/packages/Php73/tests/Rector/FuncCall/SetcookieRector/Fixture/no_modified.php.inc
@@ -11,5 +11,7 @@ if (false) {
     setcookie($name, $value, $expire);
     setcookie($name, $value, ...$args);
     setcookie(...$args);
+    setrawcookie('name');
+    setrawcookie('name', 'value');
 }
 ?>

--- a/packages/Php73/tests/Rector/FuncCall/SetcookieRector/Fixture/no_modified.php.inc
+++ b/packages/Php73/tests/Rector/FuncCall/SetcookieRector/Fixture/no_modified.php.inc
@@ -1,0 +1,31 @@
+<?php
+if (false) {
+    setcookie('name');
+    setcookie('name', 'value');
+    $name = 'name';
+    $value = 'value';
+    $expire = 3600;
+    $args = [$name, $value, $expire];
+    setcookie($name);
+    setcookie($name, $value);
+    setcookie($name, $value, $expire);
+    setcookie($name, $value, ...$args);
+    setcookie(...$args);
+}
+?>
+-----
+<?php
+if (false) {
+    setcookie('name');
+    setcookie('name', 'value');
+    $name = 'name';
+    $value = 'value';
+    $expire = 3600;
+    $args = [$name, $value, $expire];
+    setcookie($name);
+    setcookie($name, $value);
+    setcookie($name, $value, $expire);
+    setcookie($name, $value, ...$args);
+    setcookie(...$args);
+}
+?>

--- a/packages/Php73/tests/Rector/FuncCall/SetcookieRector/Fixture/options_specified.php.inc
+++ b/packages/Php73/tests/Rector/FuncCall/SetcookieRector/Fixture/options_specified.php.inc
@@ -14,6 +14,7 @@ if (false) {
     setcookie('name', 'value', 0, '', '');
     setcookie('name', 'value', 0, '', '', false);
     setcookie('name', 'value', 0, '', '', false, false);
+    setrawcookie('name', 'value', 3600);
 }
 ?>
 -----
@@ -33,5 +34,6 @@ if (false) {
     setcookie('name', 'value', ['expires' => 0, 'path' => '', 'domain' => '']);
     setcookie('name', 'value', ['expires' => 0, 'path' => '', 'domain' => '', 'secure' => false]);
     setcookie('name', 'value', ['expires' => 0, 'path' => '', 'domain' => '', 'secure' => false, 'httponly' => false]);
+    setrawcookie('name', 'value', ['expires' => 3600]);
 }
 ?>

--- a/packages/Php73/tests/Rector/FuncCall/SetcookieRector/Fixture/options_specified.php.inc
+++ b/packages/Php73/tests/Rector/FuncCall/SetcookieRector/Fixture/options_specified.php.inc
@@ -1,0 +1,37 @@
+<?php
+if (false) {
+    $expire = 3600;
+    $path = '';
+    $domain = '';
+    $secure = false;
+    $httponly = false;
+    setcookie('name', 'value', 3600);
+    setcookie('name', 'value', $expire, $path);
+    setcookie('name', 'value', $expire, $path, $domain);
+    setcookie('name', 'value', $expire, $path, $domain, $secure);
+    setcookie('name', 'value', $expire, $path, $domain, $secure, $httponly);
+    setcookie('name', 'value', 0, '');
+    setcookie('name', 'value', 0, '', '');
+    setcookie('name', 'value', 0, '', '', false);
+    setcookie('name', 'value', 0, '', '', false, false);
+}
+?>
+-----
+<?php
+if (false) {
+    $expire = 3600;
+    $path = '';
+    $domain = '';
+    $secure = false;
+    $httponly = false;
+    setcookie('name', 'value', ['expires' => 3600]);
+    setcookie('name', 'value', ['expires' => $expire, 'path' => $path]);
+    setcookie('name', 'value', ['expires' => $expire, 'path' => $path, 'domain' => $domain]);
+    setcookie('name', 'value', ['expires' => $expire, 'path' => $path, 'domain' => $domain, 'secure' => $secure]);
+    setcookie('name', 'value', ['expires' => $expire, 'path' => $path, 'domain' => $domain, 'secure' => $secure, 'httponly' => $httponly]);
+    setcookie('name', 'value', ['expires' => 0, 'path' => '']);
+    setcookie('name', 'value', ['expires' => 0, 'path' => '', 'domain' => '']);
+    setcookie('name', 'value', ['expires' => 0, 'path' => '', 'domain' => '', 'secure' => false]);
+    setcookie('name', 'value', ['expires' => 0, 'path' => '', 'domain' => '', 'secure' => false, 'httponly' => false]);
+}
+?>

--- a/packages/Php73/tests/Rector/FuncCall/SetcookieRector/SetcookieRectorTest.php
+++ b/packages/Php73/tests/Rector/FuncCall/SetcookieRector/SetcookieRectorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Php73\Tests\Rector\FuncCall\SetcookieRector;
+
+use Iterator;
+use Rector\Php73\Rector\FuncCall\SetcookieRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class SetcookieRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideDataForTest()
+     */
+    public function test(string $file): void
+    {
+        $this->doTestFile($file);
+    }
+
+    public function provideDataForTest(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    protected function getRectorClass(): string
+    {
+        return SetcookieRector::class;
+    }
+}

--- a/src/ValueObject/PhpVersionFeature.php
+++ b/src/ValueObject/PhpVersionFeature.php
@@ -104,6 +104,11 @@ final class PhpVersionFeature
     /**
      * @var string
      */
+    public const SETCOOKIE_ACCEPT_ARRAY_OPTIONS = '7.3';
+
+    /**
+     * @var string
+     */
     public const ARROW_FUNCTION = '7.4';
 
     /**


### PR DESCRIPTION
Convert to [`setcookie()`](https://www.php.net/setcookie) options array introduced in PHP 7.3.

This Rector just breaks backward compatibility with less than PHP 7.3 since PHP 7.3 actually supports old arguments. However, since the option array is required to set the `samesite` attribute, the changes are highlighted.
