### PR TITLE
ReturnTypeDeclarationRector: add broken test on array indexes (?)

### DIFF
--- a/rules/type-declaration/tests/Rector/FunctionLike/ReturnTypeDeclarationRector/Fixture/skip_array_index.php.inc
+++ b/rules/type-declaration/tests/Rector/FunctionLike/ReturnTypeDeclarationRector/Fixture/skip_array_index.php.inc
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypeDeclaration\Tests\Rector\ClassMethod\ReturnTypeDeclarationRector\Fixture;
+
+interface RepositoryInterface
+{
+    /**
+     * @param int[] $ids
+     * @param int[] $expenseReportIds
+     *
+     * @return \stdClass[]
+     */
+    public function listBy(?array $ids = null, ?array $expenseReportIds = null): array;
+}
+
+final class SkipArrayIndex
+{
+    /**
+     * @var RepositoryInterface
+     */
+    private $repository;
+
+    public function __construct(RepositoryInterface $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function __invoke(object $query): \stdClass
+    {
+        $objects = $this->repository->listBy([$query->id]);
+
+        if (empty($objects)) {
+            throw new \InvalidArgumentException($query->id);
+        }
+
+        if (1 !== count($objects)) {
+            throw new \UnexpectedValueException();
+        }
+
+        return $objects[0];
+    }
+}


### PR DESCRIPTION
I'm not sure exactly what's happening here ; might have to do with the fact that we access an array index using `[0]` ?

But I'm pretty sure it shouldn't replace `): \stdClass` by `): array` as it will break the code (PS: in my real code it's not \stdClass but some domain object).