### PR TITLE
Fix replacement for Table::buildRules()

### DIFF
--- a/config/set/cakephp/cakephp40.yaml
+++ b/config/set/cakephp/cakephp40.yaml
@@ -96,7 +96,7 @@ services:
                 buildValidator:
                     0: 'Cake\Event\EventInterface'
                 buildRules:
-                    0: 'Cake\Event\EventInterface'
+                    0: 'Cake\ORM\RulesChecker'
                 beforeRules:
                     0: 'Cake\Event\EventInterface'
                 afterRules:


### PR DESCRIPTION
I got this wrong last time. Refs cakephp/cakephp#14250