### PR TITLE
[Utils] PHPStan rule improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,9 @@ It supports all versions of PHP from 5.2 and many open-source projects:
 
 ## How to Apply Coding Standards?
 
-The AST libraries that Rector uses aren't well-suited for coding standards, so it's better to let coding standard tools do that.
+Rector uses [nikic/php-parser](https://github.com/nikic/PHP-Parser/), that build on technology called *abstract syntax tree*) technology* (AST). AST doesn't care about spaces and produces mall-formatted code. That's why your project needs to have coding standard tool and set of rules, so it can make refactored nice and shiny again.
 
-Don't have a coding standard tool for your project? Consider adding [EasyCodingStandard](https://github.com/Symplify/EasyCodingStandard), [PHP CS Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) or [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer).
-
-*Tip: If you have EasyCodingStandard, you can start your set with [`ecs-after-rector.yaml`](/ecs-after-rector.yaml).*
+Don't have any coding standard tool? Add [EasyCodingStandard](https://github.com/Symplify/EasyCodingStandard) and use prepared [`ecs-after-rector.yaml`](/ecs-after-rector.yaml) set.
 
 ## Install
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -252,3 +252,8 @@ parameters:
         - '#Class (.*?) should be written with \:\:class notation, string found#'
         - '#Parameter \#2 \$key of method Rector\\BetterPhpDocParser\\PhpDocNode\\AbstractTagValueNode\:\:printArrayItem\(\) expects string\|null, int\|string given#'
         - '#Method Rector\\Naming\\Naming\\PropertyNaming\:\:resolveShortClassName\(\) should return string but returns string\|null#'
+
+        -
+            message: "#^Class \"Rector\\\\PSR4\\\\Rector\\\\Namespace_\\\\NormalizeNamespaceByPSR4ComposerAutoloadRector\" is missing @see annotation with test case class reference$#"
+            count: 1
+            path: rules/psr4/src/Rector/Namespace_/NormalizeNamespaceByPSR4ComposerAutoloadRector.php

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,6 +13,7 @@
             <directory>rules/*/tests</directory>
             <directory>packages/*/tests</directory>
             <directory>tests</directory>
+            <directory>utils/*/tests</directory>
         </testsuite>
     </testsuites>
 

--- a/rules/nette-tester-to-phpunit/src/Rector/StaticCall/NetteAssertToPHPUnitAssertRector.php
+++ b/rules/nette-tester-to-phpunit/src/Rector/StaticCall/NetteAssertToPHPUnitAssertRector.php
@@ -11,6 +11,9 @@ use Rector\Core\RectorDefinition\CodeSample;
 use Rector\Core\RectorDefinition\RectorDefinition;
 use Rector\NetteTesterToPHPUnit\AssertManipulator;
 
+/**
+ * @see \Rector\NetteTesterToPHPUnit\Tests\Rector\Class_\NetteTesterClassToPHPUnitClassRector\NetteTesterPHPUnitRectorTest
+ */
 final class NetteAssertToPHPUnitAssertRector extends AbstractRector
 {
     /**

--- a/rules/oxid/src/Rector/FuncCall/OxidReplaceBackwardsCompatabilityClassRector.php
+++ b/rules/oxid/src/Rector/FuncCall/OxidReplaceBackwardsCompatabilityClassRector.php
@@ -15,6 +15,9 @@ use Rector\Core\Rector\AbstractRector;
 use Rector\Core\RectorDefinition\CodeSample;
 use Rector\Core\RectorDefinition\RectorDefinition;
 
+/**
+ * @see \Rector\Oxid\Tests\Rector\FuncCall\OxidReplaceBackwardsCompatabilityClassRector\OxidReplaceBackwardsCompatabilityClassRectorTest
+ */
 final class OxidReplaceBackwardsCompatabilityClassRector extends AbstractRector
 {
     /**

--- a/rules/php72/src/Rector/Each/ListEachRector.php
+++ b/rules/php72/src/Rector/Each/ListEachRector.php
@@ -18,6 +18,8 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
 
 /**
  * @source https://wiki.php.net/rfc/deprecations_php_7_2#each
+ *
+ * @see \Rector\Php72\Tests\Rector\Each\EachRectorTest
  */
 final class ListEachRector extends AbstractRector
 {

--- a/rules/php72/src/Rector/Each/WhileEachToForeachRector.php
+++ b/rules/php72/src/Rector/Each/WhileEachToForeachRector.php
@@ -18,6 +18,8 @@ use Rector\Core\RectorDefinition\RectorDefinition;
 
 /**
  * @source https://wiki.php.net/rfc/deprecations_php_7_2#each
+ *
+ * @see \Rector\Php72\Tests\Rector\Each\EachRectorTest
  */
 final class WhileEachToForeachRector extends AbstractRector
 {

--- a/rules/psr4/config/config.yaml
+++ b/rules/psr4/config/config.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     Rector\PSR4\:
         resource: '../src'

--- a/rules/sensio/src/Rector/FrameworkExtraBundle/TemplateAnnotationRector.php
+++ b/rules/sensio/src/Rector/FrameworkExtraBundle/TemplateAnnotationRector.php
@@ -23,6 +23,10 @@ use Rector\Sensio\Helper\TemplateGuesser;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @see \Rector\Sensio\Tests\Rector\FrameworkExtraBundle\TemplateAnnotationRector\TemplateAnnotationVersion3RectorTest
+ * @see \Rector\Sensio\Tests\Rector\FrameworkExtraBundle\TemplateAnnotationRector\TemplateAnnotationVersion5RectorTest
+ */
 final class TemplateAnnotationRector extends AbstractRector
 {
     /**
@@ -139,6 +143,7 @@ PHP
 
     private function getSensioTemplateTagValueNode(ClassMethod $classMethod): ?SensioTemplateTagValueNode
     {
+        /** @var PhpDocInfo|null $phpDocInfo */
         $phpDocInfo = $classMethod->getAttribute(AttributeKey::PHP_DOC_INFO);
         if ($phpDocInfo === null) {
             return null;

--- a/src/Rector/Architecture/DependencyInjection/ReplaceVariableByPropertyFetchRector.php
+++ b/src/Rector/Architecture/DependencyInjection/ReplaceVariableByPropertyFetchRector.php
@@ -15,6 +15,9 @@ use Rector\Core\RectorDefinition\CodeSample;
 use Rector\Core\RectorDefinition\RectorDefinition;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 
+/**
+ * @see \Rector\Core\Tests\Rector\Architecture\DependencyInjection\ActionInjectionToConstructorInjectionRector\ActionInjectionToConstructorInjectionRectorTest
+ */
 final class ReplaceVariableByPropertyFetchRector extends AbstractRector
 {
     /**

--- a/utils/phpstan-extensions/config/phpstan-extensions.neon
+++ b/utils/phpstan-extensions/config/phpstan-extensions.neon
@@ -1,6 +1,15 @@
 services:
-    - { class: Rector\PHPStanExtensions\Rule\ClassMethod\PreventParentMethodVisibilityOverrideRule, tags: [phpstan.rules.rule] }
-    - { class: Rector\PHPStanExtensions\Rule\ClassLike\KeepRectorNamespaceForRectorRule, tags: [phpstan.rules.rule] }
+    -
+        class: Rector\PHPStanExtensions\Rule\SeeAnnotationToTestRule
+        tags: [phpstan.rules.rule]
+
+    -
+        class: Rector\PHPStanExtensions\Rule\ClassMethod\PreventParentMethodVisibilityOverrideRule
+        tags: [phpstan.rules.rule]
+
+    -
+         class: Rector\PHPStanExtensions\Rule\ClassLike\KeepRectorNamespaceForRectorRule
+         tags: [phpstan.rules.rule]
 
     - Rector\PHPStanExtensions\Utils\PHPStanValueResolver
 

--- a/utils/phpstan-extensions/src/Rule/ClassMethod/PreventParentMethodVisibilityOverrideRule.php
+++ b/utils/phpstan-extensions/src/Rule/ClassMethod/PreventParentMethodVisibilityOverrideRule.php
@@ -8,13 +8,19 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
-use PHPStan\Rules\RuleError;
-use PHPStan\Rules\RuleErrorBuilder;
 use Rector\Core\Exception\NotImplementedException;
 use ReflectionMethod;
 
+/**
+ * @see \Rector\PHPStanExtensions\Tests\Rule\ClassMethod\PreventParentMethodVisibilityOverrideRuleTest
+ */
 final class PreventParentMethodVisibilityOverrideRule implements Rule
 {
+    /**
+     * @var string
+     */
+    public const ERROR_MESSAGE = 'Change "%s()" method visibility to "%s" to respect parent method visibility.';
+
     public function getNodeType(): string
     {
         return ClassMethod::class;
@@ -22,7 +28,7 @@ final class PreventParentMethodVisibilityOverrideRule implements Rule
 
     /**
      * @param ClassMethod $node
-     * @return RuleError[]
+     * @return string[]
      */
     public function processNode(Node $node, Scope $scope): array
     {
@@ -49,8 +55,8 @@ final class PreventParentMethodVisibilityOverrideRule implements Rule
 
             $methodVisibility = $this->resolveReflectionMethodVisibilityAsStrings($parentReflectionMethod);
 
-            $ruleError = $this->createRuleError($node, $scope, $methodName, $methodVisibility);
-            return [$ruleError];
+            $errorMessage = sprintf(self::ERROR_MESSAGE, $methodName, $methodVisibility);
+            return [$errorMessage];
         }
 
         return [];
@@ -86,20 +92,5 @@ final class PreventParentMethodVisibilityOverrideRule implements Rule
         }
 
         throw new NotImplementedException();
-    }
-
-    private function createRuleError(Node $node, Scope $scope, string $methodName, string $methodVisibility): RuleError
-    {
-        $message = sprintf(
-            'Change "%s()" method visibility to "%s" to respect parent method visibility.',
-            $methodName,
-            $methodVisibility
-        );
-
-        $ruleErrorBuilder = RuleErrorBuilder::message($message);
-        $ruleErrorBuilder->line($node->getLine());
-        $ruleErrorBuilder->file($scope->getFile());
-
-        return $ruleErrorBuilder->build();
     }
 }

--- a/utils/phpstan-extensions/src/Rule/SeeAnnotationToTestRule.php
+++ b/utils/phpstan-extensions/src/Rule/SeeAnnotationToTestRule.php
@@ -5,13 +5,21 @@ declare(strict_types=1);
 namespace Rector\PHPStanExtensions\Rule;
 
 use Nette\Utils\Strings;
+use PhpParser\Comment\Doc;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Broker\Broker;
+use PHPStan\PhpDoc\ResolvedPhpDocBlock;
+use PHPStan\Reflection\ClassReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Type\FileTypeMapper;
+use Rector\Core\Contract\Rector\PhpRectorInterface;
+use Rector\PostRector\Contract\Rector\PostRectorInterface;
 
+/**
+ * @see \Rector\PHPStanExtensions\Tests\Rule\SeeAnnotationToTestRule\SeeAnnotationToTestRuleTest
+ */
 final class SeeAnnotationToTestRule implements Rule
 {
     /**
@@ -51,37 +59,30 @@ final class SeeAnnotationToTestRule implements Rule
      */
     public function processNode(Node $node, Scope $scope): array
     {
-        if ($node->name === null) {
+        $classReflection = $this->matchClassReflection($node);
+        if ($classReflection === null) {
             return [];
         }
 
-        $className = (string) $node->namespacedName;
-        if (! $this->isClassMatch($className)) {
+        if ($this->shouldSkipClassReflection($classReflection)) {
             return [];
         }
-
-        $classReflection = $this->broker->getClass($className);
 
         $docComment = $node->getDocComment();
         if ($docComment === null) {
-            return [sprintf(self::ERROR_MESSAGE, $className)];
+            return [sprintf(self::ERROR_MESSAGE, $classReflection->getName())];
         }
 
-        $resolvedPhpDoc = $this->fileTypeMapper->getResolvedPhpDoc(
-            $scope->getFile(),
-            $classReflection->getName(),
-            null,
-            null,
-            $docComment->getText()
-        );
+        $resolvedPhpDoc = $this->resolvePhpDoc($scope, $classReflection, $docComment);
 
         $seeTags = $resolvedPhpDoc->getPhpDocNode()->getTagsByName('@see');
+
         // @todo validate to refer a TestCase class
         if ($seeTags !== []) {
             return [];
         }
 
-        return [sprintf(self::ERROR_MESSAGE, $className)];
+        return [sprintf(self::ERROR_MESSAGE, $classReflection->getName())];
     }
 
     private function isClassMatch(string $className): bool
@@ -93,5 +94,49 @@ final class SeeAnnotationToTestRule implements Rule
         }
 
         return false;
+    }
+
+    private function shouldSkipClassReflection(ClassReflection $classReflection): bool
+    {
+        if (! $this->isClassMatch($classReflection->getName())) {
+            return true;
+        }
+
+        if ($classReflection->isAbstract()) {
+            return true;
+        }
+
+        // meta-Rector
+        if ($classReflection->isSubclassOf(PostRectorInterface::class)) {
+            return true;
+        }
+
+        // skip filesystem for now
+        return ! $classReflection->isSubclassOf(PhpRectorInterface::class);
+    }
+
+    private function matchClassReflection(Class_ $node): ?ClassReflection
+    {
+        if ($node->name === null) {
+            return null;
+        }
+
+        $className = (string) $node->namespacedName;
+        if (! class_exists($className)) {
+            return null;
+        }
+
+        return $this->broker->getClass($className);
+    }
+
+    private function resolvePhpDoc(Scope $scope, ClassReflection $classReflection, Doc $doc): ResolvedPhpDocBlock
+    {
+        return $this->fileTypeMapper->getResolvedPhpDoc(
+            $scope->getFile(),
+            $classReflection->getName(),
+            null,
+            null,
+            $doc->getText()
+        );
     }
 }

--- a/utils/phpstan-extensions/src/Rule/SeeAnnotationToTestRule.php
+++ b/utils/phpstan-extensions/src/Rule/SeeAnnotationToTestRule.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPStanExtensions\Rule;
+
+use Nette\Utils\Strings;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Broker\Broker;
+use PHPStan\Rules\Rule;
+use PHPStan\Type\FileTypeMapper;
+
+final class SeeAnnotationToTestRule implements Rule
+{
+    /**
+     * @var string
+     */
+    public const ERROR_MESSAGE = 'Class "%s" is missing @see annotation with test case class reference';
+
+    /**
+     * @var string[]
+     */
+    private const CLASS_SUFFIXES = ['Rector'];
+
+    /**
+     * @var FileTypeMapper
+     */
+    private $fileTypeMapper;
+
+    /**
+     * @var Broker
+     */
+    private $broker;
+
+    public function __construct(Broker $broker, FileTypeMapper $fileTypeMapper)
+    {
+        $this->fileTypeMapper = $fileTypeMapper;
+        $this->broker = $broker;
+    }
+
+    public function getNodeType(): string
+    {
+        return Class_::class;
+    }
+
+    /**
+     * @param Class_ $node
+     * @return string[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ($node->name === null) {
+            return [];
+        }
+
+        $className = (string) $node->namespacedName;
+        if (! $this->isClassMatch($className)) {
+            return [];
+        }
+
+        $classReflection = $this->broker->getClass($className);
+
+        $docComment = $node->getDocComment();
+        if ($docComment === null) {
+            return [sprintf(self::ERROR_MESSAGE, $className)];
+        }
+
+        $resolvedPhpDoc = $this->fileTypeMapper->getResolvedPhpDoc(
+            $scope->getFile(),
+            $classReflection->getName(),
+            null,
+            null,
+            $docComment->getText()
+        );
+
+        $seeTags = $resolvedPhpDoc->getPhpDocNode()->getTagsByName('@see');
+        // @todo validate to refer a TestCase class
+        if ($seeTags !== []) {
+            return [];
+        }
+
+        return [sprintf(self::ERROR_MESSAGE, $className)];
+    }
+
+    private function isClassMatch(string $className): bool
+    {
+        foreach (self::CLASS_SUFFIXES as $classSuffix) {
+            if (Strings::endsWith($className, $classSuffix)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/utils/phpstan-extensions/tests/AbstractServiceAwareRuleTestCase.php
+++ b/utils/phpstan-extensions/tests/AbstractServiceAwareRuleTestCase.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPStanExtensions\Tests;
+
+use PHPStan\DependencyInjection\Container;
+use PHPStan\DependencyInjection\ContainerFactory;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @deprecated
+ * Waits on https://github.com/symplify/symplify/pull/1908 to be merged + tagged
+ */
+abstract class AbstractServiceAwareRuleTestCase extends RuleTestCase
+{
+    protected function getRuleFromConfig(string $ruleClass, string $config): Rule
+    {
+        $container = $this->createContainer([$config]);
+        return $container->getByType($ruleClass);
+    }
+
+    /**
+     * @param string[] $configs
+     */
+    private function createContainer(array $configs): Container
+    {
+        $containerFactory = new ContainerFactory(getcwd());
+        // random for tests cache invalidation in case the container changes
+        $tempDirectory = sys_get_temp_dir() . '/_phpstan_rector/id_' . random_int(0, 1000);
+
+        return $containerFactory->create($tempDirectory, $configs, [], []);
+    }
+}

--- a/utils/phpstan-extensions/tests/Rule/ClassLike/KeepRectorNamespaceForRectorRuleTest.php
+++ b/utils/phpstan-extensions/tests/Rule/ClassLike/KeepRectorNamespaceForRectorRuleTest.php
@@ -12,21 +12,19 @@ use Rector\PHPStanExtensions\Rule\ClassLike\KeepRectorNamespaceForRectorRule;
 final class KeepRectorNamespaceForRectorRuleTest extends RuleTestCase
 {
     /**
-     * @param array<string|int> $expectedErrorsWithLines
      * @dataProvider provideData()
      */
     public function testRule(string $filePath, array $expectedErrorsWithLines): void
     {
-        $this->analyse([$filePath], [$expectedErrorsWithLines]);
+        $this->analyse([$filePath], $expectedErrorsWithLines);
     }
 
     public function provideData(): Iterator
     {
         yield [__DIR__ . '/Source/Rector/ClassInCorrectNamespaceRector.php', []];
-        yield [
-            __DIR__ . '/Source/Rector/WrongClass.php',
-            ['Change namespace for "WrongClass". It cannot be in Rector namespace, unless Rector rule.', 8],
-        ];
+
+        $errorMessage = sprintf(KeepRectorNamespaceForRectorRule::ERROR_MESSAGE, 'WrongClass', 'Rector');
+        yield [__DIR__ . '/Source/Rector/WrongClass.php', [[$errorMessage, 7]]];
     }
 
     protected function getRule(): Rule

--- a/utils/phpstan-extensions/tests/Rule/ClassLike/Source/Rector/WrongClass.php
+++ b/utils/phpstan-extensions/tests/Rule/ClassLike/Source/Rector/WrongClass.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-
 namespace Rector\PHPStanExtensions\Tests\Rule\ClassLike\Source\Rector;
 
 final class WrongClass

--- a/utils/phpstan-extensions/tests/Rule/ClassMethod/PreventParentMethodVisibilityOverrideRuleTest.php
+++ b/utils/phpstan-extensions/tests/Rule/ClassMethod/PreventParentMethodVisibilityOverrideRuleTest.php
@@ -4,18 +4,25 @@ declare(strict_types=1);
 
 namespace Rector\PHPStanExtensions\Tests\Rule\ClassMethod;
 
+use Iterator;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Rector\PHPStanExtensions\Rule\ClassMethod\PreventParentMethodVisibilityOverrideRule;
 
 final class PreventParentMethodVisibilityOverrideRuleTest extends RuleTestCase
 {
-    public function testRule(): void
+    /**
+     * @dataProvider provideData()
+     */
+    public function testRule(string $filePath, array $expectedErrorsWithLines): void
     {
-        $this->analyse(
-            [__DIR__ . '/Source/ClassWithOverridingVisibility.php'],
-            [['Change "run()" method visibility to "protected" to respect parent method visibility.', 10]]
-        );
+        $this->analyse([$filePath], $expectedErrorsWithLines);
+    }
+
+    public function provideData(): Iterator
+    {
+        $errorMessage = sprintf(PreventParentMethodVisibilityOverrideRule::ERROR_MESSAGE, 'run', 'protected');
+        yield [__DIR__ . '/Source/ClassWithOverridingVisibility.php', [[$errorMessage, 9]]];
     }
 
     protected function getRule(): Rule

--- a/utils/phpstan-extensions/tests/Rule/ClassMethod/Source/GoodVisibility.php
+++ b/utils/phpstan-extensions/tests/Rule/ClassMethod/Source/GoodVisibility.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Rector\PHPStanExtensions\Tests\Rule\ClassMethod\Source;
 
-final class ClassWithOverridingVisibility extends GoodVisibility
+abstract class GoodVisibility
 {
-    public function run()
+    protected function run()
     {
+
     }
 }

--- a/utils/phpstan-extensions/tests/Rule/SeeAnnotationToTestRule/Fixture/ClassMissingDocBlockRector.php
+++ b/utils/phpstan-extensions/tests/Rule/SeeAnnotationToTestRule/Fixture/ClassMissingDocBlockRector.php
@@ -4,7 +4,22 @@ declare(strict_types=1);
 
 namespace Rector\PHPStanExtensions\Tests\Rule\SeeAnnotationToTestRule\Fixture;
 
-final class ClassMissingDocBlockRector
-{
+use PhpParser\Node;
+use Rector\Core\Contract\Rector\PhpRectorInterface;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\RectorDefinition\RectorDefinition;
 
+final class ClassMissingDocBlockRector extends AbstractRector implements PhpRectorInterface
+{
+    public function getNodeTypes(): array
+    {
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+    }
+
+    public function getDefinition(): RectorDefinition
+    {
+    }
 }

--- a/utils/phpstan-extensions/tests/Rule/SeeAnnotationToTestRule/Fixture/ClassMissingDocBlockRector.php
+++ b/utils/phpstan-extensions/tests/Rule/SeeAnnotationToTestRule/Fixture/ClassMissingDocBlockRector.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPStanExtensions\Tests\Rule\SeeAnnotationToTestRule\Fixture;
+
+final class ClassMissingDocBlockRector
+{
+
+}

--- a/utils/phpstan-extensions/tests/Rule/SeeAnnotationToTestRule/Fixture/ClassMissingSeeAnnotationRector.php
+++ b/utils/phpstan-extensions/tests/Rule/SeeAnnotationToTestRule/Fixture/ClassMissingSeeAnnotationRector.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPStanExtensions\Tests\Rule\SeeAnnotationToTestRule\Fixture;
+
+/**
+ * Some doc block
+ */
+final class ClassMissingSeeAnnotationRector
+{
+
+}

--- a/utils/phpstan-extensions/tests/Rule/SeeAnnotationToTestRule/Fixture/ClassMissingSeeAnnotationRector.php
+++ b/utils/phpstan-extensions/tests/Rule/SeeAnnotationToTestRule/Fixture/ClassMissingSeeAnnotationRector.php
@@ -4,10 +4,25 @@ declare(strict_types=1);
 
 namespace Rector\PHPStanExtensions\Tests\Rule\SeeAnnotationToTestRule\Fixture;
 
+use PhpParser\Node;
+use Rector\Core\Contract\Rector\PhpRectorInterface;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\RectorDefinition\RectorDefinition;
+
 /**
  * Some doc block
  */
-final class ClassMissingSeeAnnotationRector
+final class ClassMissingSeeAnnotationRector extends AbstractRector implements PhpRectorInterface
 {
+    public function getNodeTypes(): array
+    {
+    }
 
+    public function refactor(Node $node): ?Node
+    {
+    }
+
+    public function getDefinition(): RectorDefinition
+    {
+    }
 }

--- a/utils/phpstan-extensions/tests/Rule/SeeAnnotationToTestRule/SeeAnnotationToTestRuleTest.php
+++ b/utils/phpstan-extensions/tests/Rule/SeeAnnotationToTestRule/SeeAnnotationToTestRuleTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\PHPStanExtensions\Tests\Rule\SeeAnnotationToTestRule;
+
+use Iterator;
+use PHPStan\Rules\Rule;
+use Rector\PHPStanExtensions\Rule\SeeAnnotationToTestRule;
+use Rector\PHPStanExtensions\Tests\AbstractServiceAwareRuleTestCase;
+use Rector\PHPStanExtensions\Tests\Rule\SeeAnnotationToTestRule\Fixture\ClassMissingDocBlockRector;
+use Rector\PHPStanExtensions\Tests\Rule\SeeAnnotationToTestRule\Fixture\ClassMissingSeeAnnotationRector;
+
+final class SeeAnnotationToTestRuleTest extends AbstractServiceAwareRuleTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function testRule(string $filePath, array $expectedErrorsWithLines): void
+    {
+        $this->analyse([$filePath], $expectedErrorsWithLines);
+    }
+
+    public function provideData(): Iterator
+    {
+        $errorMessage = sprintf(SeeAnnotationToTestRule::ERROR_MESSAGE, ClassMissingDocBlockRector::class);
+        yield [__DIR__ . '/Fixture/ClassMissingDocBlockRector.php', [[$errorMessage, 7]]];
+
+        $errorMessage = sprintf(SeeAnnotationToTestRule::ERROR_MESSAGE, ClassMissingSeeAnnotationRector::class);
+        yield [__DIR__ . '/Fixture/ClassMissingSeeAnnotationRector.php', [[$errorMessage, 10]]];
+    }
+
+    protected function getRule(): Rule
+    {
+        return $this->getRuleFromConfig(
+            SeeAnnotationToTestRule::class,
+            __DIR__ . '/../../../config/phpstan-extensions.neon'
+        );
+    }
+}

--- a/utils/phpstan-extensions/tests/Rule/SeeAnnotationToTestRule/SeeAnnotationToTestRuleTest.php
+++ b/utils/phpstan-extensions/tests/Rule/SeeAnnotationToTestRule/SeeAnnotationToTestRuleTest.php
@@ -24,10 +24,10 @@ final class SeeAnnotationToTestRuleTest extends AbstractServiceAwareRuleTestCase
     public function provideData(): Iterator
     {
         $errorMessage = sprintf(SeeAnnotationToTestRule::ERROR_MESSAGE, ClassMissingDocBlockRector::class);
-        yield [__DIR__ . '/Fixture/ClassMissingDocBlockRector.php', [[$errorMessage, 7]]];
+        yield [__DIR__ . '/Fixture/ClassMissingDocBlockRector.php', [[$errorMessage, 12]]];
 
         $errorMessage = sprintf(SeeAnnotationToTestRule::ERROR_MESSAGE, ClassMissingSeeAnnotationRector::class);
-        yield [__DIR__ . '/Fixture/ClassMissingSeeAnnotationRector.php', [[$errorMessage, 10]]];
+        yield [__DIR__ . '/Fixture/ClassMissingSeeAnnotationRector.php', [[$errorMessage, 15]]];
     }
 
     protected function getRule(): Rule


### PR DESCRIPTION
Every Rector should have `@see` annotation with test case reference, so it's easy to jump in and create a fixture. 

Also will be useful in the future for: https://github.com/rectorphp/getrector.org/issues/155

<br>

:no_entry_sign: 


```php
final class NetteAssertToPHPUnitAssertRector extends AbstractRector
```


<br>

:+1: 

```php
/**
 * @see \Rector\NetteTesterToPHPUnit\Tests\Rector\Class_\NetteTesterClassToPHPUnitClassRector\NetteTesterPHPUnitRectorTest
 */
final class NetteAssertToPHPUnitAssertRector extends AbstractRector
```