### PR TITLE
Rector CI: enable SOLID set

### DIFF
--- a/ci/check_keep_fixtures.php
+++ b/ci/check_keep_fixtures.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Nette\Utils\Strings;
 use Rector\Core\Testing\PHPUnit\FixtureSplitter;
+use Rector\Core\Testing\ValueObject\SplitLine;
 use Symfony\Component\Finder\Finder;
 use Symplify\PackageBuilder\Console\ShellCode;
 use Symplify\PackageBuilder\Console\Style\SymfonyStyleFactory;
@@ -29,12 +30,12 @@ $errors = [];
 
 /** @var SmartFileInfo $smartFileInfo */
 foreach ($smartFileInfos as $smartFileInfo) {
-    if (! Strings::match($smartFileInfo->getContents(), FixtureSplitter::SPLIT_LINE)) {
+    if (! Strings::match($smartFileInfo->getContents(), SplitLine::SPLIT_LINE)) {
         continue;
     }
 
     // original → expected
-    [$originalContent, $expectedContent] = Strings::split($smartFileInfo->getContents(), FixtureSplitter::SPLIT_LINE);
+    [$originalContent, $expectedContent] = Strings::split($smartFileInfo->getContents(), SplitLine::SPLIT_LINE);
     if ($originalContent !== $expectedContent) {
         continue;
     }
@@ -48,8 +49,8 @@ if ($errors === []) {
 
 $symfonyStyle->warning(sprintf(
     'These files have same content before "%s" and after it. Remove the content after "%s"',
-    FixtureSplitter::SPLIT_LINE,
-    FixtureSplitter::SPLIT_LINE
+    SplitLine::SPLIT_LINE,
+    SplitLine::SPLIT_LINE
 ));
 
 $symfonyStyle->listing($errors);

--- a/ecs.yaml
+++ b/ecs.yaml
@@ -21,7 +21,6 @@ services:
 
 parameters:
     paths:
-        - "ci"
         - "bin"
         - "src"
         - "packages"

--- a/packages/better-php-doc-parser/src/Contract/PhpDocNode/ShortNameAwareTagInterface.php
+++ b/packages/better-php-doc-parser/src/Contract/PhpDocNode/ShortNameAwareTagInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\BetterPhpDocParser\Contract\PhpDocNode;
+
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagValueNode;
+
+interface ShortNameAwareTagInterface extends PhpDocTagValueNode
+{
+    public function getShortName(): string;
+}

--- a/packages/better-php-doc-parser/src/PhpDocInfo/PhpDocInfo.php
+++ b/packages/better-php-doc-parser/src/PhpDocInfo/PhpDocInfo.php
@@ -27,8 +27,8 @@ use Rector\AttributeAwarePhpDoc\Ast\PhpDoc\AttributeAwareVarTagValueNode;
 use Rector\BetterPhpDocParser\Annotation\AnnotationNaming;
 use Rector\BetterPhpDocParser\Attributes\Ast\PhpDoc\SpacelessPhpDocTagNode;
 use Rector\BetterPhpDocParser\Contract\PhpDocNode\AttributeAwareNodeInterface;
+use Rector\BetterPhpDocParser\Contract\PhpDocNode\ShortNameAwareTagInterface;
 use Rector\BetterPhpDocParser\Contract\PhpDocNode\TypeAwareTagValueNodeInterface;
-use Rector\BetterPhpDocParser\PhpDocNode\AbstractTagValueNode;
 use Rector\Core\Exception\NotImplementedException;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\NodeTypeResolver\PHPStan\TypeComparator;
@@ -104,9 +104,9 @@ final class PhpDocInfo
         $this->phpDocNode->children[] = $phpDocChildNode;
     }
 
-    public function addTagValueNodeWithShortName(AbstractTagValueNode $tagValueNode): void
+    public function addTagValueNodeWithShortName(ShortNameAwareTagInterface $shortNameAwareTag): void
     {
-        $spacelessPhpDocTagNode = new SpacelessPhpDocTagNode($tagValueNode::SHORT_NAME, $tagValueNode);
+        $spacelessPhpDocTagNode = new SpacelessPhpDocTagNode($shortNameAwareTag->getShortName(), $shortNameAwareTag);
         $this->addPhpDocTagNode($spacelessPhpDocTagNode);
     }
 

--- a/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/AbstractDoctrineTagValueNode.php
+++ b/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/AbstractDoctrineTagValueNode.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Rector\BetterPhpDocParser\PhpDocNode\Doctrine;
 
 use Rector\BetterPhpDocParser\Contract\Doctrine\DoctrineTagNodeInterface;
+use Rector\BetterPhpDocParser\Contract\PhpDocNode\ShortNameAwareTagInterface;
 use Rector\BetterPhpDocParser\PhpDocNode\AbstractTagValueNode;
 
-abstract class AbstractDoctrineTagValueNode extends AbstractTagValueNode implements DoctrineTagNodeInterface
+abstract class AbstractDoctrineTagValueNode extends AbstractTagValueNode implements DoctrineTagNodeInterface, ShortNameAwareTagInterface
 {
 }

--- a/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Class_/EntityTagValueNode.php
+++ b/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Class_/EntityTagValueNode.php
@@ -9,11 +9,6 @@ use Rector\BetterPhpDocParser\PhpDocNode\Doctrine\AbstractDoctrineTagValueNode;
 final class EntityTagValueNode extends AbstractDoctrineTagValueNode
 {
     /**
-     * @var string
-     */
-    public const SHORT_NAME = '@ORM\Entity';
-
-    /**
      * @var string|null
      */
     private $repositoryClass;
@@ -52,5 +47,10 @@ final class EntityTagValueNode extends AbstractDoctrineTagValueNode
     public function removeRepositoryClass(): void
     {
         $this->repositoryClass = null;
+    }
+
+    public function getShortName(): string
+    {
+        return '@ORM\Entity';
     }
 }

--- a/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Class_/IndexTagValueNode.php
+++ b/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Class_/IndexTagValueNode.php
@@ -6,13 +6,13 @@ namespace Rector\BetterPhpDocParser\PhpDocNode\Doctrine\Class_;
 
 final class IndexTagValueNode extends AbstractIndexTagValueNode
 {
-    /**
-     * @var string
-     */
-    public const SHORT_NAME = '@ORM\Index';
-
     public function getTag(): ?string
     {
-        return $this->tag ?: self::SHORT_NAME;
+        return $this->tag ?: $this->getShortName();
+    }
+
+    public function getShortName(): string
+    {
+        return '@ORM\Index';
     }
 }

--- a/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Class_/InheritanceTypeTagValueNode.php
+++ b/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Class_/InheritanceTypeTagValueNode.php
@@ -9,11 +9,6 @@ use Rector\BetterPhpDocParser\PhpDocNode\Doctrine\AbstractDoctrineTagValueNode;
 final class InheritanceTypeTagValueNode extends AbstractDoctrineTagValueNode
 {
     /**
-     * @var string
-     */
-    public const SHORT_NAME = '@ORM\InheritanceType';
-
-    /**
      * @var string|null
      */
     private $value;
@@ -35,5 +30,10 @@ final class InheritanceTypeTagValueNode extends AbstractDoctrineTagValueNode
         }
 
         return '(value="' . $this->value . '")';
+    }
+
+    public function getShortName(): string
+    {
+        return '@ORM\InheritanceType';
     }
 }

