### PR TITLE
RemoveDefaultArgumentValueRector: add broken test on static method call.

### DIFF
--- a/rules/dead-code/tests/Rector/MethodCall/RemoveDefaultArgumentValueRector/Fixture/skip_static_method_call.php.inc
+++ b/rules/dead-code/tests/Rector/MethodCall/RemoveDefaultArgumentValueRector/Fixture/skip_static_method_call.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\DeadCode\Tests\Rector\MethodCall\RemoveDefaultArgumentValueRector\Fixture;
+
+final class SkipStaticMethodCall
+{
+    public function __invoke(callable $callback): void
+    {
+        \Closure::bind($callback, $this, self::class)($this);
+    }
+}


### PR DESCRIPTION
Might be related to https://github.com/rectorphp/rector/pull/2953 as it's the same error, but it might not (as the Rector is quite different).

Fails with error : 

```                                  
 [ERROR] Could not process "File.php" file, due to:     
         "Pick more specific node than "PhpParser\Node\Expr\StaticCall"".                                                                        
```