### PR TITLE
Add parallel execution to ci/run_all_sets

### DIFF
--- a/.github/workflows/sets_check_parallel.yaml
+++ b/.github/workflows/sets_check_parallel.yaml
@@ -1,0 +1,19 @@
+name: Sets Check (parallel)
+
+on:
+    pull_request: null
+    push:
+        branches:
+            - master
+
+jobs:
+    run_all_sets:
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v2
+            -   uses: shivammathur/setup-php@v1
+                with:
+                    php-version: 7.4
+                    coverage: none # disable xdebug, pcov
+            -   run: composer install --no-progress
+            -   run: php ci/run_all_sets_parallel.php

--- a/ci/run_all_sets_parallel.php
+++ b/ci/run_all_sets_parallel.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Set\SetProvider;
+use Rector\Utils\ParallelProcessRunner\Exception\CouldNotDeterminedCpuCoresException;
+use Rector\Utils\ParallelProcessRunner\SystemInfo;
+use Rector\Utils\ParallelProcessRunner\Task;
+use Rector\Utils\ParallelProcessRunner\TaskRunner;
+use Symplify\PackageBuilder\Console\ShellCode;
+
+require __DIR__.'/../vendor/autoload.php';
+
+$setProvider = new SetProvider();
+
+// We'll only check one file for now.
+// This makes sure that all sets are "runnable" but keeps the runtime at a managable level
+$file         = __DIR__.'/../src/Rector/AbstractRector.php';
+
+$excludedSets = [
+    // required Kernel class to be set in parameters
+    'symfony-code-quality',
+];
+
+$cwd = __DIR__."/..";
+
+$systemInfo   = new SystemInfo();
+$taskRunner   = new TaskRunner(
+    "php",
+    $cwd."/bin/rector",
+    $cwd,
+    true
+);
+$sleepSeconds = 1;
+$maxProcesses = 1;
+try {
+    $maxProcesses = $systemInfo->getCpuCores();
+} catch (CouldNotDeterminedCpuCoresException $t) {
+    echo "WARNING: Could not determine number of CPU cores due to ".$t->getMessage().PHP_EOL;
+}
+
+$tasks = [];
+foreach ($setProvider->provide() as $setName) {
+    if (in_array($setName, $excludedSets, true)) {
+        continue;
+    }
+    $tasks[$setName] = new Task($file, $setName);
+}
+
+if ($taskRunner->run($tasks, $maxProcesses, $sleepSeconds)) {
+    exit(ShellCode::SUCCESS);
+}
+exit(ShellCode::ERROR);

--- a/composer.json
+++ b/composer.json
@@ -190,6 +190,7 @@
             "Rector\\Twig\\Tests\\": "rules/twig/tests",
             "Rector\\TypeDeclaration\\Tests\\": "rules/type-declaration/tests",
             "Rector\\Utils\\DocumentationGenerator\\": "utils/documentation-generator/src",
+            "Rector\\Utils\\ParallelProcessRunner\\": "utils/parallel-process-runner/src",
             "Rector\\Utils\\PHPStanAttributeTypeSyncer\\": "utils/phpstan-attribute-type-syncer/src",
             "Rector\\Utils\\PHPStanStaticTypeMapperChecker\\": "utils/phpstan-static-type-mapper-checker/src",
             "Rector\\ZendToSymfony\\Tests\\": "rules/zend-to-symfony/tests"
@@ -241,7 +242,7 @@
             "bin/rector check-static-type-mappers",
             "@check-sets"
         ],
-        "check-sets": "php ci/run_all_sets.php",
+        "check-sets": "php ci/run_all_sets_parallel.php",
         "check-cs": "vendor/bin/ecs check --ansi",
         "check-fixtures": "php ci/check_keep_fixtures.php",
         "check-services": "php ci/check_services_in_yaml_configs.php",