--- a/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Class_/TableTagValueNode.php
+++ b/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Class_/TableTagValueNode.php
@@ -9,11 +9,6 @@ use Rector\BetterPhpDocParser\PhpDocNode\Doctrine\AbstractDoctrineTagValueNode;
 final class TableTagValueNode extends AbstractDoctrineTagValueNode
 {
     /**
-     * @var string
-     */
-    public const SHORT_NAME = '@ORM\Table';
-
-    /**
      * @var string|null
      */
     private $name;
@@ -151,5 +146,10 @@ final class TableTagValueNode extends AbstractDoctrineTagValueNode
     public function getName(): ?string
     {
         return $this->name;
+    }
+
+    public function getShortName(): string
+    {
+        return '@ORM\Table';
     }
 }

--- a/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Class_/UniqueConstraintTagValueNode.php
+++ b/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Class_/UniqueConstraintTagValueNode.php
@@ -6,13 +6,13 @@ namespace Rector\BetterPhpDocParser\PhpDocNode\Doctrine\Class_;
 
 final class UniqueConstraintTagValueNode extends AbstractIndexTagValueNode
 {
-    /**
-     * @var string
-     */
-    public const SHORT_NAME = '@ORM\UniqueConstraint';
-
     public function getTag(): ?string
     {
-        return $this->tag ?: self::SHORT_NAME;
+        return $this->tag ?: $this->getShortName();
+    }
+
+    public function getShortName(): string
+    {
+        return '@ORM\UniqueConstraint';
     }
 }

--- a/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Property_/ColumnTagValueNode.php
+++ b/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Property_/ColumnTagValueNode.php
@@ -10,11 +10,6 @@ use Rector\BetterPhpDocParser\PhpDocNode\Doctrine\AbstractDoctrineTagValueNode;
 final class ColumnTagValueNode extends AbstractDoctrineTagValueNode
 {
     /**
-     * @var string
-     */
-    public const SHORT_NAME = '@ORM\Column';
-
-    /**
      * @var string|null
      */
     private $name;
@@ -166,5 +161,10 @@ final class ColumnTagValueNode extends AbstractDoctrineTagValueNode
     public function isNullable(): ?bool
     {
         return $this->nullable;
+    }
+
+    public function getShortName(): string
+    {
+        return '@ORM\Column';
     }
 }

