### PR TITLE
#2861: Support throw of static methods

### DIFF
--- a/rules/coding-style/src/Rector/Throw_/AnnotateThrowablesRector.php
+++ b/rules/coding-style/src/Rector/Throw_/AnnotateThrowablesRector.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Rector\CodingStyle\Rector\Throw_;
 
+use Nette\Utils\Reflection;
+use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Throw_;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ThrowsTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
@@ -19,12 +22,23 @@ use Rector\Core\RectorDefinition\CodeSample;
 use Rector\Core\RectorDefinition\RectorDefinition;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PHPStan\Type\ShortenedObjectType;
+use ReflectionMethod;
 
 /**
  * @see \Rector\CodingStyle\Tests\Rector\Throw_\AnnotateThrowablesRector\AnnotateThrowablesRectorTest
  */
 final class AnnotateThrowablesRector extends AbstractRector
 {
+    /**
+     * @var string
+     */
+    private const RETURN_DOCBLOCK_TAG_REGEX = '#@return[ a-zA-Z0-9\|\\\t]+#';
+
+    /**
+     * @var array
+     */
+    private $foundThrownClasses = [];
+
     /**
      * @return string[]
      */
@@ -102,11 +116,9 @@ PHP
                 continue;
             }
 
-            if ($throwsType instanceof ShortenedObjectType) {
-                $className = $throwsType->getFullyQualifiedName();
-            } else {
-                $className = $throwsType->getClassName();
-            }
+            $className = $throwsType instanceof ShortenedObjectType
+                ? $throwsType->getFullyQualifiedName()
+                : $throwsType->getClassName();
 
             if (! in_array($className, $identifiedThrownThrowables, true)) {
                 continue;
@@ -125,28 +137,65 @@ PHP
         }
 
         if ($throw->expr instanceof StaticCall) {
-            return $this->identifyThrownThrowablesInStaticCall();
+            return $this->identifyThrownThrowablesInStaticCall($throw->expr);
         }
 
         return [];
     }
 
