### PR TITLE
[PHP 7.4] Skip already splitted literal separator

### DIFF
--- a/rules/php-74/src/Rector/LNumber/AddLiteralSeparatorToNumberRector.php
+++ b/rules/php-74/src/Rector/LNumber/AddLiteralSeparatorToNumberRector.php
@@ -17,6 +17,7 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
 /**
  * @see https://wiki.php.net/rfc/numeric_literal_separator
  * @see https://github.com/nikic/PHP-Parser/pull/615
+ *
  * @see \Rector\Php74\Tests\Rector\LNumber\AddLiteralSeparatorToNumberRector\AddLiteralSeparatorToNumberRectorTest
  *
  * Taking the most generic use case to the account: https://wiki.php.net/rfc/numeric_literal_separator#should_it_be_the_role_of_an_ide_to_group_digits
@@ -76,6 +77,12 @@ PHP
         }
 
         $numericValueAsString = (string) $node->value;
+
+        // ...
+        dump($node->getAttribute(AttributeKey::ORIGINAL_NODE));
+        dump($numericValueAsString);
+        die;
+
         if ($this->shouldSkip($node, $numericValueAsString)) {
             return null;
         }

--- a/rules/php-74/tests/Rector/LNumber/AddLiteralSeparatorToNumberRector/Fixture/skip_already_split.php.inc
+++ b/rules/php-74/tests/Rector/LNumber/AddLiteralSeparatorToNumberRector/Fixture/skip_already_split.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Php74\Tests\Rector\LNumber\AddLiteralSeparatorToNumberRector\Fixture;
+
+class SkipAlreadySplit
+{
+    public function run()
+    {
+        $c = 100_00;
+    }
+}


### PR DESCRIPTION
Depends on https://github.com/nikic/PHP-Parser/pull/655 