--- a/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Property_/CustomIdGeneratorTagValueNode.php
+++ b/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Property_/CustomIdGeneratorTagValueNode.php
@@ -11,11 +11,6 @@ final class CustomIdGeneratorTagValueNode extends AbstractDoctrineTagValueNode
     /**
      * @var string
      */
-    public const SHORT_NAME = '@ORM\CustomIdGenerator';
-
-    /**
-     * @var string
-     */
     private $class;
 
     public function __construct(string $class, ?string $originalContent = null)
@@ -27,5 +22,10 @@ final class CustomIdGeneratorTagValueNode extends AbstractDoctrineTagValueNode
     public function __toString(): string
     {
         return sprintf('(class="%s")', $this->class);
+    }
+
+    public function getShortName(): string
+    {
+        return '@ORM\CustomIdGenerator';
     }
 }

--- a/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Property_/GeneratedValueTagValueNode.php
+++ b/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Property_/GeneratedValueTagValueNode.php
@@ -11,11 +11,6 @@ final class GeneratedValueTagValueNode extends AbstractDoctrineTagValueNode
     /**
      * @var string
      */
-    public const SHORT_NAME = '@ORM\GeneratedValue';
-
-    /**
-     * @var string
-     */
     private $strategy;
 
     public function __construct(string $strategy)
@@ -26,5 +21,10 @@ final class GeneratedValueTagValueNode extends AbstractDoctrineTagValueNode
     public function __toString(): string
     {
         return sprintf('(strategy="%s")', $this->strategy);
+    }
+
+    public function getShortName(): string
+    {
+        return '@ORM\GeneratedValue';
     }
 }

--- a/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Property_/IdTagValueNode.php
+++ b/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Property_/IdTagValueNode.php
@@ -8,13 +8,13 @@ use Rector\BetterPhpDocParser\PhpDocNode\Doctrine\AbstractDoctrineTagValueNode;
 
 final class IdTagValueNode extends AbstractDoctrineTagValueNode
 {
-    /**
-     * @var string
-     */
-    public const SHORT_NAME = '@ORM\Id';
-
     public function __toString(): string
     {
         return '';
+    }
+
+    public function getShortName(): string
+    {
+        return '@ORM\Id';
     }
 }

--- a/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Property_/JoinColumnTagValueNode.php
+++ b/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Property_/JoinColumnTagValueNode.php
@@ -10,11 +10,6 @@ use Rector\BetterPhpDocParser\PhpDocNode\Doctrine\AbstractDoctrineTagValueNode;
 final class JoinColumnTagValueNode extends AbstractDoctrineTagValueNode implements TagAwareNodeInterface
 {
     /**
-     * @var string
-     */
-    public const SHORT_NAME = '@ORM\JoinColumn';
-
-    /**
      * @var bool|null
      */
     private $nullable;
@@ -126,11 +121,16 @@ final class JoinColumnTagValueNode extends AbstractDoctrineTagValueNode implemen
 
     public function getTag(): ?string
     {
-        return $this->tag ?: self::SHORT_NAME;
+        return $this->tag ?: $this->getShortName();
     }
 
     public function getUnique(): ?bool
     {
         return $this->unique;
+    }
+
+    public function getShortName(): string
+    {
+        return '@ORM\JoinColumn';
     }
 }

--- a/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Property_/JoinTableTagValueNode.php
+++ b/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Property_/JoinTableTagValueNode.php
@@ -11,11 +11,6 @@ final class JoinTableTagValueNode extends AbstractDoctrineTagValueNode
     /**
      * @var string
      */
-    public const SHORT_NAME = '@ORM\JoinTable';
-
-    /**
-     * @var string
-     */
     private $name;
 
     /**
@@ -110,5 +105,10 @@ final class JoinTableTagValueNode extends AbstractDoctrineTagValueNode
         }
 
         return $this->printContentItems($contentItems);
+    }
+
+    public function getShortName(): string
+    {
+        return '@ORM\JoinTable';
     }
 }

--- a/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Property_/ManyToManyTagValueNode.php
+++ b/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Property_/ManyToManyTagValueNode.php
@@ -14,11 +14,6 @@ final class ManyToManyTagValueNode extends AbstractDoctrineTagValueNode implemen
     /**
      * @var string
      */
-    public const SHORT_NAME = '@ORM\ManyToMany';
-
-    /**
-     * @var string
-     */
     private $targetEntity;
 
     /**
@@ -147,5 +142,10 @@ final class ManyToManyTagValueNode extends AbstractDoctrineTagValueNode implemen
     public function changeTargetEntity(string $targetEntity): void
     {
         $this->targetEntity = $targetEntity;
+    }
+
+    public function getShortName(): string
+    {
+        return '@ORM\ManyToMany';
     }
 }

--- a/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Property_/ManyToOneTagValueNode.php
+++ b/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Property_/ManyToOneTagValueNode.php
@@ -13,11 +13,6 @@ final class ManyToOneTagValueNode extends AbstractDoctrineTagValueNode implement
     /**
      * @var string
      */
