### PR TITLE
[DX] drop confusing --only option to promote config

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,18 +213,6 @@ class SomeClass
 }
 ```
 
-### Filter Rectors
-
-If you have a configuration file for Rector including many sets and Rectors, you might want at times to run only a single Rector from them. The `--only` argument allows that, for example :
-
-```bash
-vendor/bin/rector process --set solid --only "Rector\SOLID\Rector\Class_\FinalizeClassesWithoutChildrenRector" src/
-```
-
-Will only run `Rector\SOLID\Rector\Class_\FinalizeClassesWithoutChildrenRector`.
-
-Please note that the backslash in the Rector's fully-qualified class name needs to be properly escaped (by surrounding the string in double quotes).
-
 ### Provide PHP Version
 
 By default Rector uses the language features matching your system version of PHP. You can configure it for a different PHP version:

--- a/src/Application/RectorApplication.php
+++ b/src/Application/RectorApplication.php
@@ -11,7 +11,6 @@ use Rector\Core\Application\FileSystem\RemovedAndAddedFilesCollector;
 use Rector\Core\Application\FileSystem\RemovedAndAddedFilesProcessor;
 use Rector\Core\Configuration\Configuration;
 use Rector\Core\Extension\FinishingExtensionRunner;
-use Rector\Core\Testing\Application\EnabledRectorsProvider;
 use Rector\FileSystemRector\FileSystemFileProcessor;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -71,11 +70,6 @@ final class RectorApplication
     private $removedAndAddedFilesProcessor;
 
     /**
-     * @var EnabledRectorsProvider
-     */
-    private $enabledRectorsProvider;
-
-    /**
      * @var NodeScopeResolver
      */
     private $nodeScopeResolver;
@@ -91,7 +85,6 @@ final class RectorApplication
         ErrorAndDiffCollector $errorAndDiffCollector,
         Configuration $configuration,
         FileProcessor $fileProcessor,
-        EnabledRectorsProvider $enabledRectorsProvider,
         RemovedAndAddedFilesCollector $removedAndAddedFilesCollector,
         RemovedAndAddedFilesProcessor $removedAndAddedFilesProcessor,
         NodeScopeResolver $nodeScopeResolver,
@@ -104,7 +97,6 @@ final class RectorApplication
         $this->fileProcessor = $fileProcessor;
         $this->removedAndAddedFilesCollector = $removedAndAddedFilesCollector;
         $this->removedAndAddedFilesProcessor = $removedAndAddedFilesProcessor;
-        $this->enabledRectorsProvider = $enabledRectorsProvider;
         $this->nodeScopeResolver = $nodeScopeResolver;
         $this->finishingExtensionRunner = $finishingExtensionRunner;
     }
@@ -134,12 +126,6 @@ final class RectorApplication
             $this->tryCatchWrapper($fileInfo, function (SmartFileInfo $smartFileInfo): void {
                 $this->fileProcessor->parseFileInfoToLocalCache($smartFileInfo);
             }, 'parsing');
-        }
-
-        // active only one rule
-        if ($this->configuration->getOnlyRector() !== null) {
-            $onlyRector = $this->configuration->getOnlyRector();
-            $this->enabledRectorsProvider->addEnabledRector($onlyRector);
         }
 
         // 2. change nodes with Rectors

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -5,12 +5,9 @@ declare(strict_types=1);
 namespace Rector\Core\Configuration;
 
 use Jean85\PrettyVersions;
-use Nette\Utils\Strings;
 use OndraM\CiDetector\CiDetector;
 use Rector\ChangesReporting\Output\CheckstyleOutputFormatter;
 use Rector\ChangesReporting\Output\JsonOutputFormatter;
-use Rector\Core\Exception\Rector\RectorNotFoundOrNotValidRectorClassException;
-use Rector\Core\Rector\AbstractRector;
 use Rector\Core\Testing\PHPUnit\PHPUnitEnvironment;
 use Symfony\Component\Console\Input\InputInterface;
 use Symplify\SmartFileSystem\SmartFileInfo;
@@ -31,11 +28,6 @@ final class Configuration
      * @var bool
      */
     private $showProgressBar = true;
-
-    /**
-     * @var string|null
-     */
-    private $onlyRector;
 
     /**
      * @var bool
@@ -113,11 +105,6 @@ final class Configuration
         $outputFileOption = $input->getOption(Option::OPTION_OUTPUT_FILE);
         $this->outputFile = $outputFileOption ? (string) $outputFileOption : null;
 
-        /** @var string|null $onlyRector */
-        $onlyRector = $input->getOption(Option::OPTION_ONLY);
-
-        $this->setOnlyRector($onlyRector);
-
         $commandLinePaths = (array) $input->getArgument(Option::SOURCE);
         // manual command line value has priority
         if (count($commandLinePaths) > 0) {
@@ -190,11 +177,6 @@ final class Configuration
         return $this->mustMatchGitDiff;
     }
 
-    public function getOnlyRector(): ?string
-    {
-        return $this->onlyRector;
-    }
-
     public function getOutputFile(): ?string
     {
         return $this->outputFile;
@@ -258,32 +240,5 @@ final class Configuration
             return false;
         }
         return $input->getOption(Option::OPTION_OUTPUT_FORMAT) !== CheckstyleOutputFormatter::NAME;
-    }
-
-    private function setOnlyRector(?string $rector): void
-    {
-        if ($rector) {
-            $this->ensureIsValidRectorClass($rector);
-            $this->onlyRector = $rector;
-        } else {
-            $this->onlyRector = null;
-        }
-    }
-
-    private function ensureIsValidRectorClass(string $rector): void
-    {
-        // simple check
-        if (! Strings::endsWith($rector, 'Rector')) {
-            throw new RectorNotFoundOrNotValidRectorClassException($rector);
-        }
-
-        if (! class_exists($rector)) {
-            throw new RectorNotFoundOrNotValidRectorClassException($rector);
-        }
-
-        // must inherit from AbstractRector
-        if (! in_array(AbstractRector::class, class_parents($rector), true)) {
-            throw new RectorNotFoundOrNotValidRectorClassException($rector);
-        }
     }
 }

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -39,11 +39,6 @@ final class Option
     /**
      * @var string
      */
-    public const OPTION_ONLY = 'only';
-
-    /**
-     * @var string
-     */
     public const AUTO_IMPORT_NAMES = 'auto_import_names';
 
     /**

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -166,13 +166,6 @@ final class ProcessCommand extends AbstractCommand
             'Execute only on file(s) matching the git diff.'
         );
 
-        $this->addOption(
-            Option::OPTION_ONLY,
-            'r',
-            InputOption::VALUE_REQUIRED,
-            'Run only one single Rector from the loaded Rectors (in services, sets, etc).'
-        );
-
         $availableOutputFormatters = $this->outputFormatterCollector->getNames();
         $this->addOption(
             Option::OPTION_OUTPUT_FORMAT,


### PR DESCRIPTION
## Why?

- it's confusing, people are unable to use it https://github.com/rectorphp/rector/issues/3020#issuecomment-621765729
- the `--only="Namespace\Class"` must be quoted right - slashes? single? double? + OS differences
- unable to configure, e.g. rename class method
- no CLI tool has this *feature*, so API is not intuitive

<br>

## Prefer Config

- configurable
- [YAML autocomplete](https://www.tomasvotruba.com/blog/2018/08/23/9-features-of-symfony-plugin-you-should-not-miss-in-gifs/#4-instant-service-autocomplete-in-yaml-yaml)
- easy to reproduce in [demo](getrector.org/demo)

```yaml
# rector.yaml
services:
    Namespace\Class: null
```