### PR TITLE
Fix RenameAnnotationRector for null phpdoc

### DIFF
--- a/rules/renaming/src/Rector/Annotation/RenameAnnotationRector.php
+++ b/rules/renaming/src/Rector/Annotation/RenameAnnotationRector.php
@@ -90,8 +90,11 @@ PHP
         /** @var Class_ $class */
         $class = $node->getAttribute(AttributeKey::CLASS_NODE);
 
-        /** @var PhpDocInfo $phpDocInfo */
+        /** @var PhpDocInfo|null $phpDocInfo */
         $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
+        if ($phpDocInfo === null) {
+            return null;
+        }
 
         foreach ($this->classToAnnotationMap as $type => $annotationMap) {
             /** @var string $type */

--- a/rules/renaming/tests/Rector/Annotation/RenameAnnotationRector/Fixture/skip_method_with_comment_not_php_doc.php.inc
+++ b/rules/renaming/tests/Rector/Annotation/RenameAnnotationRector/Fixture/skip_method_with_comment_not_php_doc.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Renaming\Tests\Rector\Annotation\RenameAnnotationRector\Fixture;
+
+/*
+ * This definition fails only when is extending \PHPUnit\Framework\TestCase
+ */
+final class FixtureRenameWithMethodWithCommentTest extends \PHPUnit\Framework\TestCase
+{
+    /*
+     * this is a comment, not a phpdoc
+     */
+    public function test()
+    {
+    }
+}
+
+?>


### PR DESCRIPTION
Fixes #3381

Including the fixture produces error:

```
$ phpunit rules/renaming/tests/Rector/Annotation/RenameAnnotationRector/RenameAnnotationRectorTest.php 
PHPUnit 9.1.4 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.3.15-3
Configuration: /home/eclipxe/work/github/rector/phpunit.xml

.E                                                                  2 / 2 (100%)

Time: 00:02.103, Memory: 82.36 MB

There was 1 error:

1) Rector\Renaming\Tests\Rector\Annotation\RenameAnnotationRector\RenameAnnotationRectorTest::test with data set #1 ('/home/eclipxe/work/github/rec...hp.inc')
Error: Call to a member function hasByName() on null

/home/eclipxe/work/github/rector/rules/renaming/src/Rector/Annotation/RenameAnnotationRector.php:106
...
```

The null check and return make the test pass again.

When creating the fixture to test I notice that it only fails when the class extends `\PHPUnit\Framework\TestCase` and classname ends with `Test`.

I didn't find a way to reproduce the error without the previous condition.

PD: running `composer complete-check` changes `compiler/src/HttpKernel/RectorCompilerKernel.php`. I didn't include it.

Please, let me know if you would like some changes.