-    public const SHORT_NAME = '@ORM\ManyToOne';
-
-    /**
-     * @var string
-     */
     private $targetEntity;
 
     /**
@@ -100,5 +95,10 @@ final class ManyToOneTagValueNode extends AbstractDoctrineTagValueNode implement
     public function changeTargetEntity(string $targetEntity): void
     {
         $this->targetEntity = $targetEntity;
+    }
+
+    public function getShortName(): string
+    {
+        return '@ORM\ManyToOne';
     }
 }

--- a/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Property_/OneToManyTagValueNode.php
+++ b/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Property_/OneToManyTagValueNode.php
@@ -12,11 +12,6 @@ use Rector\BetterPhpDocParser\PhpDocNode\Doctrine\AbstractDoctrineTagValueNode;
 final class OneToManyTagValueNode extends AbstractDoctrineTagValueNode implements ToManyTagNodeInterface, MappedByNodeInterface, TypeAwareTagValueNodeInterface
 {
     /**
-     * @var string
-     */
-    public const SHORT_NAME = '@ORM\OneToMany';
-
-    /**
      * @var string|null
      */
     private $mappedBy;
@@ -123,5 +118,10 @@ final class OneToManyTagValueNode extends AbstractDoctrineTagValueNode implement
     public function changeTargetEntity(string $targetEntity): void
     {
         $this->targetEntity = $targetEntity;
+    }
+
+    public function getShortName(): string
+    {
+        return '@ORM\OneToMany';
     }
 }

--- a/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Property_/OneToOneTagValueNode.php
+++ b/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Property_/OneToOneTagValueNode.php
@@ -14,11 +14,6 @@ final class OneToOneTagValueNode extends AbstractDoctrineTagValueNode implements
     /**
      * @var string
      */
-    public const SHORT_NAME = '@ORM\OneToOne';
-
-    /**
-     * @var string
-     */
     private $targetEntity;
 
     /**
@@ -137,5 +132,10 @@ final class OneToOneTagValueNode extends AbstractDoctrineTagValueNode implements
     public function changeTargetEntity(string $targetEntity): void
     {
         $this->targetEntity = $targetEntity;
+    }
+
+    public function getShortName(): string
+    {
+        return '@ORM\OneToOne';
     }
 }

--- a/packages/better-php-doc-parser/src/PhpDocNode/Symfony/SymfonyRouteTagValueNode.php
+++ b/packages/better-php-doc-parser/src/PhpDocNode/Symfony/SymfonyRouteTagValueNode.php
@@ -5,16 +5,12 @@ declare(strict_types=1);
 namespace Rector\BetterPhpDocParser\PhpDocNode\Symfony;
 
 use Nette\Utils\Strings;
+use Rector\BetterPhpDocParser\Contract\PhpDocNode\ShortNameAwareTagInterface;
 use Rector\BetterPhpDocParser\PhpDocNode\AbstractTagValueNode;
 use Symfony\Component\Routing\Annotation\Route;
 
-final class SymfonyRouteTagValueNode extends AbstractTagValueNode
+final class SymfonyRouteTagValueNode extends AbstractTagValueNode implements ShortNameAwareTagInterface
 {
-    /**
-     * @var string
-     */
-    public const SHORT_NAME = '@Route';
-
     /**
      * @var string
      */
@@ -126,6 +122,11 @@ final class SymfonyRouteTagValueNode extends AbstractTagValueNode
     {
         $this->orderedVisibleItems[] = 'methods';
         $this->methods = $methods;
+    }
+
+    public function getShortName(): string
+    {
+        return '@Route';
     }
 
     private function createPath(): string

--- a/packages/better-php-doc-parser/src/PhpDocNodeFactory/Doctrine/Property_/JoinTablePhpDocNodeFactory.php
+++ b/packages/better-php-doc-parser/src/PhpDocNodeFactory/Doctrine/Property_/JoinTablePhpDocNodeFactory.php
@@ -20,7 +20,7 @@ final class JoinTablePhpDocNodeFactory extends AbstractPhpDocNodeFactory
     /**
      * @var string
      */
