### PR TITLE
Add extra allowed interface to EntityAliasToClassConstantReferenceRector

### DIFF
--- a/rules/doctrine/src/Rector/MethodCall/EntityAliasToClassConstantReferenceRector.php
+++ b/rules/doctrine/src/Rector/MethodCall/EntityAliasToClassConstantReferenceRector.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Rector\Doctrine\Rector\MethodCall;
 
+use Doctrine\Common\Persistence\ManagerRegistry as DeprecatedManagerRegistry;
 use Doctrine\Common\Persistence\ObjectManager as DeprecatedObjectManager;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectManager;
 use Nette\Utils\Strings;
 use PhpParser\Node;
@@ -20,6 +22,17 @@ use Rector\Core\RectorDefinition\RectorDefinition;
  */
 final class EntityAliasToClassConstantReferenceRector extends AbstractRector
 {
+    /**
+     * @var string[]
+     */
+    private const ALLOWED_OBJECT_TYPES = [
+        EntityManagerInterface::class,
+        ObjectManager::class,
+        DeprecatedObjectManager::class,
+        ManagerRegistry::class,
+        DeprecatedManagerRegistry::class,
+    ];
+
     /**
      * @var string[]
      */
@@ -63,10 +76,7 @@ PHP
      */
     public function refactor(Node $node): ?Node
     {
-        if (! $this->isObjectTypes(
-            $node->var,
-            [EntityManagerInterface::class, ObjectManager::class, DeprecatedObjectManager::class]
-        )) {
+        if (! $this->isObjectTypes($node->var, self::ALLOWED_OBJECT_TYPES)) {
             return null;
         }
 

--- a/rules/doctrine/tests/Rector/MethodCall/EntityAliasToClassConstantReferenceRector/Fixture/fixture3.php.inc
+++ b/rules/doctrine/tests/Rector/MethodCall/EntityAliasToClassConstantReferenceRector/Fixture/fixture3.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+
+final class Test2Controller extends AbstractController
+{
+    public function indexAction()
+    {
+        $this->getDoctrine()->getRepository('App:Post');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+
+final class Test2Controller extends AbstractController
+{
+    public function indexAction()
+    {
+        $this->getDoctrine()->getRepository(\App\Entity\Post::class);
+    }
+}
+
+?>


### PR DESCRIPTION
This is an extension to the changes in #3146. I've discovered some other usages which were not covered by this rector. So these extra interfaces will allow to fix these cases also.

```
$this->getDoctrine()->getRepository();
```

This is also possible as the manager registry will select to correct manager based on the provided entity. 

https://github.com/doctrine/persistence/blob/fdaaa50cb23760c9da2d6dcab9f10caa34d92b61/lib/Doctrine/Persistence/AbstractManagerRegistry.php#L226-L233