-    private function identifyThrownThrowablesInStaticCall(): array
+    private function identifyThrownThrowablesInStaticCall(StaticCall $staticCall): array
     {
-        return [];
+        return $this->extractMethodReturnsFromDocblock($staticCall);
+    }
+
+    private function extractMethodReturnsFromDocblock(StaticCall $staticCall): array
+    {
+        $thrownClass = $staticCall->class;
+        if (! $thrownClass instanceof FullyQualified) {
+            throw new ShouldNotHappenException();
+        }
+        $classFqn = implode('\\', $thrownClass->parts);
+        $methodNode = $thrownClass->getAttribute('nextNode');
+        $methodName = $methodNode->name;
+        $reflectedMethod = new ReflectionMethod($classFqn, $methodName);
+        $methodDocblock = $reflectedMethod->getDocComment();
+
+        // copied from https://github.com/nette/di/blob/d1c0598fdecef6d3b01e2ace5f2c30214b3108e6/src/DI/Autowiring.php#L215
+        $result = Strings::match((string) $methodDocblock, self::RETURN_DOCBLOCK_TAG_REGEX);
+        if ($result === null) {
+            return [];
+        }
+
+        $returnTags = explode('|', str_replace('@return ', '', $result[0]));
+        $returnClasses = [];
+        foreach ($returnTags as $returnTag) {
+            $returnClasses[] = Reflection::expandClassName($returnTag, $reflectedMethod->getDeclaringClass());
+        }
+
+        $this->foundThrownClasses = $returnClasses;
+
+        return $returnClasses;
     }
 
     private function annotateThrowable(Throw_ $node): void
     {
         $throwClass = $this->buildFQN($node);
-        if ($throwClass === null) {
+        if ($throwClass !== null) {
+            $this->foundThrownClasses[] = $throwClass;
+        }
+
+        if (empty($this->foundThrownClasses)) {
             return;
         }
 
-        $docComment = $this->buildThrowsDocComment($throwClass);
+        foreach ($this->foundThrownClasses as $thrownClass) {
+            $docComment = $this->buildThrowsDocComment($thrownClass);
 
-        $throwingStmtPhpDocInfo = $this->getThrowingStmtPhpDocInfo($node);
-        $throwingStmtPhpDocInfo->addPhpDocTagNode($docComment);
+            $throwingStmtPhpDocInfo = $this->getThrowingStmtPhpDocInfo($node);
+            $throwingStmtPhpDocInfo->addPhpDocTagNode($docComment);
+        }
+
+        $this->foundThrownClasses = [];
     }
 
     private function buildThrowsDocComment(string $throwableClass): AttributeAwarePhpDocTagNode

--- a/rules/coding-style/tests/Rector/Throw_/AnnotateThrowablesRector/Fixture/factory_static_method_with_return_dockblock.php.inc
+++ b/rules/coding-style/tests/Rector/Throw_/AnnotateThrowablesRector/Fixture/factory_static_method_with_return_dockblock.php.inc
@@ -6,7 +6,7 @@ use Rector\CodingStyle\Tests\Rector\Throw_\AnnotateThrowablesRector\Source\Excep
 
 function throwWithFactoryStaticMethodWithReturnDocblock()
 {
-    throw ExceptionsFactoryStaticMethodWithReturnDocblock::createExceptionEccolo(1);
+    throw ExceptionsFactoryStaticMethodWithReturnDocblock::createException(1);
 }
 
 ?>
@@ -15,20 +15,17 @@ function throwWithFactoryStaticMethodWithReturnDocblock()
 
 namespace Rector\CodingStyle\Tests\Rector\Throw_\AnnotateThrowablesRector\Fixture;
 
-use Rector\CodingStyle\Tests\Rector\Throw_\AnnotateThrowablesRector\Source\Exceptions\TheException;
-use Rector\CodingStyle\Tests\Rector\Throw_\AnnotateThrowablesRector\Source\Exceptions\TheExceptionTheSecond;
-use Rector\CodingStyle\Tests\Rector\Throw_\AnnotateThrowablesRector\Source\Exceptions\TheExceptionTheThird;
 use Rector\CodingStyle\Tests\Rector\Throw_\AnnotateThrowablesRector\Source\ExceptionsFactoryStaticMethodWithReturnDocblock;
 
 /**
- * @throws TheException
- * @throws TheExceptionTheSecond
- * @throws TheExceptionTheThird
+ * @throws \Rector\CodingStyle\Tests\Rector\Throw_\AnnotateThrowablesRector\Source\Exceptions\TheException
+ * @throws \Rector\CodingStyle\Tests\Rector\Throw_\AnnotateThrowablesRector\Source\Exceptions\TheExceptionTheSecond
+ * @throws \Rector\CodingStyle\Tests\Rector\Throw_\AnnotateThrowablesRector\Source\Exceptions\TheExceptionTheThird
  * @throws \RuntimeException
  */
 function throwWithFactoryStaticMethodWithReturnDocblock()
 {
-    throw ExceptionsFactoryStaticMethodWithReturnDocblock::createExceptionEccolo(1);
+    throw ExceptionsFactoryStaticMethodWithReturnDocblock::createException(1);
 }
 
 ?>

--- a/rules/coding-style/tests/Rector/Throw_/AnnotateThrowablesRector/Source/ExceptionsFactoryStaticMethodWithReturnDocblock.php
+++ b/rules/coding-style/tests/Rector/Throw_/AnnotateThrowablesRector/Source/ExceptionsFactoryStaticMethodWithReturnDocblock.php
@@ -9,11 +9,13 @@ use Rector\CodingStyle\Tests\Rector\Throw_\AnnotateThrowablesRector\Source\Excep
 class ExceptionsFactoryStaticMethodWithReturnDocblock
 {
     /**
+     * This is the DocComment of createException().
+     *
      * @param int $code
      *
      * @return TheException|TheExceptionTheSecond|TheExceptionTheThird|\RuntimeException
      */
-    public static function createExceptionEccolo(int $code)
+    public static function createException(int $code)
     {
         switch ($code) {
             case 1:


### PR DESCRIPTION
#2889 (general discussion: #2861).

# What this should support

```php
function throwThroughStaticMethod()
{
    throw ExcetionFactory::createException();
}
```

# Explanation

See the test case here: https://github.com/rectorphp/rector/blob/71ad810c8c777def532af6ff22be6d4d900b3bdd/rules/coding-style/tests/Rector/Throw_/AnnotateThrowablesRector/Fixture/factory_static_method_with_return_dockblock.php.inc

The problem is to read the Docblock of the invoked method.

One approach, as suggested in #2861  (https://github.com/rectorphp/rector/issues/2861#issuecomment-586970207) is to use the reflection.

Currently it is possible to obtain the Docblock using reflection, but the docblock is obtained as a simple string and it cannot be parsed.

Obtaining a simple string is useless, as it makes impossible to know which classes are actually returned.

```php
    /**
     * This is the DocComment of createExceptionEccolo().
     *
     * @param int $code
     *
     * @return TheException|TheExceptionTheSecond|TheExceptionTheThird|\RuntimeException
     */
```

Is `TheException` something like `Namespace1\TheException` or is it `Namespace2\TheExeception`?

Without being able to access a parsed version of the Docblock, it is impossible to know what is returned by the invoked static method.

@TomasVotruba , WDYT?
