### PR TITLE
AssertTrueFalseInternalTypeToSpecificMethodRector: add broken test method call

### DIFF
--- a/rules/dead-code/tests/Rector/MethodCall/RemoveDefaultArgumentValueRector/Fixture/skip_static_method_call.php.inc
+++ b/rules/dead-code/tests/Rector/MethodCall/RemoveDefaultArgumentValueRector/Fixture/skip_static_method_call.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\DeadCode\Tests\Rector\MethodCall\RemoveDefaultArgumentValueRector\Fixture;
+
+final class SkipStaticMethodCall
+{
+    public function __invoke(callable $callback): void
+    {
+        \Closure::bind($callback, $this, self::class)($this);
+    }
+}

--- a/rules/phpunit/tests/Rector/SpecificMethod/AssertTrueFalseInternalTypeToSpecificMethodRector/Fixture/fixture_2.php.inc
+++ b/rules/phpunit/tests/Rector/SpecificMethod/AssertTrueFalseInternalTypeToSpecificMethodRector/Fixture/fixture_2.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPUnit\Tests\Rector\SpecificMethod\AssertTrueFalseInternalTypeToSpecificMethodRector\Fixture;
+
+final class Fixture2Test extends \PHPUnit\Framework\TestCase
+{
+    public function testSomething(object $object): void
+    {
+        self::assertFalse($object->someMethod());
+    }
+}


### PR DESCRIPTION
Might be related to #2954 and #2955. They all come from `Rector\NodeNameResolver\NodeNameResolver->getName()`. I won't open any more issues like this one for now as to not spam you if it all comes from the same source ; this should give you enough of a sample to work with. ;) 

Fails with error : 

```
 [ERROR] Could not process "File.php" file, due to:     
         "Pick more specific node than "PhpParser\Node\Expr\MethodCall"".     
```