-    public const INVERSE_JOIN_COLUMNS = 'inverseJoinColumns';
+    private const INVERSE_JOIN_COLUMNS = 'inverseJoinColumns';
 
     /**
      * @var string

--- a/packages/node-collector/src/NodeFinder/ClassConstParsedNodesFinder.php
+++ b/packages/node-collector/src/NodeFinder/ClassConstParsedNodesFinder.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\NodeCollector\NodeFinder;
+
+use Rector\SOLID\Analyzer\ClassConstantFetchAnalyzer;
+
+final class ClassConstParsedNodesFinder
+{
+    /**
+     * @var ClassConstantFetchAnalyzer
+     */
+    private $classConstantFetchAnalyzer;
+
+    public function __construct(ClassConstantFetchAnalyzer $classConstantFetchAnalyzer)
+    {
+        $this->classConstantFetchAnalyzer = $classConstantFetchAnalyzer;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function findDirectClassConstantFetches(string $desiredClassName, string $desiredConstantName): array
+    {
+        $classConstantFetchByClassAndName = $this->classConstantFetchAnalyzer->provideClassConstantFetchByClassAndName();
+
+        return $classConstantFetchByClassAndName[$desiredClassName][$desiredConstantName] ?? [];
+    }
+
+    /**
+     * @return string[]
+     */
+    public function findIndirectClassConstantFetches(string $desiredClassName, string $desiredConstantName): array
+    {
+        $classConstantFetchByClassAndName = $this->classConstantFetchAnalyzer->provideClassConstantFetchByClassAndName();
+        foreach ($classConstantFetchByClassAndName as $className => $classesByConstantName) {
+            if (! isset($classesByConstantName[$desiredConstantName])) {
+                continue;
+            }
+
+            // include child usages
+            if (! is_a($desiredClassName, $className, true)) {
+                continue;
+            }
+
+            if ($desiredClassName === $className) {
+                continue;
+            }
+
+            return $classesByConstantName[$desiredConstantName];
+        }
+
+        return [];
+    }
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -67,7 +67,6 @@ parameters:
         - '#Call to function in_array\(\) with arguments string, (.*?) and true will always evaluate to false#'
 
         # known values
-        - '#Access to an undefined property PhpParser\\Node\\Expr::\$left#'
         - '#Access to an undefined property PhpParser\\Node\\Expr::\$right#'
 
         - '#Access to an undefined property PhpParser\\Node\\Expr\\MethodCall\|PhpParser\\Node\\Stmt\\ClassMethod::\$params#'

--- a/rector-ci.yaml
+++ b/rector-ci.yaml
@@ -1,22 +1,26 @@
-services:
-    Rector\SOLID\Rector\Property\ChangeReadOnlyPropertyWithDefaultValueToConstantRector: null
-    Rector\SOLID\Rector\ClassMethod\ChangeReadOnlyVariableWithDefaultValueToConstantRector: null
+#services:
+#    Rector\SOLID\Rector\ClassConst\PrivatizeLocalClassConstantRector: null
+#    Rector\SOLID\Rector\Property\ChangeReadOnlyPropertyWithDefaultValueToConstantRector: null
+#    Rector\SOLID\Rector\ClassMethod\ChangeReadOnlyVariableWithDefaultValueToConstantRector: null
 
 parameters:
     sets:
-        - 'coding-style'
-        - 'code-quality'
-        - 'dead-code'
-        - 'nette-utils-code-quality'
+#        - 'coding-style'
+#        - 'code-quality'
+#        - 'dead-code'
+#        - 'nette-utils-code-quality'
+        - 'solid'
 
     paths:
-        - 'ci'
         - 'src'
+        - 'rules'
         - 'packages'
         - 'tests'
 
     autoload_paths:
-        - 'ci/check_services_in_yaml_configs.php'
+        # needed for FixtureSplitter::SPLIT_LINE public use
+        - 'ci/check_keep_fixtures.php'
+#        - 'ci/check_services_in_yaml_configs.php'
 
     exclude_paths:
         - '/Fixture/'

--- a/rector-ci.yaml
+++ b/rector-ci.yaml
@@ -17,11 +17,6 @@ parameters:
         - 'packages'
         - 'tests'
 
-    autoload_paths:
-        # needed for FixtureSplitter::SPLIT_LINE public use
-        - 'ci/check_keep_fixtures.php'
-#        - 'ci/check_services_in_yaml_configs.php'
-
     exclude_paths:
         - '/Fixture/'
         - '/Source/'

--- a/rector-ci.yaml
+++ b/rector-ci.yaml
@@ -1,14 +1,9 @@
-#services:
-#    Rector\SOLID\Rector\ClassConst\PrivatizeLocalClassConstantRector: null
-#    Rector\SOLID\Rector\Property\ChangeReadOnlyPropertyWithDefaultValueToConstantRector: null
-#    Rector\SOLID\Rector\ClassMethod\ChangeReadOnlyVariableWithDefaultValueToConstantRector: null
-
 parameters:
     sets:
-#        - 'coding-style'
-#        - 'code-quality'
-#        - 'dead-code'
-#        - 'nette-utils-code-quality'
+        - 'coding-style'
+        - 'code-quality'
+        - 'dead-code'
+        - 'nette-utils-code-quality'
         - 'solid'
 
     paths:

--- a/rules/doctrine-code-quality/src/Rector/Class_/ChangeQuerySetParametersMethodParameterFromArrayToArrayCollectionRector.php
+++ b/rules/doctrine-code-quality/src/Rector/Class_/ChangeQuerySetParametersMethodParameterFromArrayToArrayCollectionRector.php
@@ -23,7 +23,7 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
  *
  * @see \Rector\DoctrineCodeQuality\Tests\Rector\Class_\ChangeQuerySetParametersMethodParameterFromArrayToArrayCollection\ChangeQuerySetParametersMethodParameterFromArrayToArrayCollectionRectorTest
  */
-class ChangeQuerySetParametersMethodParameterFromArrayToArrayCollectionRector extends AbstractRector
+final class ChangeQuerySetParametersMethodParameterFromArrayToArrayCollectionRector extends AbstractRector
 {
     public function getNodeTypes(): array
     {

--- a/rules/doctrine/src/PhpDocParser/Ast/PhpDoc/PhpDocTagNodeFactory.php
+++ b/rules/doctrine/src/PhpDocParser/Ast/PhpDoc/PhpDocTagNodeFactory.php
@@ -61,14 +61,12 @@ final class PhpDocTagNodeFactory
             [new JoinColumnTagValueNode(null, 'uuid')]
         );
 
-        return new SpacelessPhpDocTagNode(JoinTableTagValueNode::SHORT_NAME, $joinTableTagValueNode);
+        return new SpacelessPhpDocTagNode($joinTableTagValueNode->getShortName(), $joinTableTagValueNode);
     }
 
-    public function createJoinColumnTagNode(bool $isNullable): PhpDocTagNode
+    public function createJoinColumnTagNode(bool $isNullable): JoinColumnTagValueNode
     {
-        $joinColumnTagValueNode = new JoinColumnTagValueNode(null, 'uuid', null, $isNullable);
-
-        return new SpacelessPhpDocTagNode(JoinColumnTagValueNode::SHORT_NAME, $joinColumnTagValueNode);
+        return new JoinColumnTagValueNode(null, 'uuid', null, $isNullable);
     }
 
     private function createVarTagValueNodeWithType(TypeNode $typeNode): AttributeAwareVarTagValueNode

--- a/rules/doctrine/src/Rector/Class_/RemoveRepositoryFromEntityAnnotationRector.php
+++ b/rules/doctrine/src/Rector/Class_/RemoveRepositoryFromEntityAnnotationRector.php
@@ -65,6 +65,7 @@ PHP
             return null;
         }
 