--- a/packages/node-type-resolver/src/DependencyInjection/PHPStanServicesFactory.php
+++ b/packages/node-type-resolver/src/DependencyInjection/PHPStanServicesFactory.php
@@ -54,7 +54,9 @@ final class PHPStanServicesFactory
 
             // bleeding edge clean out, see https://github.com/rectorphp/rector/issues/2431
             if (Strings::match($phpstanNeonContent, self::BLEEDING_EDGE_PATTERN)) {
-                $temporaryPhpstanNeon = $currentWorkingDirectory . '/rector-temp-phpstan.neon';
+                // Note: We need a unique file per process if rector runs in parallel
+                $pid = getmypid();
+                $temporaryPhpstanNeon = $currentWorkingDirectory . '/rector-temp-phpstan' . $pid . '.neon';
                 $clearedPhpstanNeonContent = Strings::replace($phpstanNeonContent, self::BLEEDING_EDGE_PATTERN);
                 FileSystem::write($temporaryPhpstanNeon, $clearedPhpstanNeonContent);
 

--- a/utils/parallel-process-runner/src/Exception/CouldNotDeterminedCpuCoresException.php
+++ b/utils/parallel-process-runner/src/Exception/CouldNotDeterminedCpuCoresException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Utils\ParallelProcessRunner\Exception;
+
+use RuntimeException;
+
+class CouldNotDeterminedCpuCoresException extends RuntimeException
+{
+}

--- a/utils/parallel-process-runner/src/Exception/ProcessResultInvalidException.php
+++ b/utils/parallel-process-runner/src/Exception/ProcessResultInvalidException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Utils\ParallelProcessRunner\Exception;
+
+use RuntimeException;
+
+class ProcessResultInvalidException extends RuntimeException
+{
+}

--- a/utils/parallel-process-runner/src/SystemInfo.php
+++ b/utils/parallel-process-runner/src/SystemInfo.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Utils\ParallelProcessRunner;
+
+use Rector\Utils\ParallelProcessRunner\Exception\CouldNotDeterminedCpuCoresException;
+
+final class SystemInfo
+{
+    /**
+     * @see https://gist.github.com/divinity76/01ef9ca99c111565a72d3a8a6e42f7fb
+     *
+     * returns number of cpu cores
+     * Copyleft 2018, license: WTFPL
+     */
+    public function getCpuCores(): int
+    {
+        if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
+            $str = trim(shell_exec('wmic cpu get NumberOfCores 2>&1'));
+            if (! preg_match('#(\d+)#', $str, $matches)) {
+                throw new CouldNotDeterminedCpuCoresException('wmic failed to get number of cpu cores on windows!');
+            }
+            return (int) $matches[1];
+        }
+        $ret = @shell_exec('nproc');
+        if (is_string($ret)) {
+            $ret = trim($ret);
+            if (($tmp = filter_var($ret, FILTER_VALIDATE_INT)) !== false) {
+                return (int) $tmp;
+            }
+        }
+        if (is_readable('/proc/cpuinfo')) {
+            $cpuinfo = file_get_contents('/proc/cpuinfo');
+            $count = substr_count($cpuinfo, 'processor');
+            if ($count > 0) {
+                return $count;
+            }
+        }
+        throw new CouldNotDeterminedCpuCoresException('failed to detect number of CPUs!');
+    }
+}

--- a/utils/parallel-process-runner/src/Task.php
+++ b/utils/parallel-process-runner/src/Task.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Utils\ParallelProcessRunner;
+
+final class Task
+{
+    /**
+     * @var string
+     */
+    private $pathToFile;
+
+    /**
+     * @var string
+     */
+    private $setName;
+
+    public function __construct(string $pathToFile, string $setName)
+    {
+        $this->pathToFile = $pathToFile;
+        $this->setName = $setName;
+    }
+
+    public function getPathToFile(): string
+    {
+        return $this->pathToFile;
+    }
+
+    public function getSetName(): string
+    {
+        return $this->setName;
+    }
+}

