### PR TITLE
Inject the coveralls token as a secret

### DIFF
--- a/.github/workflows/code_coverage.yaml
+++ b/.github/workflows/code_coverage.yaml
@@ -25,4 +25,4 @@ jobs:
                     wget https://github.com/php-coveralls/php-coveralls/releases/download/v2.1.0/php-coveralls.phar
                     php php-coveralls.phar --verbose
                 env:
-                    COVERALLS_REPO_TOKEN: 'Ew7FYsOKM3T3s1nEsPHJkSe6jdVIFHME8'
+                    COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}


### PR DESCRIPTION
1. Replace the Coveralls repo token in YAML with an environment variable.
2. Re-generate the token in Coveralls settings, since this one is already leaked online.
3. TODO: Set the new token as a `COVERALLS_REPO_TOKEN` variable in GitHub Actions Settings in the repository.