### PR TITLE
Fix PHP notice in ternary to spaceship rector

### DIFF
--- a/rules/php-70/src/Rector/Ternary/TernaryToSpaceshipRector.php
+++ b/rules/php-70/src/Rector/Ternary/TernaryToSpaceshipRector.php
@@ -84,6 +84,10 @@ PHP
 
         $nestedTernary = $ternary->else;
 
+        if (! $nestedTernary->cond instanceof BinaryOp) {
+            return true;
+        }
+
         // $a X $b ? . : ($a X $b ? . : .)
         if (! $this->areNodesEqual($ternary->cond->left, $nestedTernary->cond->left)) {
             return true;

--- a/rules/php-70/tests/Rector/Ternary/TernaryToSpaceshipRector/Fixture/skip_non_binary_op_in_nested_ternary.php.inc
+++ b/rules/php-70/tests/Rector/Ternary/TernaryToSpaceshipRector/Fixture/skip_non_binary_op_in_nested_ternary.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-function foo($foo, $baz)
+function foo($foo, $bar)
 {
-    return $foo == 'bar' ? 'it is bar' : (isset($baz) ? 'baz' : 'bizz');
+    return $foo == 'foo' ? 'it is foo' : (isset($bar) ? 'bar' : 'baz');
 }

--- a/rules/php-70/tests/Rector/Ternary/TernaryToSpaceshipRector/Fixture/skip_non_binary_op_in_nested_ternary.php.inc
+++ b/rules/php-70/tests/Rector/Ternary/TernaryToSpaceshipRector/Fixture/skip_non_binary_op_in_nested_ternary.php.inc
@@ -1,0 +1,6 @@
+<?php
+
+function foo($foo, $baz)
+{
+    return $foo == 'bar' ? 'it is bar' : (isset($baz) ? 'baz' : 'bizz');
+}


### PR DESCRIPTION
Fixes generated PHP notice `Notice: Undefined property: PhpParser\Node\Expr\Isset_::$left in /home/fsok/src/rector/rules/php-70/src/Rector/Ternary/TernaryToSpaceshipRector.php on line 88`