### PR TITLE
Rule "Rector\ClassConst\VarConstantCommentRector" keeps throwing "could not process" errors.

### DIFF
--- a/rules/coding-style/src/Rector/ClassConst/VarConstantCommentRector.php
+++ b/rules/coding-style/src/Rector/ClassConst/VarConstantCommentRector.php
@@ -73,7 +73,7 @@ PHP
         /** @var PhpDocInfo|null $phpDocInfo */
         $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
         if ($phpDocInfo === null) {
-            $this->phpDocInfoFactory->createEmpty($node);
+            $phpDocInfo = $this->phpDocInfoFactory->createEmpty($node);
         }
 
         $phpDocInfo->changeVarType($constStaticType);


### PR DESCRIPTION
If we don't redeclare the `$phpDocInfo` variable, it will fail at the next line, as calling a method on null will fail.