### PR TITLE
Add RunnableTestCase to run fixed code in a test

### DIFF
--- a/rules/code-quality/tests/Rector/FuncCall/ArrayKeysAndInArrayToArrayKeyExistsRector/ArrayKeysAndInArrayToArrayKeyExistsRectorTest.php
+++ b/rules/code-quality/tests/Rector/FuncCall/ArrayKeysAndInArrayToArrayKeyExistsRector/ArrayKeysAndInArrayToArrayKeyExistsRectorTest.php
@@ -6,9 +6,9 @@ namespace Rector\CodeQuality\Tests\Rector\FuncCall\ArrayKeysAndInArrayToArrayKey
 
 use Iterator;
 use Rector\CodeQuality\Rector\FuncCall\ArrayKeysAndInArrayToArrayKeyExistsRector;
-use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;
+use Rector\Core\Testing\PHPUnit\AbstractRunnableRectorTestCase;
 
-final class ArrayKeysAndInArrayToArrayKeyExistsRectorTest extends AbstractRectorTestCase
+final class ArrayKeysAndInArrayToArrayKeyExistsRectorTest extends AbstractRunnableRectorTestCase
 {
     /**
      * @dataProvider provideData()
@@ -16,6 +16,7 @@ final class ArrayKeysAndInArrayToArrayKeyExistsRectorTest extends AbstractRector
     public function test(string $file): void
     {
         $this->doTestFile($file);
+        $this->assertOriginalAndFixedFileResultEquals($file);
     }
 
     public function provideData(): Iterator

--- a/rules/code-quality/tests/Rector/FuncCall/ArrayKeysAndInArrayToArrayKeyExistsRector/Fixture/fixture.php.inc
+++ b/rules/code-quality/tests/Rector/FuncCall/ArrayKeysAndInArrayToArrayKeyExistsRector/Fixture/fixture.php.inc
@@ -1,11 +1,16 @@
 <?php
 
-namespace Rector\CodeQuality\Tests\Rector\FuncCall\ArrayKeysAndInArrayToIssetRector\Fixture;
+namespace Rector\CodeQuality\Tests\Rector\FuncCall\ArrayKeysAndInArrayToArrayKeyExistsRector\Fixture;
 
-class SomeClass
+use Rector\Core\Testing\PHPUnit\RunnableInterface;
+
+class SomeClass implements RunnableInterface
 {
-    public function run($packageName, $values)
+    public function run()
     {
+        $packageName = "foo";
+        $values      = ["foo" => "bar"];
+        
         $keys = array_keys($values);
         return in_array($packageName, $keys, true);
     }
@@ -15,12 +20,16 @@ class SomeClass
 -----
 <?php
 
-namespace Rector\CodeQuality\Tests\Rector\FuncCall\ArrayKeysAndInArrayToIssetRector\Fixture;
+namespace Rector\CodeQuality\Tests\Rector\FuncCall\ArrayKeysAndInArrayToArrayKeyExistsRector\Fixture;
 
-class SomeClass
+use Rector\Core\Testing\PHPUnit\RunnableInterface;
+
+class SomeClass implements RunnableInterface
 {
-    public function run($packageName, $values)
+    public function run()
     {
+        $packageName = "foo";
+        $values      = ["foo" => "bar"];
         return array_key_exists($packageName, $values);
     }
 }

--- a/src/Testing/PHPUnit/AbstractRunnableRectorTestCase.php
+++ b/src/Testing/PHPUnit/AbstractRunnableRectorTestCase.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Testing\PHPUnit;
+
+use Nette\Utils\Strings;
+use Rector\Core\Testing\ValueObject\SplitLine;
+use ReflectionClass;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+abstract class AbstractRunnableRectorTestCase extends AbstractRectorTestCase
+{
+    protected function assertOriginalAndFixedFileResultEquals(string $file): void
+    {
+        /**
+         * Todo: Duplicate from
+         *
+         * @see FixtureSplitter::splitContentToOriginalFileAndExpectedFile
+         * ==> refactor in a method
+         */
+        $smartFileInfo = new SmartFileInfo($file);
+        if (Strings::match($smartFileInfo->getContents(), SplitLine::SPLIT_LINE)) {
+            [$originalContent, $expectedContent] = Strings::split($smartFileInfo->getContents(), SplitLine::SPLIT_LINE);
+        } else {
+            $originalContent = $smartFileInfo->getContents();
+            $expectedContent = $originalContent;
+        }
+
+        $originalInstance = $this->loadClass($originalContent);
+        if ($originalInstance !== null) {
+            $expectedInstance = $this->loadClass($expectedContent);
+            if ($expectedInstance !== null) {
+                $actual = $originalInstance->run();
+                $expected = $expectedInstance->run();
+
+                $this->assertSame($actual, $expected);
+            }
+        }
+    }
+
+    protected function getTemporaryClassName(): string
+    {
+        $testName = (new ReflectionClass(static::class))->getShortName();
+        // Todo - pull in Ramsey UUID to generate temporay class names?
+//        $uuid      = Uuid::uuid4()->toString();
+        $uuid = md5((string) random_int(0, 100000000));
+        $className = $testName . '_' . $uuid;
+
+        return Strings::replace($className, '#[^0-9a-zA-Z]#', '_');
+    }
+
+    protected function loadClass(string $classContent): ?RunnableInterface
+    {
+        $className = $this->getTemporaryClassName();
+        $loadable = Strings::replace($classContent, '#\\s*<\\?php#', '');
+        $loadable = Strings::replace($loadable, '#\\s*namespace.*;#', '');
+        $loadable = Strings::replace($loadable, '#class\\s+(\\S*)\\s+#', sprintf('class %s ', $className));
+        eval($loadable);
+        if (is_a($className, RunnableInterface::class, true)) {
+            /**
+             * @var RunnableInterface
+             */
+            return new $className();
+        }
+        return null;
+    }
+}

--- a/src/Testing/PHPUnit/RunnableInterface.php
+++ b/src/Testing/PHPUnit/RunnableInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Testing\PHPUnit;
+
+interface RunnableInterface
+{
+    public function run();
+}


### PR DESCRIPTION
- added RunnableTestCase::assertOriginalAndFixedFileYieldSameResult($file)
  that takes a fixture file and expects fixture classes that implement the
  new RunnableInterface which exposes a run() method
- the fixture class is dynamically renamed to avoid naming conflicts
  and loaded via eval()
- fixtures that don't implement the RunnableInterface are ignored
  otherwise the run() method is called on the original class as well
  as on the fixed one and the output is expected to be equal
  (via assertSame) by default
- the default assertion behavior can be changed via $assertion callable