### PR TITLE
AddSeeTestAnnotationRectorTest: add broken test for simple comment.

### DIFF
--- a/rules/phpunit/tests/Rector/Class_/AddSeeTestAnnotationRector/Fixture/skip_simple_class_comment.php.inc
+++ b/rules/phpunit/tests/Rector/Class_/AddSeeTestAnnotationRector/Fixture/skip_simple_class_comment.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\Class_\AddSeeTestAnnotationRector\Fixture;
+
+/*
+ * Some class command not in a PHPDoc Block
+ */
+class SkipSimpleClassComment
+{
+}

--- a/rules/phpunit/tests/Rector/Class_/AddSeeTestAnnotationRector/Source/SkipSimpleClassCommentTest.php
+++ b/rules/phpunit/tests/Rector/Class_/AddSeeTestAnnotationRector/Source/SkipSimpleClassCommentTest.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\Rector\Class_\AddSeeTestAnnotationRector\Source;
+
+final class SkipSimpleClassCommentTest
+{
+
+}


### PR DESCRIPTION
I was not able to reproduce in the demo however (where it adds the `@see` annotation even on the simple comment...) https://getrector.org/demo/9890b876-ff9e-4bd4-bff1-ad1598d41f42#result

In local I get an error block like : 

```
 [ERROR] Could not process "File.php" file by                           
         "Rector\PHPUnit\Rector\Class_\AddSeeTestAnnotationRector", due to:                                             
         "Call to a member function getTagsByName() on null".                                                                                                                                                                                 
```