### PR TITLE
Improve $node name get on static or method call

### DIFF
--- a/packages/node-collector/src/NodeCollector/ParsedPropertyFetchNodeCollector.php
+++ b/packages/node-collector/src/NodeCollector/ParsedPropertyFetchNodeCollector.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Rector\NodeCollector\NodeCollector;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\StaticCall;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\TypeWithClassName;
 use PHPStan\Type\UnionType;
@@ -53,6 +55,12 @@ final class ParsedPropertyFetchNodeCollector
         }
 
         $propertyType = $this->nodeTypeResolver->getStaticType($node->var);
+
+        // make sure name is valid
+        if ($node->name instanceof StaticCall || $node->name instanceof MethodCall) {
+            return;
+        }
+
         $propertyName = $this->nodeNameResolver->getName($node->name);
 
         if ($propertyType instanceof TypeWithClassName) {

--- a/packages/node-type-resolver/tests/NodeVisitor/FunctionMethodAndClassNodeVisitor/FunctionMethodAndClassNodeVisitorTest.php
+++ b/packages/node-type-resolver/tests/NodeVisitor/FunctionMethodAndClassNodeVisitor/FunctionMethodAndClassNodeVisitorTest.php
@@ -8,15 +8,26 @@ use Iterator;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NameResolver;
-use Rector\CodingStyle\Naming\ClassNaming;
+use Rector\Core\HttpKernel\RectorKernel;
 use Rector\Core\Testing\PHPUnit\AbstractNodeVisitorTestCase;
-use Rector\NodeNameResolver\NodeNameResolver;
-use Rector\NodeNameResolver\Regex\RegexPatternDetector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\NodeVisitor\FunctionMethodAndClassNodeVisitor;
 
 final class FunctionMethodAndClassNodeVisitorTest extends AbstractNodeVisitorTestCase
 {
+    /**
+     * @var FunctionMethodAndClassNodeVisitor
+     */
+    private $functionMethodAndClassNodeVisitor;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->bootKernel(RectorKernel::class);
+        $this->functionMethodAndClassNodeVisitor = self::$container->get(FunctionMethodAndClassNodeVisitor::class);
+    }
+
     /**
      * @dataProvider provideData();
      */
@@ -37,9 +48,7 @@ final class FunctionMethodAndClassNodeVisitorTest extends AbstractNodeVisitorTes
     {
         $nodeTraverser = new NodeTraverser();
         $nodeTraverser->addVisitor(new NameResolver());
-        $nodeTraverser->addVisitor(
-            new FunctionMethodAndClassNodeVisitor(new ClassNaming(new NodeNameResolver(new RegexPatternDetector())))
-        );
+        $nodeTraverser->addVisitor($this->functionMethodAndClassNodeVisitor);
         $nodeTraverser->traverse($nodes);
     }
 


### PR DESCRIPTION
### Before

```
[ERROR] Could not process "abz/SomeClass.php" file, due to:                                                            
         "Pick more specific node than "PhpParser\Node\Expr\MethodCall"
```


### After

```
[ERROR] Could not process "abz/SomeClass.php" file, due to:                                                            
         "Pick more specific node than "PhpParser\Node\Expr\MethodCall", e.g. "$node->name"                             
                                                                                                                        
         Caused in "abz/SomeClass.php" file on line 9 on code "$this->foo()".     
         Look at "InnerRectorClass.php:35"

```