+        /** @var EntityTagValueNode|null $doctrineEntityTag */
         $doctrineEntityTag = $phpDocInfo->getByType(EntityTagValueNode::class);
         if ($doctrineEntityTag === null) {
             return null;

--- a/rules/php-74/src/Rector/Closure/ClosureToArrowFunctionRector.php
+++ b/rules/php-74/src/Rector/Closure/ClosureToArrowFunctionRector.php
@@ -93,7 +93,7 @@ PHP
 
         $arrowFunction->expr = $return->expr;
 
-        if ($node->static === true) {
+        if ($node->static) {
             $arrowFunction->static = true;
         }
 

--- a/rules/solid/src/Rector/ClassConst/PrivatizeLocalClassConstantRector.php
+++ b/rules/solid/src/Rector/ClassConst/PrivatizeLocalClassConstantRector.php
@@ -10,8 +10,8 @@ use Rector\Core\Rector\AbstractRector;
 use Rector\Core\RectorDefinition\CodeSample;
 use Rector\Core\RectorDefinition\RectorDefinition;
 use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\NodeCollector\NodeFinder\ClassConstParsedNodesFinder;
 use Rector\NodeTypeResolver\Node\AttributeKey;
-use Rector\SOLID\Analyzer\ClassConstantFetchAnalyzer;
 use Rector\SOLID\NodeFinder\ParentClassConstantNodeFinder;
 use Rector\SOLID\Reflection\ParentConstantReflectionResolver;
 use Rector\SOLID\ValueObject\ConstantVisibility;
@@ -24,12 +24,7 @@ final class PrivatizeLocalClassConstantRector extends AbstractRector
     /**
      * @var string
      */
-    public const HAS_NEW_ACCESS_LEVEL = 'has_new_access_level';
-
-    /**
-     * @var ClassConstantFetchAnalyzer
-     */
-    private $classConstantFetchAnalyzer;
+    private const HAS_NEW_ACCESS_LEVEL = 'has_new_access_level';
 
     /**
      * @var ParentConstantReflectionResolver
@@ -41,14 +36,19 @@ final class PrivatizeLocalClassConstantRector extends AbstractRector
      */
     private $parentClassConstantNodeFinder;
 
+    /**
+     * @var ClassConstParsedNodesFinder
+     */
+    private $classConstParsedNodesFinder;
+
     public function __construct(
-        ClassConstantFetchAnalyzer $classConstantFetchAnalyzer,
         ParentConstantReflectionResolver $parentConstantReflectionResolver,
-        ParentClassConstantNodeFinder $parentClassConstantNodeFinder
+        ParentClassConstantNodeFinder $parentClassConstantNodeFinder,
+        ClassConstParsedNodesFinder $classConstParsedNodesFinder
     ) {
-        $this->classConstantFetchAnalyzer = $classConstantFetchAnalyzer;
         $this->parentConstantReflectionResolver = $parentConstantReflectionResolver;
         $this->parentClassConstantNodeFinder = $parentClassConstantNodeFinder;
+        $this->classConstParsedNodesFinder = $classConstParsedNodesFinder;
     }
 
     public function getDefinition(): RectorDefinition
@@ -122,9 +122,18 @@ PHP
             return $node;
         }
 
-        $useClasses = $this->findClassConstantFetches($class, $constant);
+        $directUseClasses = $this->classConstParsedNodesFinder->findDirectClassConstantFetches($class, $constant);
+        $indirectUseClasses = $this->classConstParsedNodesFinder->findIndirectClassConstantFetches($class, $constant);
 
-        return $this->changeConstantVisibility($node, $useClasses, $parentClassConstantVisibility, $class);
+        $this->changeConstantVisibility(
+            $node,
+            $directUseClasses,
+            $indirectUseClasses,
+            $parentClassConstantVisibility,
+            $class
+        );
+
+        return $node;
     }
 
     private function shouldSkip(ClassConst $classConst): bool
