### PR TITLE
[GetClassOnNullRector] Add failing test in trait.

### DIFF
--- a/rules/php-72/tests/Rector/FuncCall/GetClassOnNullRector/Fixture/skip_return_before_method_call.php.inc
+++ b/rules/php-72/tests/Rector/FuncCall/GetClassOnNullRector/Fixture/skip_return_before_method_call.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Php72\Tests\Rector\FuncCall\GetClassOnNullRector\Fixture;
+
+trait SomeTrait
+{
+    /**
+     * @return mixed
+     */
+    private function someMethodInTrait(?object $objectInTrait)
+    {
+        if (null === $objectInTrait) {
+            return null;
+        }
+
+        return get_class($objectInTrait);
+    }
+}
+
+final class SomeClassUsingTheTrait
+{
+    use SomeTrait;
+
+    public function __invoke()
+    {
+        $object = new \stdClass();
+        $object->id = 42;
+
+        $fromClass = $this->someMethodInClass($object);
+        $fromTrait = $this->someMethodInTrait($object);
+    }
+
+    public function someMethodInClass(?object $objectInClass)
+    {
+        if (null === $objectInClass) {
+            return null;
+        }
+
+        return get_class($objectInClass);
+    }
+}


### PR DESCRIPTION
https://getrector.org/demo/10a00600-21ac-4ca7-9f72-1cce72977b0f#result

It should detect the check `if (null === $object) { return null; }` and not process the statement `get_class($object)` (this demo is simplified as much as possible, compared to my real code).