### PR TITLE
github-action: Annotate Github Pull Requests based on a Checkstyle X…

### DIFF
--- a/.github/workflows/phpstan.yaml
+++ b/.github/workflows/phpstan.yaml
@@ -15,5 +15,7 @@ jobs:
                 with:
                     php-version: 7.3
                     coverage: none
-            -   run: composer install --no-progress
-            -   run: composer phpstan
+            -   run: |
+                    composer install --no-progress
+                    composer require staabm/annotate-pull-request-from-checkstyle:^1.0
+            -   run: composer phpstan --error-format=checkstyle | vendor/bin/cs2pr

--- a/.github/workflows/phpstan.yaml
+++ b/.github/workflows/phpstan.yaml
@@ -18,4 +18,5 @@ jobs:
             -   run: |
                     composer install --no-progress
                     composer require staabm/annotate-pull-request-from-checkstyle:^1.0
+            # turn the phpstan errors (formatted in checkstyle-format) into github pull request check annotations
             -   run: composer phpstan -- --error-format=checkstyle | vendor/bin/cs2pr

--- a/.github/workflows/phpstan.yaml
+++ b/.github/workflows/phpstan.yaml
@@ -16,7 +16,6 @@ jobs:
                     php-version: 7.3
                     coverage: none
                     tools: cs2pr
-            -   run: |
-                    composer install --no-progress
+            -   run: composer install --no-progress
             # turn the phpstan errors (formatted in checkstyle-format) into github pull request check annotations
             -   run: composer phpstan -- --error-format=checkstyle | cs2pr

--- a/.github/workflows/phpstan.yaml
+++ b/.github/workflows/phpstan.yaml
@@ -18,4 +18,4 @@ jobs:
             -   run: |
                     composer install --no-progress
                     composer require staabm/annotate-pull-request-from-checkstyle:^1.0
-            -   run: composer phpstan --error-format=checkstyle | vendor/bin/cs2pr
+            -   run: composer phpstan -- --error-format=checkstyle | vendor/bin/cs2pr

--- a/.github/workflows/phpstan.yaml
+++ b/.github/workflows/phpstan.yaml
@@ -15,8 +15,8 @@ jobs:
                 with:
                     php-version: 7.3
                     coverage: none
+                    tools: cs2pr  
             -   run: |
                     composer install --no-progress
-                    composer require staabm/annotate-pull-request-from-checkstyle:^1.0
             # turn the phpstan errors (formatted in checkstyle-format) into github pull request check annotations
-            -   run: composer phpstan -- --error-format=checkstyle | vendor/bin/cs2pr
+            -   run: composer phpstan -- --error-format=checkstyle | cs2pr

--- a/.github/workflows/phpstan.yaml
+++ b/.github/workflows/phpstan.yaml
@@ -15,7 +15,7 @@ jobs:
                 with:
                     php-version: 7.3
                     coverage: none
-                    tools: cs2pr  
+                    tools: cs2pr
             -   run: |
                     composer install --no-progress
             # turn the phpstan errors (formatted in checkstyle-format) into github pull request check annotations

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,6 +16,7 @@ parameters:
         - compiler/src
 
     excludes_analyse:
+        - "*/Expected/*"
         # complex printer
         - "packages/ContributorTools/src/Command/DumpNodesCommand.php"
         - "utils/phpstan/generate-paths.php"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,7 +16,6 @@ parameters:
         - compiler/src
 
     excludes_analyse:
-        - "*/Expected/*"
         # complex printer
         - "packages/ContributorTools/src/Command/DumpNodesCommand.php"
         - "utils/phpstan/generate-paths.php"


### PR DESCRIPTION
…ML-report

That means you no longer search thru your GithubAction logfiles. No need to interpret messages which are formatted differently with every tool. Instead you can focus on your Pull Request, and you don't need to leave the Pull Request area.

See https://github.com/staabm/annotate-pull-request-from-checkstyle