### PR TITLE
Skip unpackaged args in ArraySpreadInsteadOfArrayMergeRector

### DIFF
--- a/rules/php-74/src/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector.php
+++ b/rules/php-74/src/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector.php
@@ -100,8 +100,12 @@ PHP
         $array = new Array_();
 
         foreach ($funcCall->args as $arg) {
-            $value = $arg->value;
+            // cannot handle unpacked arguments
+            if ($arg->unpack) {
+                return null;
+            }
 
+            $value = $arg->value;
             if ($this->shouldSkipArrayForInvalidTypeOrKeys($value)) {
                 return null;
             }

--- a/rules/php-74/tests/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector/Fixture/skip_spread_array_merge.php.inc
+++ b/rules/php-74/tests/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector/Fixture/skip_spread_array_merge.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Php74\Tests\Rector\FuncCall\ArraySpreadInsteadOfArrayMergeRector\Fixture;
+
+use stdClass;
+
+class SkipSpreadyArrayMerge
+{
+    public function run()
+    {
+        $values = [
+            [new stdClass()],
+            [new stdClass]
+        ];
+
+        $items = array_merge(...$values);
+
+        return array_merge($items, ...$values);
+    }
+}


### PR DESCRIPTION
Closes #2854 