### PR TITLE
WIP: #2753 Fix Auto Import Names

### DIFF
--- a/packages/renaming/tests/Rector/Class_/RenameClassRector/FixtureAutoImportNames/class_imported_as_alias.php.inc
+++ b/packages/renaming/tests/Rector/Class_/RenameClassRector/FixtureAutoImportNames/class_imported_as_alias.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\Renaming\Tests\Rector\Class_\RenameClassRector\Fixture\AutoImportNamesParameter;
+
+use Rector\Renaming\Tests\Rector\Class_\RenameClassRector\Source\FirstNamespace\FirstOriginalClass as AliasedClass;
+use Rector\Renaming\Tests\Rector\Class_\RenameClassRector\Source\SecondNamespace;
+
+$aliasedClass = new AliasedClass();
+$secondClass = new SecondNamespace\SecondOriginalClass();
+
+?>
+-----
+<?php
+
+namespace Rector\Renaming\Tests\Rector\Class_\RenameClassRector\Fixture\AutoImportNamesParameter;
+
+use Rector\Renaming\Tests\Rector\Class_\RenameClassRector\Source\SecondNamespace\SecondOriginalClass;
+use Rector\Renaming\Tests\Rector\Class_\RenameClassRector\Source\FirstNamespace\FirstOriginalClass as AliasedClass;
+
+$aliasedClass = new AliasedClass();
+$secondClass = new SecondOriginalClass();
+
+?>

--- a/packages/renaming/tests/Rector/Class_/RenameClassRector/FixtureAutoImportNames/class_imported_as_alias_with_namespace_with_false_condition.php.inc
+++ b/packages/renaming/tests/Rector/Class_/RenameClassRector/FixtureAutoImportNames/class_imported_as_alias_with_namespace_with_false_condition.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+namespace Rector\Renaming\Tests\Rector\Class_\RenameClassRector\Fixture\AutoImportNamesParameter;
+
+use NotExistingNamespace\ClassName as Alias;
+
+if (false) {
+    $someAlias = new Alias();
+}

--- a/packages/renaming/tests/Rector/Class_/RenameClassRector/FixtureAutoImportNames/class_imported_as_alias_without_namespace.php.inc
+++ b/packages/renaming/tests/Rector/Class_/RenameClassRector/FixtureAutoImportNames/class_imported_as_alias_without_namespace.php.inc
@@ -1,0 +1,5 @@
+<?php
+
+use NotExistingNamespace\ClassName as Alias;
+
+$someAlias = new Alias();

--- a/packages/renaming/tests/Rector/Class_/RenameClassRector/FixtureAutoImportNames/class_imported_as_alias_without_namespace_with_false_condition.php.inc
+++ b/packages/renaming/tests/Rector/Class_/RenameClassRector/FixtureAutoImportNames/class_imported_as_alias_without_namespace_with_false_condition.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+use NotExistingNamespace\ClassName as Alias;
+
+if (false) {
+    $someAlias = new Alias();
+}

--- a/packages/renaming/tests/Rector/Class_/RenameClassRector/Source/FirstNamespace/FirstOriginalClass.php
+++ b/packages/renaming/tests/Rector/Class_/RenameClassRector/Source/FirstNamespace/FirstOriginalClass.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Renaming\Tests\Rector\Class_\RenameClassRector\Source\FirstNamespace;
+
+final class FirstOriginalClass
+{
+}

--- a/packages/renaming/tests/Rector/Class_/RenameClassRector/Source/SecondNamespace/SecondOriginalClass.php
+++ b/packages/renaming/tests/Rector/Class_/RenameClassRector/Source/SecondNamespace/SecondOriginalClass.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace Rector\Renaming\Tests\Rector\Class_\RenameClassRector\Source\SecondNamespace;
+
+final class SecondOriginalClass
+{
+}


### PR DESCRIPTION
**WIP**

Ref  #2753.

Added 4 tests and 3 will fail. I need a help to understand expected result.

1) **class_imported_as_alias.php.inc**
`SecondOriginalClass` was imported but `SecondNamespace` was not removed from `use` section.

2) **class_imported_as_alias_with_namespace_with_false_condition.php.inc**
Passed however `NotExistingNamespace\ClassName` was not exist. Did `if (false) {` condition make it pass?

3) **class_imported_as_alias_without_namespace.php.inc**
Failed because `NotExistingNamespace\ClassName` didn't exist. Looks right.

4) **class_imported_as_alias_without_namespace_with_false_condition.php.inc**
This is the case from issue #2753. Alias replaced by original class name and alias was not removed from `use` section.
And one more question to this case: why it's not the same as in the second case? The only difference is presence of namespace.