--- a/utils/parallel-process-runner/src/TaskRunner.php
+++ b/utils/parallel-process-runner/src/TaskRunner.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Utils\ParallelProcessRunner;
+
+use Nette\Utils\Strings;
+use Rector\Utils\ParallelProcessRunner\Exception\ProcessResultInvalidException;
+use Symfony\Component\Process\Process;
+use Throwable;
+
+final class TaskRunner
+{
+    /**
+     * @var string
+     */
+    private $phpExecutable;
+
+    /**
+     * @var string
+     */
+    private $rectorExecutable;
+
+    /**
+     * @var string
+     */
+    private $cwd;
+
+    /**
+     * @var bool
+     */
+    private $failOnlyOnError = false;
+
+    public function __construct(string $phpExecutable, string $rectorExecutable, string $cwd, bool $failOnlyOnError)
+    {
+        $this->phpExecutable = $phpExecutable;
+        $this->rectorExecutable = $rectorExecutable;
+        $this->cwd = $cwd;
+        $this->failOnlyOnError = $failOnlyOnError;
+    }
+
+    /**
+     * @param Task[] $tasks
+     */
+    public function run(array $tasks, int $maxProcesses = 1, int $sleepSeconds = 1): bool
+    {
+        $this->printInfo($tasks, $maxProcesses);
+
+        $success = true;
+
+        /** @var Process[] $runningProcesses */
+        $runningProcesses = [];
+        $remainingTasks = $tasks;
+        $finished = 0;
+        $total = count($tasks);
+        do {
+            $this->sleepIfNecessary($remainingTasks, $runningProcesses, $maxProcesses, $sleepSeconds);
+
+            $this->startProcess($remainingTasks, $runningProcesses, $success, $maxProcesses, $total, $finished);
+
+            $this->evaluateRunningProcesses($runningProcesses, $success, $total, $finished);
+
+            $someProcessesAreStillRunning = count($runningProcesses) > 0;
+            $notAllProcessesAreStartedYet = count($remainingTasks) > 0;
+        } while ($someProcessesAreStillRunning || $notAllProcessesAreStartedYet);
+
+        return $success;
+    }
+
+    /**
+     * We should sleep when the processes are running in order to not
+     * exhaust system resources. But we only wanna do this when
+     * we can't start another processes:
+     * either because none are left or
+     * because we reached the threshold of allowed processes
+     *
+     * @param string[] $taskIdsToRuns
+     * @param Process[] $runningProcesses
+     */
+    private function sleepIfNecessary(
+        array $taskIdsToRuns,
+        array $runningProcesses,
+        int $maxProcesses,
+        int $secondsToSleep
+    ): void {
+        $noMoreProcessesAreLeft = count($taskIdsToRuns) === 0;
+        $maxNumberOfProcessesAreRunning = count($runningProcesses) >= $maxProcesses;
+        if ($noMoreProcessesAreLeft || $maxNumberOfProcessesAreRunning) {
+            sleep($secondsToSleep);
+        }
+    }
+
+    /**
+     * @param Task[] $remainingTasks
+     * @param Task[] $runningProcesses
+     */
+    private function startProcess(
+        array &$remainingTasks,
+        array &$runningProcesses,
+        bool &$success,
+        int $maxProcesses,
+        int $total,
+        int $finished
+    ): void {
+        if ($this->canStartAnotherProcess($remainingTasks, $runningProcesses, $maxProcesses)) {
+            $setName = array_key_first($remainingTasks);
+            $task = array_shift($remainingTasks);
+
+            try {
+                $process = $this->createProcess($task);
+                $process->start();
+                $runningProcesses[$setName] = $process;
+            } catch (Throwable $throwable) {
+                $success = false;
+                $this->printError($setName, $throwable->getMessage(), $total, $finished);
+            }
+        }
+    }
+
+    private function evaluateRunningProcesses(
+        array &$runningProcesses,
+        bool &$success,
+        int $total,
+        int &$finished
+    ): void {
+        foreach ($runningProcesses as $setName => $process) {
+            if (! $process->isRunning()) {
+                $finished++;
+                unset($runningProcesses[$setName]);
+
+                try {
+                    $this->evaluateProcess($process);
+                    $this->printSuccess($setName, $total, $finished);
+                } catch (Throwable $throwable) {
+                    $success = false;
+                    $this->printError(
+                        $setName,
+                        $process->getOutput() . $process->getErrorOutput(),
+                        $total,
+                        $finished
+                    );
+                }
+            }
+        }
+    }
+
+    private function canStartAnotherProcess(array $remainingTasks, array $runningProcesses, int $max): bool
+    {
+        $hasOpenTasks = count($remainingTasks) > 0;
+        $moreProcessesCanBeStarted = count($runningProcesses) < $max;
+        return $hasOpenTasks && $moreProcessesCanBeStarted;
+    }
+
+    private function createProcess(Task $task): Process
+    {
+        $command = [
+            $this->phpExecutable,
+            $this->rectorExecutable,
+            'process',
+            $task->getPathToFile(),
+            '--set',
+            $task->getSetName(),
+            '--dry-run',
+        ];
+
+        return new Process($command, $this->cwd);
+    }
+
+    private function printSuccess(string $set, int $totalTasks, int $finishedTasks): void
+    {
+        echo sprintf('(%d/%d) ✔ Set "%s" is OK' . PHP_EOL, $finishedTasks, $totalTasks, $set);
+    }
+
+    private function printError(string $set, string $output, int $totalTasks, int $finishedTasks): void
+    {
+        echo sprintf('(%d/%d) ❌ Set "%s" failed: %s' . PHP_EOL, $finishedTasks, $totalTasks, $set, $output);
+    }
+
+    private function printInfo(array $tasks, int $maxProcesses): void
+    {
+        echo sprintf('Running %d sets with %d parallel processes' . PHP_EOL . PHP_EOL, count($tasks), $maxProcesses);
+    }
+
+    private function evaluateProcess(Process $process): void
+    {
+        if ($process->isSuccessful()) {
+            return;
+        }
+
+        // If the process was not successful, there might
+        // OR an actual error due to an exception
+        // The latter case is determined via regex
+        // EITHER be a "possible correction" from rector
+
+        $fullOutput = array_filter([$process->getOutput(), $process->getErrorOutput()]);
+
+        $ouptput = implode("\n", $fullOutput);
+
+        $actualErrorHappened = Strings::match($ouptput, '#(Fatal error)|(\[ERROR\])#');
+
+        if ($this->failOnlyOnError && ! $actualErrorHappened) {
+            return;
+        }
+
+        throw new ProcessResultInvalidException($ouptput);
+    }
+}


