### PR TITLE
Make sure doctrine alias rector works in symfony controllers

### DIFF
--- a/rules/doctrine/src/Rector/MethodCall/EntityAliasToClassConstantReferenceRector.php
+++ b/rules/doctrine/src/Rector/MethodCall/EntityAliasToClassConstantReferenceRector.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Rector\Doctrine\Rector\MethodCall;
 
+use Doctrine\Common\Persistence\ObjectManager as DeprecatedObjectManager;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ObjectManager;
 use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
@@ -61,7 +63,10 @@ PHP
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isObjectType($node, EntityManagerInterface::class)) {
+        if (! $this->isObjectTypes(
+            $node->var,
+            [EntityManagerInterface::class, ObjectManager::class, DeprecatedObjectManager::class]
+        )) {
             return null;
         }
 

--- a/rules/doctrine/tests/Rector/MethodCall/EntityAliasToClassConstantReferenceRector/Fixture/fixture2.php.inc
+++ b/rules/doctrine/tests/Rector/MethodCall/EntityAliasToClassConstantReferenceRector/Fixture/fixture2.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+
+final class TestController extends AbstractController
+{
+    public function indexAction()
+    {
+        $this->getDoctrine()->getManager()->getRepository('App:Post');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+
+final class TestController extends AbstractController
+{
+    public function indexAction()
+    {
+        $this->getDoctrine()->getManager()->getRepository(\App\Entity\Post::class);
+    }
+}
+
+?>

--- a/stubs/Doctrine/Persistence/ManagerRegistry.php
+++ b/stubs/Doctrine/Persistence/ManagerRegistry.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Doctrine\Common\Persistence;
+namespace Doctrine\Persistence;
 
 use Doctrine\ORM\EntityManagerInterface;
 
-if (class_exists('Doctrine\Common\Persistence\ManagerRegistry')) {
+if (class_exists('Doctrine\Persistence\ManagerRegistry')) {
     return;
 }
 

--- a/stubs/Doctrine/Persistence/ObjectManager.php
+++ b/stubs/Doctrine/Persistence/ObjectManager.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Persistence;
+
+if (interface_exists('Doctrine\Persistence\ObjectManager')) {
+    return;
+}
+
+interface ObjectManager
+{
+
+}

--- a/stubs/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/stubs/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace Symfony\Bundle\FrameworkBundle\Controller;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
+
 if (class_exists('Symfony\Bundle\FrameworkBundle\Controller\AbstractController')) {
     return;
 }
 
 abstract class AbstractController
 {
-
+    public function getDoctrine(): ManagerRegistry
+    {
+    }
 }


### PR DESCRIPTION
While using this rector on a project, I noticed it didn't work on symfony controllers. Because the `$this->getDoctrine()->getManager()` returns an instance of `Doctrine\Persistence\ObjectManager` (or the deprecated interface `Doctrine\Common\Persistence\ObjectManager`). So I've debugged and adjusted the check so it would also work in symfony controllers.

The only strange thing is that the original example (test fixture) does work in the test suite with the old code, but it didn't work in the project I was debugging 🤷‍♂ 