### PR TITLE
[BUGFIX] Add cross platform compatible newline character

### DIFF
--- a/src/Testing/PHPUnit/FixtureSplitter.php
+++ b/src/Testing/PHPUnit/FixtureSplitter.php
@@ -13,7 +13,7 @@ final class FixtureSplitter
     /**
      * @var string
      */
-    public const SPLIT_LINE = '#-----\n#';
+    public const SPLIT_LINE = '#-----' . PHP_EOL . '#';
 
     /**
      * @var string


### PR DESCRIPTION
We had issues with running tests on Windows. After short investigation we fixed this by providing the PHP_EOL constant.