### PR TITLE
Rule Rector\ClassMethod\AddArrayReturnDocTypeRector could not process files

### DIFF
--- a/rules/type-declaration/src/Rector/ClassMethod/AddArrayReturnDocTypeRector.php
+++ b/rules/type-declaration/src/Rector/ClassMethod/AddArrayReturnDocTypeRector.php
@@ -109,9 +109,11 @@ PHP
             return null;
         }
 
-        /** @var PhpDocInfo $phpDocInfo */
+        /** @var PhpDocInfo|null $phpDocInfo */
         $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
-        $phpDocInfo->changeReturnType($inferedType);
+        if ($phpDocInfo instanceof PhpDocInfo) {
+            $phpDocInfo->changeReturnType($inferedType);
+        }
 
         return $node;
     }


### PR DESCRIPTION
I'm in over my head on this one, as I don't really understand what the code is trying to do in that part. But I get errors like:

```
 [ERROR] Could not process "<filename>" file by "Rector\TypeDeclaration\Rector\ClassMethod\AddArrayReturnDocTypeRector", due to:
"Call to a member function changeReturnType() on null".
```

The function is being called on `$phpDocInfo`, which can be null. It is declared in the docblock as being an object of type `PhpDocInfo`, but it seems that's not always true (in my code at least). 

This change is not the right solution! It fixed the processing errors. But it still is not correctly recognizing the classes being added to the docblock, as they show up as long names, even when both 'auto_import_names' and 'import_doc_blocks' are set to true.

I'm not going to use this rector, as it also changes `array<int, Example>` to `Example[]`, but I wanted to leave this here, as it is throwing a lot of errors, and at first sight it seemed quite easy to spot the problem. I'm not sure how to proceed. I'm going to look into some other rectors, where I have similar processing problems.