### PR TITLE
Keep empty php code as is

### DIFF
--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -82,13 +82,8 @@ final class BetterStandardPrinter extends Standard
         // php attributes
         $content = $this->contentPhpAttributePlaceholderReplacer->decorateContent($content);
 
-        // remove dead <?php structures
-        $clearContent = Strings::replace($content, '#\<\?php(\s)\?\>\n?#');
-
-        $clearContent = Strings::replace($clearContent, '#\<\?php(\s+)\?\>#');
-
         // keep EOL
-        return rtrim($clearContent) . $this->nl;
+        return rtrim($content) . $this->nl;
     }
 
     /**


### PR DESCRIPTION
(Resolving the same type of issue as in https://github.com/rectorphp/rector/pull/3394)
To maintain the assumption, that rector would only change what it was instructed to, when there's an empty php code `<?php ?>`, we want to preserve it.
You can see an example of when it's necessary here: https://github.com/rectorphp/rector/issues/3352#issuecomment-631691576

Removing empty php code should be a specific Rector rule that people can opt-in to run, instead of automatically being removed every time Rector runs.