### PR TITLE
added --config parameter to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ parameters:
 
 ### C. Custom Sets
 
-1. Create a `rector.yaml` config file with your desired Rectors:
+1. Create a `rector.yaml` config file with your desired Rectors or provide another config file with `--config`:
 
     ```yaml
     services:


### PR DESCRIPTION
`--config` parameter was nowhere metioned. Therefore I complemented it at a useful place.

Further I suggest a dedicated chapter for all possible parameters in the future because they are nowhere explained. Other params like the `-n` as synonym for `-dry-run` is also not mentioned and could lead to confusion