### PR DESCRIPTION
- add a task runner to run the sets in parallel
- number of cores is determined automatically via https://gist.github.com/divinity76/01ef9ca99c111565a72d3a8a6e42f7fb
- added github action at `ci/sets_check_parallel.yaml` to make sure it works in CI

==> roughly 3 times faster on my local machine with 8 cores

Usage:

`php ci/run_all_sets_parallel.php`

Output:
```
www-data@f273549c9848:/codebase/rector$ time php ci/run_all_sets_parallel.php
Running 135 sets with 8 parallel processes

✔ Set "cakephp-24-to-symfony-51" is OK ( 1 / 135)
✔ Set "cakephp34" is OK ( 2 / 135)
✔ Set "action-injection-to-constructor-injection" is OK ( 3 / 135)
✔ Set "array-str-functions-to-static-call" is OK ( 4 / 135)
✔ Set "cakephp30" is OK ( 5 / 135)
✔ Set "cakephp35" is OK ( 6 / 135)
✔ Set "cakephp36" is OK ( 7 / 135)
✔ Set "cakephp37" is OK ( 8 / 135)
✔ Set "cakephp38" is OK ( 9 / 135)
✔ Set "cakephp40" is OK (10 / 135)
✔ Set "constructor-injectin-to-action-injection" is OK (11 / 135)
✔ Set "celebrity" is OK (12 / 135)
✔ Set "code-quality" is OK (13 / 135)
✔ Set "codeigniter-40" is OK (14 / 135)
✔ Set "contributte-to-symfony" is OK (15 / 135)
✔ Set "coding-style" is OK (16 / 135)
✔ Set "dead-classes" is OK (17 / 135)
✔ Set "doctrine" is OK (18 / 135)
✔ Set "dead-code" is OK (19 / 135)
✔ Set "doctrine-behaviors-20" is OK (20 / 135)
✔ Set "doctrine-code-quality" is OK (21 / 135)
✔ Set "doctrine-common-20" is OK (22 / 135)
✔ Set "doctrine-dbal-210" is OK (23 / 135)
✔ Set "doctrine-dbal-30" is OK (24 / 135)
✔ Set "doctrine-id-to-uuid-step-1" is OK (25 / 135)
✔ Set "doctrine-gedmo-to-knplabs" is OK (26 / 135)
✔ Set "doctrine-id-to-uuid-step-2" is OK (27 / 135)
✔ Set "doctrine-id-to-uuid-step-3" is OK (28 / 135)
✔ Set "doctrine-id-to-uuid-step-4" is OK (29 / 135)
✔ Set "doctrine-services" is OK (30 / 135)
✔ Set "doctrine-id-to-uuid-step-5" is OK (31 / 135)
✔ Set "doctrine-repository-as-service" is OK (32 / 135)
✔ Set "doctrine25" is OK (33 / 135)
✔ Set "early-return" is OK (34 / 135)
✔ Set "easy-admin-bundle20" is OK (35 / 135)
✔ Set "framework-extra-bundle-50" is OK (36 / 135)
✔ Set "elasticsearch-dsl50" is OK (37 / 135)
✔ Set "framework-extra-bundle-30" is OK (38 / 135)
✔ Set "gmagick_to_imagick" is OK (39 / 135)
✔ Set "guzzle50" is OK (40 / 135)
✔ Set "kdyby-translator-to-contributte-translation" is OK (41 / 135)
✔ Set "jms-decouple" is OK (42 / 135)
✔ Set "kdyby-to-symfony" is OK (43 / 135)
✔ Set "laravel-static-to-injection" is OK (44 / 135)
✔ Set "laravel50" is OK (45 / 135)
✔ Set "laravel51" is OK (46 / 135)
✔ Set "laravel52" is OK (47 / 135)
✔ Set "laravel53" is OK (48 / 135)
✔ Set "laravel54" is OK (49 / 135)
✔ Set "laravel55" is OK (50 / 135)
✔ Set "laravel56" is OK (51 / 135)
✔ Set "laravel57" is OK (52 / 135)
✔ Set "laravel58" is OK (53 / 135)
✔ Set "laravel60" is OK (54 / 135)
✔ Set "monolog20" is OK (55 / 135)
✔ Set "mysql-to-mysqli" is OK (56 / 135)
✔ Set "nette-30" is OK (57 / 135)
✔ Set "nette-application-code-quality" is OK (58 / 135)
✔ Set "nette-control-to-symfony-controller" is OK (59 / 135)
✔ Set "nette-forms-to-symfony" is OK (60 / 135)
✔ Set "nette-param-types" is OK (61 / 135)
✔ Set "nette-return-types" is OK (62 / 135)
✔ Set "nette-tester-to-phpunit" is OK (63 / 135)
✔ Set "nette-to-symfony" is OK (64 / 135)
✔ Set "nette-utils-code-quality" is OK (65 / 135)
✔ Set "oxid60" is OK (66 / 135)
✔ Set "php-code-sniffer30" is OK (67 / 135)
✔ Set "phalcon40" is OK (68 / 135)
✔ Set "php-di-decouple" is OK (69 / 135)
✔ Set "php52" is OK (70 / 135)
✔ Set "php53" is OK (71 / 135)
✔ Set "php54" is OK (72 / 135)
✔ Set "php55" is OK (73 / 135)
✔ Set "php56" is OK (74 / 135)
✔ Set "php70" is OK (75 / 135)
✔ Set "php71" is OK (76 / 135)
✔ Set "php72" is OK (77 / 135)
✔ Set "php73" is OK (78 / 135)
✔ Set "php74" is OK (79 / 135)
✔ Set "php80" is OK (80 / 135)
✔ Set "phpspec30" is OK (81 / 135)
✔ Set "phpspec-to-phpunit" is OK (82 / 135)
✔ Set "phpspec40" is OK (83 / 135)
✔ Set "phpstan" is OK (84 / 135)
✔ Set "phpunit-injector" is OK (85 / 135)
✔ Set "phpunit-exception" is OK (86 / 135)
✔ Set "phpunit-mock" is OK (87 / 135)
✔ Set "phpunit-code-quality" is OK (88 / 135)
✔ Set "phpunit-specific-method" is OK (89 / 135)
✔ Set "phpunit-yield-data-provider" is OK (90 / 135)
✔ Set "phpunit40" is OK (91 / 135)
✔ Set "phpunit50" is OK (92 / 135)
✔ Set "phpunit60" is OK (93 / 135)
✔ Set "phpunit70" is OK (94 / 135)
✔ Set "phpunit75" is OK (95 / 135)
✔ Set "phpunit80" is OK (96 / 135)
✔ Set "phpunit80-dms" is OK (97 / 135)
✔ Set "phpunit90" is OK (98 / 135)
✔ Set "privatization" is OK (99 / 135)
✔ Set "psr-4" is OK (100 / 135)
✔ Set "safe07" is OK (101 / 135)
✔ Set "shopware55" is OK (102 / 135)
✔ Set "shopware56" is OK (103 / 135)
✔ Set "silverstripe" is OK (104 / 135)
✔ Set "solid" is OK (105 / 135)
✔ Set "swiftmailer60" is OK (106 / 135)
✔ Set "sylius10" is OK (107 / 135)
✔ Set "sylius102" is OK (108 / 135)
✔ Set "sylius109" is OK (109 / 135)
✔ Set "symfony-constructor-injection" is OK (110 / 135)
✔ Set "symfony-phpunit" is OK (111 / 135)
✔ Set "symfony26" is OK (112 / 135)
✔ Set "symfony28" is OK (113 / 135)
✔ Set "symfony30" is OK (114 / 135)
✔ Set "symfony31" is OK (115 / 135)
✔ Set "symfony32" is OK (116 / 135)
✔ Set "symfony33" is OK (117 / 135)
✔ Set "symfony34" is OK (118 / 135)
✔ Set "symfony40" is OK (119 / 135)
✔ Set "symfony43" is OK (120 / 135)
✔ Set "symfony41" is OK (121 / 135)
✔ Set "symfony42" is OK (122 / 135)
✔ Set "symfony44" is OK (123 / 135)
✔ Set "symfony50" is OK (124 / 135)
✔ Set "twig112" is OK (125 / 135)
✔ Set "symfony50-types" is OK (126 / 135)
✔ Set "twig-underscore-to-namespace" is OK (127 / 135)
✔ Set "twig20" is OK (128 / 135)
✔ Set "twig240" is OK (129 / 135)
✔ Set "twig127" is OK (130 / 135)
✔ Set "twig134" is OK (131 / 135)
✔ Set "twig140" is OK (132 / 135)
✔ Set "type-declaration" is OK (133 / 135)
✔ Set "unwrap-compat" is OK (134 / 135)
✔ Set "zend-to-symfony" is OK (135 / 135)

real    2m10.352s
user    6m34.306s
sys     2m12.982s
```