@@ -168,42 +177,41 @@ PHP
         );
     }
 
-    private function findClassConstantFetches(string $className, string $constantName): ?array
-    {
-        $classConstantFetchByClassAndName = $this->classConstantFetchAnalyzer->provideClassConstantFetchByClassAndName();
-
-        return $classConstantFetchByClassAndName[$className][$constantName] ?? null;
-    }
-
     /**
-     * @param string[]|null $useClasses
+     * @param string[] $directUseClasses
+     * @param string[] $indirectUseClasses
      */
     private function changeConstantVisibility(
         ClassConst $classConst,
-        ?array $useClasses,
+        array $directUseClasses,
+        array $indirectUseClasses,
         ?ConstantVisibility $constantVisibility,
         string $class
-    ): Node {
+    ): void {
         // 1. is actually never used (@todo use in "dead-code" set)
-        if ($useClasses === null) {
-            $this->makePrivateOrWeaker($classConst, $constantVisibility);
-            return $classConst;
+        if ($directUseClasses === []) {
+            if ($indirectUseClasses !== [] && $constantVisibility !== null) {
+                $this->makePrivateOrWeaker($classConst, $constantVisibility);
+            }
+
+            return;
         }
 
         // 2. is only local use? → private
-        if ($useClasses === [$class]) {
-            $this->makePrivateOrWeaker($classConst, $constantVisibility);
-            return $classConst;
+        if ($directUseClasses === [$class]) {
+            if ($indirectUseClasses === []) {
+                $this->makePrivateOrWeaker($classConst, $constantVisibility);
+            }
+
+            return;
         }
 
         // 3. used by children → protected
-        if ($this->isUsedByChildrenOnly($useClasses, $class)) {
+        if ($this->isUsedByChildrenOnly($directUseClasses, $class)) {
             $this->makeProtected($classConst);
         } else {
             $this->makePublic($classConst);
         }
-
-        return $classConst;
     }
 
     private function makePrivateOrWeaker(ClassConst $classConst, ?ConstantVisibility $parentConstantVisibility): void

--- a/rules/solid/src/Rector/Foreach_/ChangeNestedForeachIfsToEarlyContinueRector.php
+++ b/rules/solid/src/Rector/Foreach_/ChangeNestedForeachIfsToEarlyContinueRector.php
@@ -98,7 +98,7 @@ PHP
     public function refactor(Node $node): ?Node
     {
         $nestedIfsWithOnlyNonReturn = $this->ifManipulator->collectNestedIfsWithNonBreaking($node);
-        if ($nestedIfsWithOnlyNonReturn === []) {
+        if (count($nestedIfsWithOnlyNonReturn) < 2) {
             return null;
         }
 

--- a/rules/solid/tests/Rector/ClassConst/PrivatizeLocalClassConstantRector/Fixture/skip_multi_inheritance.php.inc
+++ b/rules/solid/tests/Rector/ClassConst/PrivatizeLocalClassConstantRector/Fixture/skip_multi_inheritance.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\SOLID\Tests\Rector\ClassConst\PrivatizeLocalClassConstantRector\Fixture;
+
+use Rector\SOLID\Tests\Rector\ClassConst\PrivatizeLocalClassConstantRector\Source\AbstractInBetweenVariableParentClassUser;
+use Rector\SOLID\Tests\Rector\ClassConst\PrivatizeLocalClassConstantRector\Source\AbstractVariableParentClassUser;
+
+class SkipMultiInheritance extends AbstractInBetweenVariableParentClassUser
+{
+    /**
+     * @var string
+     */
+    public const SHORT_NAME = '@Id';
+}
+
+class TheVariableUse
+{
+    public function run(AbstractVariableParentClassUser $value)
+    {
+        return $value::SHORT_NAME;
+    }
+}

--- a/rules/solid/tests/Rector/ClassConst/PrivatizeLocalClassConstantRector/Fixture/skip_used_by_parents_class.php.inc
+++ b/rules/solid/tests/Rector/ClassConst/PrivatizeLocalClassConstantRector/Fixture/skip_used_by_parents_class.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\SOLID\Tests\Rector\ClassConst\PrivatizeLocalClassConstantRector\Fixture;
+
+use Rector\CodingStyle\Tests\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsParentRector\Fixture\ParentClass;
+
+class SkipUsedByParentClass extends ParentClassUser
+{
+    /**
+     * @var string
+     */
+    public const SHORT_NAME = '@Assert\Type';
+}
+
+class ParentClassUser
+{
+
+}
+
+class TheUse
+{
+    public function run()
+    {
+        return ParentClassUser::SHORT_NAME;
+    }
+}

--- a/rules/solid/tests/Rector/ClassConst/PrivatizeLocalClassConstantRector/Source/AbstractInBetweenVariableParentClassUser.php
+++ b/rules/solid/tests/Rector/ClassConst/PrivatizeLocalClassConstantRector/Source/AbstractInBetweenVariableParentClassUser.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\SOLID\Tests\Rector\ClassConst\PrivatizeLocalClassConstantRector\Source;
+
+abstract class AbstractInBetweenVariableParentClassUser extends AbstractVariableParentClassUser
+{
+
+}

--- a/rules/solid/tests/Rector/ClassConst/PrivatizeLocalClassConstantRector/Source/AbstractVariableParentClassUser.php
+++ b/rules/solid/tests/Rector/ClassConst/PrivatizeLocalClassConstantRector/Source/AbstractVariableParentClassUser.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace Rector\SOLID\Tests\Rector\ClassConst\PrivatizeLocalClassConstantRector\Source;
+
+abstract class AbstractVariableParentClassUser
+{
+
+}

--- a/rules/solid/tests/Rector/Foreach_/ChangeNestedForeachIfsToEarlyContinueRector/Fixture/skip_single_line.php.inc
+++ b/rules/solid/tests/Rector/Foreach_/ChangeNestedForeachIfsToEarlyContinueRector/Fixture/skip_single_line.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\SOLID\Tests\Rector\Foreach_\ChangeNestedForeachIfsToEarlyContinueRector\Fixture;
+
+class SkipSingleLine
+{
+    public function run()
+    {
+        $items = [];
+
+        foreach ($values as $value) {
+            if ($value === 5) {
+                $items[] = 'maybe';
+            }
+        }
+    }
+}

--- a/src/Testing/PHPUnit/FixtureSplitter.php
+++ b/src/Testing/PHPUnit/FixtureSplitter.php
@@ -6,15 +6,11 @@ namespace Rector\Core\Testing\PHPUnit;
 
 use Nette\Utils\FileSystem;
 use Nette\Utils\Strings;
+use Rector\Core\Testing\ValueObject\SplitLine;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class FixtureSplitter
 {
-    /**
-     * @var string
-     */
-    public const SPLIT_LINE = '#-----' . PHP_EOL . '#';
-
     /**
      * @var string
      */
@@ -32,9 +28,9 @@ final class FixtureSplitter
         SmartFileInfo $smartFileInfo,
         bool $autoloadTestFixture
     ): array {
-        if (Strings::match($smartFileInfo->getContents(), self::SPLIT_LINE)) {
+        if (Strings::match($smartFileInfo->getContents(), SplitLine::SPLIT_LINE)) {
             // original → expected
-            [$originalContent, $expectedContent] = Strings::split($smartFileInfo->getContents(), self::SPLIT_LINE);
+            [$originalContent, $expectedContent] = Strings::split($smartFileInfo->getContents(), SplitLine::SPLIT_LINE);
         } else {
             // no changes
             $originalContent = $smartFileInfo->getContents();

--- a/src/Testing/ValueObject/SplitLine.php
+++ b/src/Testing/ValueObject/SplitLine.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Testing\ValueObject;
+
+final class SplitLine
+{
+    /**
+     * @var string
+     */
+    public const SPLIT_LINE = '#-----' . PHP_EOL . '#';
+}


### PR DESCRIPTION
Closes #2908

## Todo

- [x] refactor `$tagValueNode::SHORT_NAME` to use `->getShortName()` method to make design less magical and required by interface contract