### PR TITLE
Add failing tests for method annotation

### DIFF
--- a/rules/symfony/tests/Rector/ClassMethod/MergeMethodAnnotationToRouteAnnotationRector/Fixture/fixture_with_template_annotation.php.inc
+++ b/rules/symfony/tests/Rector/ClassMethod/MergeMethodAnnotationToRouteAnnotationRector/Fixture/fixture_with_template_annotation.php.inc
@@ -1,0 +1,42 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\ClassMethod\MergeMethodAnnotationToRouteAnnotationRector\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Symfony\Component\Routing\Annotation\Route;
+
+class ClassWithTemplateAnnotationController
+{
+    /**
+     * @Route("/show/{id}")
+     * @Method({"GET", "HEAD"})
+     * @Template("AdminBundle:Payment:create.html.twig")
+     */
+    public function show($id)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Rector\ClassMethod\MergeMethodAnnotationToRouteAnnotationRector\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Symfony\Component\Routing\Annotation\Route;
+
+class ClassWithTemplateAnnotationController
+{
+    /**
+     * @Route("/show/{id}", methods={"GET", "HEAD"})
+     * @Template("AdminBundle:Payment:create.html.twig")
+     */
+    public function show($id)
+    {
+    }
+}
+
+?>

--- a/rules/symfony/tests/Rector/ClassMethod/MergeMethodAnnotationToRouteAnnotationRector/Fixture/fixture_with_template_annotation2.php.inc
+++ b/rules/symfony/tests/Rector/ClassMethod/MergeMethodAnnotationToRouteAnnotationRector/Fixture/fixture_with_template_annotation2.php.inc
@@ -1,0 +1,42 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\ClassMethod\MergeMethodAnnotationToRouteAnnotationRector\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Symfony\Component\Routing\Annotation\Route;
+
+class ClassWithTemplateAnnotation2Controller
+{
+    /**
+     * @Route("/show/{id}")
+     * @Template("AdminBundle:Payment:create.html.twig")
+     * @Method({"GET", "HEAD"})
+     */
+    public function show($id)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Rector\ClassMethod\MergeMethodAnnotationToRouteAnnotationRector\Fixture;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Symfony\Component\Routing\Annotation\Route;
+
+class ClassWithTemplateAnnotation2Controller
+{
+    /**
+     * @Route("/show/{id}", methods={"GET", "HEAD"})
+     * @Template("AdminBundle:Payment:create.html.twig")
+     */
+    public function show($id)
+    {
+    }
+}
+
+?>


### PR DESCRIPTION
I've added two failing tests for the MergeMethodAnnotationToRouteAnnotationRector.
In my opinion it shouldn't change the template annotation and it seems that the method won't be merged if some other annotation stands between the Route and Method annoation.

When the tests will get fixed, this PR will fix issue #2785.

I wasn't able to get this fixed by myself, maybe you could help me?