FYI comparison with the "old" check:

```
time php ci/run_all_sets.php
Set "action-injection-to-constructor-injection" is OK
Set "array-str-functions-to-static-call" is OK
Set "cakephp30" is OK
Set "cakephp34" is OK
Set "cakephp35" is OK
Set "cakephp36" is OK
Set "cakephp37" is OK
Set "cakephp38" is OK
Set "cakephp40" is OK
Set "celebrity" is OK
Set "code-quality" is OK
Set "codeigniter-40" is OK
Set "coding-style" is OK
Set "constructor-injectin-to-action-injection" is OK
Set "contributte-to-symfony" is OK
Set "dead-classes" is OK
Set "dead-code" is OK
Set "doctrine" is OK
Set "doctrine-behaviors-20" is OK
Set "doctrine-code-quality" is OK
Set "doctrine-common-20" is OK
Set "doctrine-dbal-210" is OK
Set "doctrine-dbal-30" is OK
Set "doctrine-gedmo-to-knplabs" is OK
Set "doctrine-id-to-uuid-step-1" is OK
Set "doctrine-id-to-uuid-step-2" is OK
Set "doctrine-id-to-uuid-step-3" is OK
Set "doctrine-id-to-uuid-step-4" is OK
Set "doctrine-repository-as-service" is OK
Set "doctrine-services" is OK
Set "doctrine25" is OK
Set "early-return" is OK
Set "easy-admin-bundle20" is OK
Set "elasticsearch-dsl50" is OK
Set "framework-extra-bundle-30" is OK
Set "framework-extra-bundle-50" is OK
Set "gmagick_to_imagick" is OK
Set "guzzle50" is OK
Set "jms-decouple" is OK
Set "kdyby-to-symfony" is OK
Set "kdyby-translator-to-contributte-translation" is OK
Set "laravel-static-to-injection" is OK
Set "laravel50" is OK
Set "laravel51" is OK
Set "laravel52" is OK
Set "laravel53" is OK
Set "laravel54" is OK
Set "laravel55" is OK
Set "laravel56" is OK
Set "laravel57" is OK
Set "laravel58" is OK
Set "laravel60" is OK
Set "monolog20" is OK
Set "mysql-to-mysqli" is OK
Set "nette-30" is OK
Set "nette-application-code-quality" is OK
Set "nette-control-to-symfony-controller" is OK
Set "nette-forms-to-symfony" is OK
Set "nette-param-types" is OK
Set "nette-return-types" is OK
Set "nette-tester-to-phpunit" is OK
Set "nette-to-symfony" is OK
Set "nette-utils-code-quality" is OK
Set "oxid60" is OK
Set "phalcon40" is OK
Set "php-code-sniffer30" is OK
Set "php-di-decouple" is OK
Set "php52" is OK
Set "php53" is OK
Set "php54" is OK
Set "php55" is OK
Set "php56" is OK
Set "php70" is OK
Set "php71" is OK
Set "php72" is OK
Set "php73" is OK
Set "php74" is OK
Set "php80" is OK
Set "phpspec-to-phpunit" is OK
Set "phpspec30" is OK
Set "phpspec40" is OK
Set "phpstan" is OK
Set "phpunit-code-quality" is OK
Set "phpunit-exception" is OK
Set "phpunit-injector" is OK
Set "phpunit-mock" is OK
Set "phpunit-specific-method" is OK
Set "phpunit-yield-data-provider" is OK
Set "phpunit40" is OK
Set "phpunit50" is OK
Set "phpunit60" is OK
Set "phpunit70" is OK
Set "phpunit75" is OK
Set "phpunit80" is OK
Set "phpunit80-dms" is OK
Set "phpunit90" is OK
Set "privatization" is OK
Set "psr-4" is OK
Set "safe07" is OK
Set "shopware55" is OK
Set "shopware56" is OK
Set "silverstripe" is OK
Set "solid" is OK
Set "swiftmailer60" is OK
Set "sylius10" is OK
Set "sylius102" is OK
Set "sylius109" is OK
Set "symfony-constructor-injection" is OK
Set "symfony-phpunit" is OK
Set "symfony26" is OK
Set "symfony28" is OK
Set "symfony30" is OK
Set "symfony31" is OK
Set "symfony32" is OK
Set "symfony33" is OK
Set "symfony34" is OK
Set "symfony40" is OK
Set "symfony41" is OK
Set "symfony42" is OK
Set "symfony43" is OK
Set "symfony44" is OK
Set "symfony50" is OK
Set "symfony50-types" is OK
Set "twig-underscore-to-namespace" is OK
Set "twig112" is OK
Set "twig127" is OK
Set "twig134" is OK
Set "twig140" is OK
Set "twig20" is OK
Set "twig240" is OK
Set "unwrap-compat" is OK
Set "zend-to-symfony" is OK

real    6m48.445s
user    3m25.323s
sys     1m17.677s
```