### PR TITLE
[PHP 7.4] Improve TypedPropertyRector for Doctrine collection

### DIFF
--- a/packages/phpstan-static-type-mapper/src/DoctrineTypeAnalyzer.php
+++ b/packages/phpstan-static-type-mapper/src/DoctrineTypeAnalyzer.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPStanStaticTypeMapper;
+
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeWithClassName;
+use PHPStan\Type\UnionType;
+
+final class DoctrineTypeAnalyzer
+{
+    public function isDoctrineCollectionWithIterableUnionType(Type $type): bool
+    {
+        if (! $type instanceof UnionType) {
+            return false;
+        }
+
+        $arrayType = null;
+        $hasDoctrineCollectionType = false;
+        foreach ($type->getTypes() as $unionedType) {
+            if ($this->isCollectionObjectType($unionedType)) {
+                $hasDoctrineCollectionType = true;
+            }
+
+            if ($unionedType instanceof ArrayType) {
+                $arrayType = $unionedType;
+            }
+        }
+
+        if (! $hasDoctrineCollectionType) {
+            return false;
+        }
+
+        return $arrayType !== null;
+    }
+
+    private function isCollectionObjectType(Type $type): bool
+    {
+        if (! $type instanceof TypeWithClassName) {
+            return false;
+        }
+
+        return $type->getClassName() === 'Doctrine\Common\Collections\Collection';
+    }
+}

--- a/rules/php-74/tests/Rector/Property/TypedPropertyRector/DoctrineTypedPropertyRectorTest.php
+++ b/rules/php-74/tests/Rector/Property/TypedPropertyRector/DoctrineTypedPropertyRectorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector;
+
+use Iterator;
+use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;
+use Rector\Php74\Rector\Property\TypedPropertyRector;
+
+final class DoctrineTypedPropertyRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $file): void
+    {
+        $this->doTestFile($file);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/FixtureDoctrine');
+    }
+
+    protected function getRectorClass(): string
+    {
+        return TypedPropertyRector::class;
+    }
+
+    protected function getPhpVersion(): string
+    {
+        // before union type
+        return '7.4';
+    }
+}

--- a/rules/php-74/tests/Rector/Property/TypedPropertyRector/FixtureDoctrine/doctrine_collection.php.inc
+++ b/rules/php-74/tests/Rector/Property/TypedPropertyRector/FixtureDoctrine/doctrine_collection.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Pehapkari\Training\Entity\TrainingTerm;
+
+/**
+ * @ORM\Entity
+ */
+class DoctrineCollection
+{
+    /**
+     * @ORM\OneToMany(targetEntity="Pehapkari\Training\Entity\TrainingTerm", mappedBy="training")
+     * @var TrainingTerm[]|Collection
+     */
+    private $trainingTerms;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Pehapkari\Training\Entity\TrainingTerm;
+
+/**
+ * @ORM\Entity
+ */
+class DoctrineCollection
+{
+    /**
+     * @ORM\OneToMany(targetEntity="Pehapkari\Training\Entity\TrainingTerm", mappedBy="training")
+     * @var TrainingTerm[]|Collection
+     */
+    private \Doctrine\Common\Collections\Collection $trainingTerms;
+}
+
+?>

--- a/rules/php-74/tests/Rector/Property/TypedPropertyRector/FixtureDoctrine/doctrine_intersect_collection.php.inc
+++ b/rules/php-74/tests/Rector/Property/TypedPropertyRector/FixtureDoctrine/doctrine_intersect_collection.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Pehapkari\Training\Entity\TrainingTerm;
+
+/**
+ * @ORM\Entity
+ */
+class DoctrineIntersectCollection
+{
+    /**
+     * @ORM\OneToMany(targetEntity="Pehapkari\Training\Entity\TrainingTerm", mappedBy="training")
+     * @var TrainingTerm[]&Collection
+     */
+    private $training;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Pehapkari\Training\Entity\TrainingTerm;
+
+/**
+ * @ORM\Entity
+ */
+class DoctrineIntersectCollection
+{
+    /**
+     * @ORM\OneToMany(targetEntity="Pehapkari\Training\Entity\TrainingTerm", mappedBy="training")
+     * @var TrainingTerm[]&Collection
+     */
+    private \Doctrine\Common\Collections\Collection $training;
+}
+
+?>


### PR DESCRIPTION
## Before Doctrine Collections were Skipped

```php
<?php

namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;

use Doctrine\Common\Collections\Collection;
use Doctrine\ORM\Mapping as ORM;
use Pehapkari\Training\Entity\TrainingTerm;

/**
 * @ORM\Entity
 */
class DoctrineCollection
{
    /**
     * @ORM\OneToMany(targetEntity="Pehapkari\Training\Entity\TrainingTerm", mappedBy="training")
     * @var TrainingTerm[]&Collection
     */
    private $trainingTerms;
}
```

## Now The Collection Type is Used and Annotation Kept, to add more info

```diff
<?php

namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;

use Doctrine\Common\Collections\Collection;
use Doctrine\ORM\Mapping as ORM;
use Pehapkari\Training\Entity\TrainingTerm;

/**
 * @ORM\Entity
 */
class DoctrineCollection
{
    /**
     * @ORM\OneToMany(targetEntity="Pehapkari\Training\Entity\TrainingTerm", mappedBy="training")
     * @var TrainingTerm[]&Collection
     */
-   private $trainingTerms;
+   private Collection $trainingTerms;
}
```
