### PR TITLE
[Nette] Add ContextGetByTypeToConstructorInjectionRector

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# All 485 Rectors Overview
+# All 487 Rectors Overview
 
 - [Projects](#projects)
 - [General](#general)
@@ -25,7 +25,7 @@
 - [MockistaToMockery](#mockistatomockery) (2)
 - [MysqlToMysqli](#mysqltomysqli) (4)
 - [Naming](#naming) (1)
-- [Nette](#nette) (11)
+- [Nette](#nette) (12)
 - [NetteTesterToPHPUnit](#nettetestertophpunit) (3)
 - [NetteToSymfony](#nettetosymfony) (9)
 - [Order](#order) (3)
@@ -55,7 +55,7 @@
 - [RemovingStatic](#removingstatic) (4)
 - [Renaming](#renaming) (10)
 - [Restoration](#restoration) (3)
-- [SOLID](#solid) (11)
+- [SOLID](#solid) (12)
 - [Sensio](#sensio) (1)
 - [StrictCodeQuality](#strictcodequality) (1)
 - [Symfony](#symfony) (29)
@@ -4306,6 +4306,41 @@ Nextras/Form upgrade of addDatePicker method call to DateControl assign
          $form = new Form();
 -        $form->addDatePicker('key', 'Label');
 +        $form['key'] = new \Nextras\FormComponents\Controls\DateControl('Label');
+     }
+ }
+```
+
+<br>
+
+### `ContextGetByTypeToConstructorInjectionRector`
+
+- class: [`Rector\Nette\Rector\MethodCall\ContextGetByTypeToConstructorInjectionRector`](/../master/rules/nette/src/Rector/MethodCall/ContextGetByTypeToConstructorInjectionRector.php)
+- [test fixtures](/../master/rules/nette/tests/Rector/MethodCall/ContextGetByTypeToConstructorInjectionRector/Fixture)
+
+Move dependency passed to all children to parent as @inject/@required dependency
+
+```diff
+ class SomeClass
+ {
+     /**
+      * @var \Nette\DI\Container
+      */
+     private $context;
+
++    /**
++     * @var SomeTypeToInject
++     */
++    private $someTypeToInject;
++
++    public function __construct(SomeTypeToInject $someTypeToInject)
++    {
++        $this->someTypeToInject = $someTypeToInject;
++    }
++
+     public function run()
+     {
+-        $someTypeToInject = $this->context->getByType(SomeTypeToInject::class);
++        $someTypeToInject = $this->someTypeToInject;
      }
  }
 ```
@@ -9122,6 +9157,56 @@ Classes that have no children nor are used, should have abstract
 -class PossibleAbstractClass
 +abstract class PossibleAbstractClass
  {
+ }
+```
+
+<br>
+
+### `MultiParentingToAbstractDependencyRector`
+
+- class: [`Rector\SOLID\Rector\Class_\MultiParentingToAbstractDependencyRector`](/../master/rules/solid/src/Rector/Class_/MultiParentingToAbstractDependencyRector.php)
+- [test fixtures](/../master/rules/solid/tests/Rector/Class_/MultiParentingToAbstractDependencyRector/Fixture)
+
+Move dependency passed to all children to parent as @inject/@required dependency
+
+```yaml
+services:
+    Rector\SOLID\Rector\Class_\MultiParentingToAbstractDependencyRector:
+        $framework: nette
+```
+
+↓
+
+```diff
+ abstract class AbstractParentClass
+ {
+-    private $someDependency;
+-
+-    public function __construct(SomeDependency $someDependency)
+-    {
+-        $this->someDependency = $someDependency;
+-    }
++    /**
++     * @inject
++     * @var SomeDependency
++     */
++    public $someDependency;
+ }
+
+ class FirstChild extends AbstractParentClass
+ {
+-    public function __construct(SomeDependency $someDependency)
+-    {
+-        parent::__construct($someDependency);
+-    }
+ }
+
+ class SecondChild extends AbstractParentClass
+ {
+-    public function __construct(SomeDependency $someDependency)
+-    {
+-        parent::__construct($someDependency);
+-    }
  }
 ```
 

--- a/packages/node-collector/src/NodeCollector/ParsedClassConstFetchNodeCollector.php
+++ b/packages/node-collector/src/NodeCollector/ParsedClassConstFetchNodeCollector.php
@@ -136,15 +136,15 @@ final class ParsedClassConstFetchNodeCollector
     {
         $reflectionClass = new ReflectionClass($className);
 
-        $currentClassConstants = $reflectionClass->getConstants();
+        $currentClassConstants = array_keys($reflectionClass->getConstants());
         $parentClassReflection = $reflectionClass->getParentClass();
 
         if (! $parentClassReflection) {
-            return array_keys($currentClassConstants);
+            return $currentClassConstants;
         }
 
-        $currentClassConstants = array_diff($currentClassConstants, $parentClassReflection->getConstants());
+        $parentClassConstants = array_keys($parentClassReflection->getConstants());
 
-        return array_keys($currentClassConstants);
+        return array_diff($currentClassConstants, $parentClassConstants);
     }
 }

--- a/rules/nette/src/Rector/MethodCall/ContextGetByTypeToConstructorInjectionRector.php
+++ b/rules/nette/src/Rector/MethodCall/ContextGetByTypeToConstructorInjectionRector.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Nette\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\PropertyFetch;
+use Rector\Core\RectorDefinition\CodeSample;
+use Rector\Core\RectorDefinition\RectorDefinition;
+use Rector\Symfony\Rector\FrameworkBundle\AbstractToConstructorInjectionRector;
+
+/**
+ * @see \Rector\Nette\Tests\Rector\MethodCall\ContextGetByTypeToConstructorInjectionRector\ContextGetByTypeToConstructorInjectionRectorTest
+ */
+final class ContextGetByTypeToConstructorInjectionRector extends AbstractToConstructorInjectionRector
+{
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition(
+            'Move dependency passed to all children to parent as @inject/@required dependency',
+            [
+                new CodeSample(
+                    <<<'PHP'
+class SomeClass
+{
+    /**
+     * @var \Nette\DI\Container
+     */
+    private $context;
+
+    public function run()
+    {
+        $someTypeToInject = $this->context->getByType(SomeTypeToInject::class);
+    }
+}
+PHP
+,
+                    <<<'PHP'
+class SomeClass
+{
+    /**
+     * @var \Nette\DI\Container
+     */
+    private $context;
+
+    /**
+     * @var SomeTypeToInject
+     */
+    private $someTypeToInject;
+
+    public function __construct(SomeTypeToInject $someTypeToInject)
+    {
+        $this->someTypeToInject = $someTypeToInject;
+    }
+
+    public function run()
+    {
+        $someTypeToInject = $this->someTypeToInject;
+    }
+}
+PHP
+
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    /**
+     * @param MethodCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $node->var instanceof PropertyFetch) {
+            return null;
+        }
+
+        if (! $this->isObjectType($node->var, 'Nette\DI\Container')) {
+            return null;
+        }
+
+        if (! $this->isName($node->name, 'getByType')) {
+            return null;
+        }
+
+        return $this->processMethodCallNode($node);
+    }
+}

--- a/rules/nette/tests/Rector/MethodCall/ContextGetByTypeToConstructorInjectionRector/ContextGetByTypeToConstructorInjectionRectorTest.php
+++ b/rules/nette/tests/Rector/MethodCall/ContextGetByTypeToConstructorInjectionRector/ContextGetByTypeToConstructorInjectionRectorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Nette\Tests\Rector\MethodCall\ContextGetByTypeToConstructorInjectionRector;
+
+use Iterator;
+use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;
+use Rector\Nette\Rector\MethodCall\ContextGetByTypeToConstructorInjectionRector;
+
+final class ContextGetByTypeToConstructorInjectionRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $file): void
+    {
+        $this->doTestFile($file);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    protected function getRectorClass(): string
+    {
+        return ContextGetByTypeToConstructorInjectionRector::class;
+    }
+}

--- a/rules/nette/tests/Rector/MethodCall/ContextGetByTypeToConstructorInjectionRector/Fixture/Source/SomeTypeToInject.php
+++ b/rules/nette/tests/Rector/MethodCall/ContextGetByTypeToConstructorInjectionRector/Fixture/Source/SomeTypeToInject.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Nette\Tests\Rector\MethodCall\ContextGetByTypeToConstructorInjectionRector\Fixture\Source;
+
+final class SomeTypeToInject
+{
+
+}

--- a/rules/nette/tests/Rector/MethodCall/ContextGetByTypeToConstructorInjectionRector/Fixture/fixture.php.inc
+++ b/rules/nette/tests/Rector/MethodCall/ContextGetByTypeToConstructorInjectionRector/Fixture/fixture.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\Nette\Tests\Rector\MethodCall\ContextGetByTypeToConstructorInjectionRector\Fixture;
+
+use Rector\Nette\Tests\Rector\MethodCall\ContextGetByTypeToConstructorInjectionRector\Fixture\Source\SomeTypeToInject;
+
+class SomeClass
+{
+    /**
+     * @var \Nette\DI\Container
+     */
+    private $context;
+
+    public function run()
+    {
+        $someTypeToInject = $this->context->getByType(SomeTypeToInject::class);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Nette\Tests\Rector\MethodCall\ContextGetByTypeToConstructorInjectionRector\Fixture;
+
+use Rector\Nette\Tests\Rector\MethodCall\ContextGetByTypeToConstructorInjectionRector\Fixture\Source\SomeTypeToInject;
+
+class SomeClass
+{
+    /**
+     * @var \Nette\DI\Container
+     */
+    private $context;
+    /**
+     * @var \Rector\Nette\Tests\Rector\MethodCall\ContextGetByTypeToConstructorInjectionRector\Fixture\Source\SomeTypeToInject
+     */
+    private $someTypeToInject;
+    public function __construct(\Rector\Nette\Tests\Rector\MethodCall\ContextGetByTypeToConstructorInjectionRector\Fixture\Source\SomeTypeToInject $someTypeToInject)
+    {
+        $this->someTypeToInject = $someTypeToInject;
+    }
+
+    public function run()
+    {
+        $someTypeToInject = $this->someTypeToInject;
+    }
+}
+
+?>


### PR DESCRIPTION
Do you want to get rid of `$this->context`?

```diff
 class SomeClass
 {
     /**
      * @var \Nette\DI\Container
      */
     private $context;

+    /**
+     * @var SomeTypeToInject
+     */
+    private $someTypeToInject;
+
+    public function __construct(SomeTypeToInject $someTypeToInject)
+    {
+        $this->someTypeToInject = $someTypeToInject;
+    }
+
     public function run()
     {
-        $someTypeToInject = $this->context->getByType(SomeTypeToInject::class);
+        $someTypeToInject = $this->someTypeToInject;
     }
 }
```