### PR TITLE
AddArrayReturnDocTypeRector: add broken test on Assert::resource().

### DIFF
--- a/rules/type-declaration/tests/Rector/ClassMethod/AddArrayReturnDocTypeRector/Fixture/skip_assert.php.inc
+++ b/rules/type-declaration/tests/Rector/ClassMethod/AddArrayReturnDocTypeRector/Fixture/skip_assert.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\TypeDeclaration\Tests\Rector\ClassMethod\AddArrayReturnDocTypeRector\Fixture;
+
+use Webmozart\Assert\Assert;
+
+final class SkipAssert
+{
+    /**
+     * @return resource
+     */
+    public function stream()
+    {
+        $filePath = tempnam(sys_get_temp_dir(), 'test');
+        $stream = fopen($filePath, 'rb');
+        Assert::resource($stream, 'stream', sprintf('Could not stream content of local file: %s', $filePath));
+
+        return $stream;
+    }
+}


### PR DESCRIPTION
Rector now changes a return type `@return resource` to `@return resource|bool`, even though the code calls `Assert::resource()` to ensure it cannot be returning a boolean.