### PR TITLE
add first OXID rector

### DIFF
--- a/config/set/oxid/oxid60.yaml
+++ b/config/set/oxid/oxid60.yaml
@@ -1,0 +1,4 @@
+services:
+    Rector\Renaming\Rector\FuncCall\RenameFuncCallToStaticCallRector:
+        $functionsToStaticCalls:
+            getStr: ['OxidEsales\Eshop\Core\Str', 'getStr']


### PR DESCRIPTION
We created this initially in https://github.com/OXID-eSales/oxideshop_ce/pull/758, but I think this is useful for module developers as well. We plan to create a few other rectors in the future.