### PR TITLE
#3336 test case for partial use

### DIFF
--- a/rules/coding-style/tests/Rector/Namespace_/ImportFullyQualifiedNamesRector/Fixture/partial_use.php.inc
+++ b/rules/coding-style/tests/Rector/Namespace_/ImportFullyQualifiedNamesRector/Fixture/partial_use.php.inc
@@ -1,0 +1,17 @@
+<?php
+namespace Rector\CodingStyle\Tests\Rector\Namespace_\ImportFullyQualifiedNamesRector\Fixture;
+
+use PhpParser\Node\Stmt;
+
+$class = Stmt\Expression::class;
+
+?>
+    -----
+<?php
+namespace Rector\CodingStyle\Tests\Rector\Namespace_\ImportFullyQualifiedNamesRector\Fixture;
+
+use PhpParser\Node\Stmt;
+
+$class = Stmt\Expression::class;
+
+?>


### PR DESCRIPTION
Adds a test-case for use statements that are referencing a partial namespace only.

Fails as expected:

```diff
1) Rector\CodingStyle\Tests\Rector\Namespace_\ImportFullyQualifiedNamesRector\ImportFullyQualifiedNamesRectorTest::test with data set #5 ('/Users/lstrojny/Projects/gith...hp.inc')
rules/coding-style/tests/Rector/Namespace_/ImportFullyQualifiedNamesRector/Fixture/partial_use.php.inc
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
 <?php
 namespace Rector\CodingStyle\Tests\Rector\Namespace_\ImportFullyQualifiedNamesRector\Fixture;

+use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt;

-$class = Stmt\Expression::class;
+$class = Expression::class;

 ?>
```