### PR TITLE
Future-proof ScopeFactory

### DIFF
--- a/packages/node-type-resolver/config/config.yaml
+++ b/packages/node-type-resolver/config/config.yaml
@@ -23,17 +23,8 @@ services:
     PHPStan\Analyser\NodeScopeResolver:
         factory: ['@Rector\NodeTypeResolver\DependencyInjection\PHPStanServicesFactory', 'createNodeScopeResolver']
 
-    PHPStan\Analyser\TypeSpecifier:
-        factory: ['@Rector\NodeTypeResolver\DependencyInjection\PHPStanServicesFactory', 'createTypeSpecifier']
-
     PHPStan\Analyser\ScopeFactory:
         factory: ['@Rector\NodeTypeResolver\DependencyInjection\PHPStanServicesFactory', 'createScopeFactory']
-
-    PHPStan\DependencyInjection\Type\DynamicReturnTypeExtensionRegistryProvider:
-        factory: ['@Rector\NodeTypeResolver\DependencyInjection\PHPStanServicesFactory', 'createDynamicReturnTypeExtensionRegistryProvider']
-
-    PHPStan\DependencyInjection\Type\OperatorTypeSpecifyingExtensionRegistryProvider:
-        factory: ['@Rector\NodeTypeResolver\DependencyInjection\PHPStanServicesFactory', 'createOperatorTypeSpecifyingExtensionRegistryProvider']
 
     PHPStan\PhpDoc\TypeNodeResolver:
         factory: ['@Rector\NodeTypeResolver\DependencyInjection\PHPStanServicesFactory', 'createTypeNodeResolver']

--- a/packages/node-type-resolver/src/PHPStan/Scope/ScopeFactory.php
+++ b/packages/node-type-resolver/src/PHPStan/Scope/ScopeFactory.php
@@ -4,77 +4,25 @@ declare(strict_types=1);
 
 namespace Rector\NodeTypeResolver\PHPStan\Scope;
 
-use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\Scope;
 use PHPStan\Analyser\ScopeContext;
 use PHPStan\Analyser\ScopeFactory as PHPStanScopeFactory;
-use PHPStan\Analyser\TypeSpecifier;
-use PHPStan\DependencyInjection\Type\DynamicReturnTypeExtensionRegistryProvider;
-use PHPStan\DependencyInjection\Type\OperatorTypeSpecifyingExtensionRegistryProvider;
-use PHPStan\Reflection\ReflectionProvider;
-use PHPStan\Rules\Properties\PropertyReflectionFinder;
-use Rector\Core\PhpParser\Printer\BetterStandardPrinter;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class ScopeFactory
 {
     /**
-     * @var ReflectionProvider
-     */
-    private $reflectionProvider;
-
-    /**
-     * @var TypeSpecifier
-     */
-    private $typeSpecifier;
-
-    /**
      * @var PHPStanScopeFactory
      */
     private $phpStanScopeFactory;
 
-    /**
-     * @var BetterStandardPrinter
-     */
-    private $betterStandardPrinter;
-
-    /**
-     * @var DynamicReturnTypeExtensionRegistryProvider
-     */
-    private $dynamicReturnTypeExtensionRegistryProvider;
-
-    /**
-     * @var OperatorTypeSpecifyingExtensionRegistryProvider
-     */
-    private $operatorTypeSpecifyingExtensionRegistryProvider;
-
-    public function __construct(
-        ReflectionProvider $reflectionProvider,
-        TypeSpecifier $typeSpecifier,
-        PHPStanScopeFactory $phpStanScopeFactory,
-        BetterStandardPrinter $betterStandardPrinter,
-        DynamicReturnTypeExtensionRegistryProvider $dynamicReturnTypeExtensionRegistryProvider,
-        OperatorTypeSpecifyingExtensionRegistryProvider $operatorTypeSpecifyingExtensionRegistryProvider
-    ) {
-        $this->reflectionProvider = $reflectionProvider;
-        $this->typeSpecifier = $typeSpecifier;
+    public function __construct(PHPStanScopeFactory $phpStanScopeFactory)
+    {
         $this->phpStanScopeFactory = $phpStanScopeFactory;
-        $this->betterStandardPrinter = $betterStandardPrinter;
-        $this->dynamicReturnTypeExtensionRegistryProvider = $dynamicReturnTypeExtensionRegistryProvider;
-        $this->operatorTypeSpecifyingExtensionRegistryProvider = $operatorTypeSpecifyingExtensionRegistryProvider;
     }
 
     public function createFromFile(SmartFileInfo $fileInfo): Scope
     {
-        return new MutatingScope(
-            $this->phpStanScopeFactory,
-            $this->reflectionProvider,
-            $this->dynamicReturnTypeExtensionRegistryProvider->getRegistry(),
-            $this->operatorTypeSpecifyingExtensionRegistryProvider->getRegistry(),
-            $this->betterStandardPrinter,
-            $this->typeSpecifier,
-            new PropertyReflectionFinder(),
-            ScopeContext::create($fileInfo->getRealPath())
-        );
+        return $this->phpStanScopeFactory->create(ScopeContext::create($fileInfo->getRealPath()));
     }
 }


### PR DESCRIPTION
As MutatingScope constructor can change often and is not covered by backwards compatibility promise, this is a much better way to construct it. As you can notice, it's just a bunch of code deleted as you can simply call `$this->phpStanScopeFactory->create()` for the same effect.

Thanks.