### PR TITLE
Docker build secured image for online demo

### DIFF
--- a/.docker/php/security.ini
+++ b/.docker/php/security.ini
@@ -1,0 +1,11 @@
+# inspired by https://www.cyberciti.biz/tips/php-security-best-practices-tutorial.html
+
+disable_functions = "exec, passthru, shell_exec, system, proc_open, popen, curl_exec, curl_multi_exec, parse_ini_file, show_source"
+
+allow_url_fopen = off
+allow_url_include = off
+file_uploads = off
+
+post_max_size = 256k
+
+open_basedir="/project/:/rector/:/tmp/"

--- a/.github/workflows/publish_docker_images.yml
+++ b/.github/workflows/publish_docker_images.yml
@@ -1,0 +1,39 @@
+name: Build docker images
+on:
+    push:
+        # Publish `master` as Docker `latest` image.
+        branches:
+            - master
+
+        # Publish `v1.2.3` tags as releases.
+        tags:
+            - v*
+
+jobs:
+    publish_images:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+
+            - name: Build images
+              run: |
+                  # Strip git ref prefix from version
+                  VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+                  # Strip "v" prefix from tag name
+                  [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+                  # Use Docker `latest` tag convention
+                  [ "$VERSION" == "master" ] && VERSION=latest
+
+                  docker pull rector/rector || true
+                  docker build . --target rector --cache-from rector/rector --tag rector/rector:$VERSION
+                  docker build . --target rector-secured --cache-from rector/rector --tag rector/rector-secured:$VERSION
+
+            - name: Log into registry
+              run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+
+            - name: Push images
+              run: |
+                  docker push rector/rector
+                  docker push rector/rector-secured

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,16 @@ COPY stubs stubs
 RUN  composer install --no-dev --optimize-autoloader --prefer-dist
 
 
-FROM php:7.4-cli
+FROM php:7.4-cli as rector
 WORKDIR /rector
 
-COPY . .
 COPY --from=composer /app .
+COPY . .
 
 ENTRYPOINT [ "bin/rector" ]
+
+
+## Used for getrector.org/demo
+FROM rector as rector-secured
+
+COPY .docker/php/security.ini /usr/local/etc/php/conf.d/security.ini


### PR DESCRIPTION
After merging this PR, we can disable autobuild images on hub.docker.com, this way it way docker images will be deployed faster