### PR TITLE
[PHP 74] Fix ArraySpreadInsteadOfArrayMergeRector for non-constant string keys

### DIFF
--- a/packages/php-74/tests/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector/Fixture/skip_parse_url.php.inc
+++ b/packages/php-74/tests/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector/Fixture/skip_parse_url.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Php74\Tests\Rector\FuncCall\ArraySpreadInsteadOfArrayMergeRector\Fixture;
+
+class SkipParseUrl
+{
+    public function run()
+    {
+        return array_merge($this->parseUrl($url), $this->parseUrl($redirectLocation));
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function parseUrl(string $url): array
+    {
+        $urlParts = parse_url($url);
+
+        return array_filter($urlParts);
+    }
+}


### PR DESCRIPTION
Closes #2170