### PR TITLE
AssertTrueFalseToSpecificMethodRector: add broken test ('Pick more specific node than PhpParser\Node\Expr\StaticCall')

### DIFF
--- a/rules/phpunit/src/Rector/SpecificMethod/AssertTrueFalseToSpecificMethodRector.php
+++ b/rules/phpunit/src/Rector/SpecificMethod/AssertTrueFalseToSpecificMethodRector.php
@@ -73,7 +73,9 @@ final class AssertTrueFalseToSpecificMethodRector extends AbstractPHPUnitRector
         }
 
         $firstArgumentValue = $node->args[0]->value;
-        if (! $this->isNames($firstArgumentValue, array_keys(self::OLD_TO_NEW_METHODS))) {
+        if ($firstArgumentValue instanceof StaticCall ||
+            ! $this->isNames($firstArgumentValue, array_keys(self::OLD_TO_NEW_METHODS))
+        ) {
             return null;
         }
 

--- a/rules/phpunit/tests/Rector/SpecificMethod/AssertTrueFalseToSpecificMethodRector/Fixture/fixture3.php.inc
+++ b/rules/phpunit/tests/Rector/SpecificMethod/AssertTrueFalseToSpecificMethodRector/Fixture/fixture3.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\SpecificMethod\AssertTrueFalseToSpecificMethodRector\Fixture;
+
+final class Fixture3Test extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        self::assertFalse(SomeClass::someMethod());
+    }
+}


### PR DESCRIPTION
Same as https://github.com/rectorphp/rector/pull/2953. 