### PR TITLE
Do not dump the compiler

### DIFF
--- a/src/HttpKernel/RectorKernel.php
+++ b/src/HttpKernel/RectorKernel.php
@@ -4,17 +4,20 @@ declare(strict_types=1);
 
 namespace Rector\HttpKernel;
 
+use Phar;
 use Rector\Contract\Rector\RectorInterface;
 use Rector\DependencyInjection\Collector\RectorServiceArgumentCollector;
 use Rector\DependencyInjection\CompilerPass\MergeImportedRectorServiceArgumentsCompilerPass;
 use Rector\DependencyInjection\CompilerPass\RemoveExcludedRectorsCompilerPass;
 use Rector\DependencyInjection\Loader\TolerantRectorYamlFileLoader;
+use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\Config\Loader\DelegatingLoader;
 use Symfony\Component\Config\Loader\GlobFileLoader;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\ErrorHandler\DebugClassLoader;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\Config\FileLocator;
 use Symfony\Component\HttpKernel\Kernel;
@@ -112,5 +115,75 @@ final class RectorKernel extends Kernel implements ExtraConfigAwareKernelInterfa
         ]);
 
         return new DelegatingLoader($loaderResolver);
+    }
+
+    protected function initializeContainer()
+    {
+        $class = $this->getContainerClass();
+        $cacheDir = $this->getCacheDir();
+
+        $collectDeprecations = ($this->debug && !\defined('PHPUNIT_COMPOSER_INSTALL') && '' === Phar::running(false));
+
+        if ($collectDeprecations) {
+            $collectedLogs = [];
+            $previousHandler = set_error_handler(static function ($type, $message, $file, $line) use (&$collectedLogs, &$previousHandler) {
+                if (E_USER_DEPRECATED !== $type && E_DEPRECATED !== $type) {
+                    return $previousHandler ? $previousHandler($type, $message, $file, $line) : false;
+                }
+
+                if (isset($collectedLogs[$message])) {
+                    ++$collectedLogs[$message]['count'];
+
+                    return null;
+                }
+
+                $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 5);
+                // Clean the trace by removing first frames added by the error handler itself.
+                for ($i = 0; isset($backtrace[$i]); ++$i) {
+                    if (isset($backtrace[$i]['file'], $backtrace[$i]['line']) && $backtrace[$i]['line'] === $line && $backtrace[$i]['file'] === $file) {
+                        $backtrace = \array_slice($backtrace, 1 + $i);
+                        break;
+                    }
+                }
+                // Remove frames added by DebugClassLoader.
+                for ($i = \count($backtrace) - 2; 0 < $i; --$i) {
+                    if (\in_array($backtrace[$i]['class'] ?? null, [DebugClassLoader::class, LegacyDebugClassLoader::class], true)) {
+                        $backtrace = [$backtrace[$i + 1]];
+                        break;
+                    }
+                }
+
+                $collectedLogs[$message] = [
+                    'type' => $type,
+                    'message' => $message,
+                    'file' => $file,
+                    'line' => $line,
+                    'trace' => [$backtrace[0]],
+                    'count' => 1,
+                ];
+
+                return null;
+            });
+        }
+
+        try {
+            $container = null;
+            $container = $this->buildContainer();
+            $container->compile();
+        } finally {
+            if ($collectDeprecations) {
+                restore_error_handler();
+
+                file_put_contents($cacheDir.'/'.$class.'Deprecations.log', serialize(array_values($collectedLogs)));
+                file_put_contents($cacheDir.'/'.$class.'Compiler.log', null !== $container ? implode("\n", $container->getCompiler()->getLog()) : '');
+            }
+        }
+
+        $this->container = $container;
+        $this->container->set('kernel', $this);
+
+        if ($this->container->has('cache_warmer')) {
+            $this->container->get('cache_warmer')->warmUp($this->container->getParameter('kernel.cache_dir'));
+        }
     }
 }


### PR DESCRIPTION
This is just an idea, I don't think I can manage the finish the PR but I would say the gist of it is there.

Basically based on #2611 you have to me two solutions:

- Either embrace the huge performance cost that using the non-dumped Symfony container (which means which needs to be compiled every single time) but in which case you don't want to dump it (except in dev maybe) - it's another unnecessary overhead (the IO writing) + it will definitely cause issues in a PHAR
- Refactor `Rector` to switch from a Symfony container to another one, at the very least for the dynamic configuration

I think the second solution is the right one: the Symfony container is _not_ meant to be compiled at every request/CLI call: it has a huge service abstraction + compilation time which are enormous and only acceptable because in practice, you dump it once ready for prod and you only use that tiny optimized dumped container.

But I guess it can be quite a huge refactoring, so the first one might be a better solution at least on the short-term.