### PR TITLE
add project_type

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -14,6 +14,9 @@ parameters:
     autoload_paths: []
     rector_recipe: []
 
+    # this helps to separate opened 3rd party code vs private code approach (e.g. use of public constants)
+    project_type: "proprietary" # or "open-source"
+
     # lower for performance; higher to prevent bugs with fluent interfaces like https://github.com/rectorphp/rector/issues/1646, or https://github.com/rectorphp/rector/issues/2444
     nested_chain_method_call_limit: 30
 

--- a/rules/dead-code/src/Rector/ClassMethod/RemoveUnusedParameterRector.php
+++ b/rules/dead-code/src/Rector/ClassMethod/RemoveUnusedParameterRector.php
@@ -8,12 +8,14 @@ use PhpParser\Node;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
+use Rector\Core\Configuration\Option;
 use Rector\Core\PhpParser\Node\Manipulator\ClassManipulator;
 use Rector\Core\PhpParser\Node\Manipulator\ClassMethodManipulator;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\RectorDefinition\CodeSample;
 use Rector\Core\RectorDefinition\RectorDefinition;
 use Rector\NodeTypeResolver\Node\AttributeKey;
+use Symplify\PackageBuilder\Parameter\ParameterProvider;
 
 /**
  * @see https://www.php.net/manual/en/function.compact.php
@@ -52,12 +54,19 @@ final class RemoveUnusedParameterRector extends AbstractRector
      */
     private $classMethodManipulator;
 
+    /**
+     * @var ParameterProvider
+     */
+    private $parameterProvider;
+
     public function __construct(
         ClassManipulator $classManipulator,
-        ClassMethodManipulator $classMethodManipulator
+        ClassMethodManipulator $classMethodManipulator,
+        ParameterProvider $parameterProvider
     ) {
         $this->classManipulator = $classManipulator;
         $this->classMethodManipulator = $classMethodManipulator;
+        $this->parameterProvider = $parameterProvider;
     }
 
     public function getDefinition(): RectorDefinition
@@ -203,7 +212,8 @@ PHP
         }
 
         // skip as possible contract for 3rd party
-        if ($classMethod->isAbstract()) {
+        $projetType = $this->parameterProvider->provideParameter(Option::PROJECT_TYPE);
+        if ($classMethod->isAbstract() && $projetType === Option::PROJECT_TYPE_OPEN_SOURCE) {
             return true;
         }
 

--- a/rules/dead-code/tests/Rector/ClassMethod/RemoveUnusedParameterRector/Fixture/change_when_not_using_in_children.php.inc
+++ b/rules/dead-code/tests/Rector/ClassMethod/RemoveUnusedParameterRector/Fixture/change_when_not_using_in_children.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\DeadCode\Tests\Rector\ClassMethod\RemoveUnusedParameterRector\Fixture;
+
+abstract class AbstractClass
+{
+    public abstract function foo(string $value);
+
+}
+
+class ChildClass extends AbstractClass
+{
+    public function foo(string $value)
+    {
+        return null;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\DeadCode\Tests\Rector\ClassMethod\RemoveUnusedParameterRector\Fixture;
+
+abstract class AbstractClass
+{
+    public abstract function foo();
+
+}
+
+class ChildClass extends AbstractClass
+{
+    public function foo()
+    {
+        return null;
+    }
+}
+
+?>

--- a/rules/dead-code/tests/Rector/ClassMethod/RemoveUnusedParameterRector/FixtureOpenSource/skip_abstract.php.inc
+++ b/rules/dead-code/tests/Rector/ClassMethod/RemoveUnusedParameterRector/FixtureOpenSource/skip_abstract.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\DeadCode\Tests\Rector\ClassMethod\RemoveUnusedParameterRector\Fixture;
+namespace Rector\DeadCode\Tests\Rector\ClassMethod\RemoveUnusedParameterRector\FixtureOpenSource;
 
 abstract class SkipAbstract
 {

--- a/rules/dead-code/tests/Rector/ClassMethod/RemoveUnusedParameterRector/OpenSourceRectorTest.php
+++ b/rules/dead-code/tests/Rector/ClassMethod/RemoveUnusedParameterRector/OpenSourceRectorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DeadCode\Tests\Rector\ClassMethod\RemoveUnusedParameterRector;
+
+use Iterator;
+use Rector\Core\Configuration\Option;
+use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedParameterRector;
+
+final class OpenSourceRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $file): void
+    {
+        $this->setParameter(Option::PROJECT_TYPE, Option::PROJECT_TYPE_OPEN_SOURCE);
+        $this->doTestFile($file);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/FixtureOpenSource');
+    }
+
+    protected function getRectorClass(): string
+    {
+        return RemoveUnusedParameterRector::class;
+    }
+}

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -75,4 +75,14 @@ final class Option
      * @var string
      */
     public const OPTION_OUTPUT_FILE = 'output-file';
+
+    /**
+     * @var string
+     */
+    public const PROJECT_TYPE = 'project_type';
+
+    /**
+     * @var string
+     */
+    public const PROJECT_TYPE_OPEN_SOURCE = 'open-source';
 }


### PR DESCRIPTION
Ref #2743 

```yaml
# rector.yaml	
parameters:
    project_type: "proprietary" # = only you use it (default)
```

or more opened, e.g. allow use of public constants

```yaml
# rector.yaml	
parameters:
    project_type: "open-source" # = other people use it
```

