### PR TITLE
AssertRegExpRectorTest: add broken test on static method call

### DIFF
--- a/rules/phpunit/tests/Rector/SpecificMethod/AssertRegExpRector/Fixture/fixture_2.php.inc
+++ b/rules/phpunit/tests/Rector/SpecificMethod/AssertRegExpRector/Fixture/fixture_2.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\SpecificMethod\AssertRegExpRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class Fixture2Test extends TestCase
+{
+    public function testSomething(object $object, string $method, array $input, string $expected): void
+    {
+        static::assertSame($expected, $object::$method($input));
+    }
+}


### PR DESCRIPTION
Could not reproduce in a demo set however ('guessing because there's no real PHPUnit in there) : https://getrector.org/demo/011085dd-1266-4a33-a8a9-44e355f9f709#result

Fails with error : 

```                                  
 [ERROR] Could not process "File.php" file, due to:     
         "Pick more specific node than "PhpParser\Node\Expr\StaticCall"".                                                                        
```

I had the exact same error happen from these Rectors on my code base : 

* `Rector\PHPUnit\Rector\SpecificMethod\AssertTrueFalseToSpecificMethodRector`
* `Rector\PHPUnit\Rector\SpecificMethod\AssertFalseStrposToContainsRector`
* `Rector\PHPUnit\Rector\SpecificMethod\AssertPropertyExistsRector`

I guess the issue is the same, so I won't try to add tests for them all. We'll see later once a fix comes out if they still fail.