### PR TITLE
Fix various static calls errors in PHPUnit Rectors.

### DIFF
--- a/rules/phpunit/src/Rector/SpecificMethod/AssertFalseStrposToContainsRector.php
+++ b/rules/phpunit/src/Rector/SpecificMethod/AssertFalseStrposToContainsRector.php
@@ -71,6 +71,9 @@ final class AssertFalseStrposToContainsRector extends AbstractPHPUnitRector
         }
 
         $firstArgumentValue = $node->args[0]->value;
+        if ($firstArgumentValue instanceof StaticCall) {
+            return null;
+        }
         if (! $this->isNames($firstArgumentValue, ['strpos', 'stripos'])) {
             return null;
         }

--- a/rules/phpunit/src/Rector/SpecificMethod/AssertPropertyExistsRector.php
+++ b/rules/phpunit/src/Rector/SpecificMethod/AssertPropertyExistsRector.php
@@ -81,9 +81,10 @@ final class AssertPropertyExistsRector extends AbstractPHPUnitRector
             return null;
         }
 
-        /** @var FuncCall $firstArgumentValue */
         $firstArgumentValue = $node->args[0]->value;
-
+        if ($firstArgumentValue instanceof StaticCall) {
+            return null;
+        }
         if (! $this->isName($firstArgumentValue, 'property_exists')) {
             return null;
         }

--- a/rules/phpunit/src/Rector/SpecificMethod/AssertTrueFalseToSpecificMethodRector.php
+++ b/rules/phpunit/src/Rector/SpecificMethod/AssertTrueFalseToSpecificMethodRector.php
@@ -73,9 +73,10 @@ final class AssertTrueFalseToSpecificMethodRector extends AbstractPHPUnitRector
         }
 
         $firstArgumentValue = $node->args[0]->value;
-        if ($firstArgumentValue instanceof StaticCall ||
-            ! $this->isNames($firstArgumentValue, array_keys(self::OLD_TO_NEW_METHODS))
-        ) {
+        if ($firstArgumentValue instanceof StaticCall) {
+            return null;
+        }
+        if (! $this->isNames($firstArgumentValue, array_keys(self::OLD_TO_NEW_METHODS))) {
             return null;
         }
 

--- a/rules/phpunit/tests/Rector/SpecificMethod/AssertFalseStrposToContainsRector/Fixture/skip_static_call.php.inc
+++ b/rules/phpunit/tests/Rector/SpecificMethod/AssertFalseStrposToContainsRector/Fixture/skip_static_call.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\SpecificMethod\AssertFalseStrposToContainsRector\Fixture;
+
+final class SkipStaticCall extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        self::assertFalse(SomeClass::someMethod());
+    }
+}

--- a/rules/phpunit/tests/Rector/SpecificMethod/AssertPropertyExistsRector/Fixture/skip_static_call.php.inc
+++ b/rules/phpunit/tests/Rector/SpecificMethod/AssertPropertyExistsRector/Fixture/skip_static_call.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\SpecificMethod\AssertPropertyExistsRector\Fixture;
+
+final class SkipStaticCall extends \PHPUnit\Framework\TestCase
+{
+    public function test()
+    {
+        self::assertFalse(SomeClass::someMethod());
+    }
+}

--- a/rules/phpunit/tests/Rector/SpecificMethod/AssertTrueFalseToSpecificMethodRector/Fixture/skip_static_call.php.inc
+++ b/rules/phpunit/tests/Rector/SpecificMethod/AssertTrueFalseToSpecificMethodRector/Fixture/skip_static_call.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\PHPUnit\Tests\Rector\SpecificMethod\AssertTrueFalseToSpecificMethodRector\Fixture;
 
-final class Fixture3Test extends \PHPUnit\Framework\TestCase
+final class SkipStaticCall extends \PHPUnit\Framework\TestCase
 {
     public function test()
     {


### PR DESCRIPTION
Fixes remaining Rectors of #2953 and #2990 (PS: I tried `! $firstArgumentValue instanceof FuncCall` but it broke many tests, so I kept `$firstArgumentValue instanceof StaticCall` and put it in its own `if`)