### PR TITLE
Add RemoveFuncCallArgRector, ClearReturnNewByReferenceRector, RemoveIniGetSetFuncCallRector, ReplaceHttpServerVarsByServerRector

### DIFF
--- a/config/set/php/php52.yaml
+++ b/config/set/php/php52.yaml
@@ -1,3 +1,8 @@
 services:
     Rector\Php52\Rector\Property\VarToPublicPropertyRector: null
     Rector\Php52\Rector\Switch_\ContinueToBreakInSwitchRector: null
+
+    # see https://www.php.net/manual/en/function.ldap-first-attribute.php
+    Rector\Core\Rector\FuncCall\RemoveFuncCallArgRector:
+        $argumentPositionByFunctionName:
+            ldap_first_attribute: [2]

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# All 498 Rectors Overview
+# All 499 Rectors Overview
 
 - [Projects](#projects)
 - [General](#general)
@@ -38,7 +38,7 @@
 - [Performance](#performance) (1)
 - [Phalcon](#phalcon) (4)
 - [Php52](#php52) (2)
-- [Php53](#php53) (3)
+- [Php53](#php53) (4)
 - [Php54](#php54) (2)
 - [Php55](#php55) (2)
 - [Php56](#php56) (2)
@@ -6662,6 +6662,20 @@ Convert dirname(__FILE__) to __DIR__
 +        return __DIR__;
      }
  }
+```
+
+<br>
+
+### `ReplaceHttpServerVarsByServerRector`
+
+- class: [`Rector\Php53\Rector\Variable\ReplaceHttpServerVarsByServerRector`](/../master/rules/php53/src/Rector/Variable/ReplaceHttpServerVarsByServerRector.php)
+- [test fixtures](/../master/rules/php53/tests/Rector/Variable/ReplaceHttpServerVarsByServerRector/Fixture)
+
+Rename old $HTTP_* variable names to new replacements
+
+```diff
+-$serverVars = $HTTP_SERVER_VARS;
++$serverVars = $_SERVER;
 ```
 
 <br>

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# All 495 Rectors Overview
+# All 498 Rectors Overview
 
 - [Projects](#projects)
 - [General](#general)
@@ -38,7 +38,7 @@
 - [Performance](#performance) (1)
 - [Phalcon](#phalcon) (4)
 - [Php52](#php52) (2)
-- [Php53](#php53) (2)
+- [Php53](#php53) (3)
 - [Php54](#php54) (2)
 - [Php55](#php55) (2)
 - [Php56](#php56) (2)
@@ -6632,6 +6632,20 @@ Remove unused private method
 
 ## Php53
 
+### `ClearReturnNewByReferenceRector`
+
+- class: [`Rector\Php53\Rector\Assign\ClearReturnNewByReferenceRector`](/../master/rules/php53/src/Rector/Assign/ClearReturnNewByReferenceRector.php)
+- [test fixtures](/../master/rules/php53/tests/Rector/Assign/ClearReturnNewByReferenceRector/Fixture)
+
+Remove reference from "$assign = &new Value;"
+
+```diff
+-$assign = &new Value;
++$assign = new Value;
+```
+
+<br>
+
 ### `DirNameFileConstantToDirConstantRector`
 
 - class: [`Rector\Php53\Rector\FuncCall\DirNameFileConstantToDirConstantRector`](/../master/rules/php53/src/Rector/FuncCall/DirNameFileConstantToDirConstantRector.php)
@@ -10514,7 +10528,7 @@ Change @return types and type from static analysis to type declarations if not a
 
 ## General
 
-- [Core](#core) (42)
+- [Core](#core) (44)
 
 ## Core
 
@@ -11358,6 +11372,53 @@ services:
 +/** @var Some\Chicken $someService */
 +$someService = new Some\Chicken;
  $someClassToKeep = new Some_Class_To_Keep;
+```
+
+<br>
+
+### `RemoveFuncCallArgRector`
+
+- class: [`Rector\Core\Rector\FuncCall\RemoveFuncCallArgRector`](/../master/src/Rector/FuncCall/RemoveFuncCallArgRector.php)
+- [test fixtures](/../master/tests/Rector/FuncCall/RemoveFuncCallArgRector/Fixture)
+
+Remove argument by position by function name
+
+```yaml
+services:
+    Rector\Core\Rector\FuncCall\RemoveFuncCallArgRector:
+        $argumentPositionByFunctionName:
+            remove_last_arg:
+                - 1
+```
+
+↓
+
+```diff
+-remove_last_arg(1, 2);
++remove_last_arg(1);
+```
+
+<br>
+
+### `RemoveIniGetSetFuncCallRector`
+
+- class: [`Rector\Core\Rector\FuncCall\RemoveIniGetSetFuncCallRector`](/../master/src/Rector/FuncCall/RemoveIniGetSetFuncCallRector.php)
+- [test fixtures](/../master/tests/Rector/FuncCall/RemoveIniGetSetFuncCallRector/Fixture)
+
+Remove ini_get by configuration
+
+```yaml
+services:
+    Rector\Core\Rector\FuncCall\RemoveIniGetSetFuncCallRector:
+        $keysToRemove:
+            - y2k_compliance
+```
+
+↓
+
+```diff
+-ini_get('y2k_compliance');
+-ini_set('y2k_compliance', 1);
 ```
 
 <br>

--- a/rules/php53/src/Rector/Assign/ClearReturnNewByReferenceRector.php
+++ b/rules/php53/src/Rector/Assign/ClearReturnNewByReferenceRector.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Php53\Rector\Assign;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\AssignRef;
+use PhpParser\Node\Expr\New_;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\RectorDefinition\CodeSample;
+use Rector\Core\RectorDefinition\RectorDefinition;
+
+/**
+ * @sponsor Thanks https://twitter.com/afilina for sponsoring this rule
+
+ * @see https://3v4l.org/UJN6H
+ * @see \Rector\Php53\Rector\Assign\ClearReturnNewByReferenceRector
+ */
+final class ClearReturnNewByReferenceRector extends AbstractRector
+{
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Remove reference from "$assign = &new Value;"', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+$assign = &new Value;
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+$assign = new Value;
+CODE_SAMPLE
+            ), ]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [AssignRef::class];
+    }
+
+    /**
+     * @param AssignRef $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $node->expr instanceof New_) {
+            return null;
+        }
+
+        return new Assign($node->var, $node->expr);
+    }
+}

--- a/rules/php53/src/Rector/Variable/ReplaceHttpServerVarsByServerRector.php
+++ b/rules/php53/src/Rector/Variable/ReplaceHttpServerVarsByServerRector.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Php53\Rector\Variable;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Variable;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\RectorDefinition\CodeSample;
+use Rector\Core\RectorDefinition\RectorDefinition;
+
+/**
+ * @sponsor Thanks https://twitter.com/afilina for sponsoring this rule
+ *
+ * @see \Rector\Php53\Tests\Rector\Variable\ReplaceHttpServerVarsByServerRector\ReplaceHttpServerVarsByServerRectorTest
+ * @see https://blog.tigertech.net/posts/php-5-3-http-server-vars/
+ */
+final class ReplaceHttpServerVarsByServerRector extends AbstractRector
+{
+    /**
+     * @var string[]
+     */
+    private const VARIABLE_RENAME_MAP = [
+        'HTTP_SERVER_VARS' => '_SERVER',
+        'HTTP_GET_VARS' => '_GET',
+        'HTTP_POST_VARS' => '_POST',
+        'HTTP_POST_FILES' => '_FILES',
+        'HTTP_SESSION_VARS' => '_SESSION',
+        'HTTP_ENV_VARS' => '_ENV',
+        'HTTP_COOKIE_VARS' => '_COOKIE',
+    ];
+
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Rename old $HTTP_* variable names to new replacements', [
+            new CodeSample('$serverVars = $HTTP_SERVER_VARS;', '$serverVars = $_SERVER;'),
+        ]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Variable::class];
+    }
+
+    /**
+     * @param Variable $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        foreach (self::VARIABLE_RENAME_MAP as $oldName => $newName) {
+            if (! $this->isName($node, $oldName)) {
+                continue;
+            }
+
+            $node->name = $newName;
+            return $node;
+        }
+
+        return null;
+    }
+}

--- a/rules/php53/tests/Rector/Assign/ClearReturnNewByReferenceRector/ClearReturnNewByReferenceRectorTest.php
+++ b/rules/php53/tests/Rector/Assign/ClearReturnNewByReferenceRector/ClearReturnNewByReferenceRectorTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Php53\Tests\Rector\Assign\ClearReturnNewByReferenceRector;
+
+use Iterator;
+use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;
+use Rector\Php53\Rector\Assign\ClearReturnNewByReferenceRector;
+use SplFileInfo;
+
+final class ClearReturnNewByReferenceRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideDataForTest()
+     */
+    public function test(string $file): void
+    {
+        $this->doTestFileWithoutAutoload($file);
+    }
+
+    /**
+     * @return Iterator<SplFileInfo>
+     */
+    public function provideDataForTest(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    protected function getRectorClass(): string
+    {
+        return ClearReturnNewByReferenceRector::class;
+    }
+}

--- a/rules/php53/tests/Rector/Assign/ClearReturnNewByReferenceRector/Fixture/fixture.php.inc
+++ b/rules/php53/tests/Rector/Assign/ClearReturnNewByReferenceRector/Fixture/fixture.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+$instance = &new Foo();
+
+?>
+-----
+<?php
+
+$instance = new Foo();
+
+?>

--- a/rules/php53/tests/Rector/Variable/ReplaceHttpServerVarsByServerRector/Fixture/fixture.php.inc
+++ b/rules/php53/tests/Rector/Variable/ReplaceHttpServerVarsByServerRector/Fixture/fixture.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Php53\Tests\Rector\Variable\ReplaceHttpServerVarsByServerRector\Fixture;
+
+class SomeClass
+{
+    public function run()
+    {
+        $tmp = $HTTP_SERVER_VARS[$var];
+        parse_str($HTTP_SERVER_VARS["QUERY_STRING"]);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Php53\Tests\Rector\Variable\ReplaceHttpServerVarsByServerRector\Fixture;
+
+class SomeClass
+{
+    public function run()
+    {
+        $tmp = $_SERVER[$var];
+        parse_str($_SERVER["QUERY_STRING"]);
+    }
+}
+
+?>

--- a/rules/php53/tests/Rector/Variable/ReplaceHttpServerVarsByServerRector/ReplaceHttpServerVarsByServerRectorTest.php
+++ b/rules/php53/tests/Rector/Variable/ReplaceHttpServerVarsByServerRector/ReplaceHttpServerVarsByServerRectorTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Php53\Tests\Rector\Variable\ReplaceHttpServerVarsByServerRector;
+
+use Iterator;
+use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;
+use Rector\Php53\Rector\Variable\ReplaceHttpServerVarsByServerRector;
+use SplFileInfo;
+
+final class ReplaceHttpServerVarsByServerRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideDataForTest()
+     */
+    public function test(string $file): void
+    {
+        $this->doTestFile($file);
+    }
+
+    /**
+     * @return Iterator<SplFileInfo>
+     */
+    public function provideDataForTest(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixtures');
+    }
+
+    protected function getRectorClass(): string
+    {
+        return ReplaceHttpServerVarsByServerRector::class;
+    }
+}

--- a/src/Rector/FuncCall/RemoveFuncCallArgRector.php
+++ b/src/Rector/FuncCall/RemoveFuncCallArgRector.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\RectorDefinition\ConfiguredCodeSample;
+use Rector\Core\RectorDefinition\RectorDefinition;
+
+/**
+ * @sponsor Thanks https://twitter.com/afilina for sponsoring this rule
+ *
+ * @see \Rector\Core\Tests\Rector\FuncCall\RemoveFuncCallArgRector\RemoveFuncCallArgRectorTest
+ */
+final class RemoveFuncCallArgRector extends AbstractRector
+{
+    /**
+     * @var int[][]
+     */
+    private $argumentPositionByFunctionName = [];
+
+    /**
+     * @param int[][] $argumentPositionByFunctionName
+     */
+    public function __construct(array $argumentPositionByFunctionName = [])
+    {
+        $this->argumentPositionByFunctionName = $argumentPositionByFunctionName;
+    }
+
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Remove argument by position by function name', [
+            new ConfiguredCodeSample(
+<<<'CODE_SAMPLE'
+remove_last_arg(1, 2);
+CODE_SAMPLE
+                ,
+<<<'CODE_SAMPLE'
+remove_last_arg(1);
+CODE_SAMPLE
+                , [
+                    '$argumentPositionByFunctionName' => [
+                        'remove_last_arg' => [1],
+                    ],
+                ]),
+        ]);
+    }
+
+    /**
+     * @return class-string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    /**
+     * @param FuncCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        foreach ($this->argumentPositionByFunctionName as $functionName => $agumentPositions) {
+            if (! $this->isName($node->name, $functionName)) {
+                continue;
+            }
+
+            foreach (array_keys($node->args) as $position) {
+                if (! in_array($position, $agumentPositions, true)) {
+                    continue;
+                }
+
+                unset($node->args[$position]);
+            }
+        }
+
+        return $node;
+    }
+}

--- a/src/Rector/FuncCall/RemoveIniGetSetFuncCallRector.php
+++ b/src/Rector/FuncCall/RemoveIniGetSetFuncCallRector.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\RectorDefinition\ConfiguredCodeSample;
+use Rector\Core\RectorDefinition\RectorDefinition;
+
+/**
+ * @sponsor Thanks https://twitter.com/afilina for sponsoring this rule
+ *
+ * @see \Rector\Core\Tests\Rector\FuncCall\RemoveIniGetSetFuncCallRector\RemoveIniGetSetFuncCallRectorTest
+ */
+final class RemoveIniGetSetFuncCallRector extends AbstractRector
+{
+    /**
+     * @var string[]
+     */
+    private $keysToRemove = [];
+
+    /**
+     * @param string[] $keysToRemove
+     */
+    public function __construct(array $keysToRemove = [])
+    {
+        $this->keysToRemove = $keysToRemove;
+    }
+
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Remove ini_get by configuration', [
+            new ConfiguredCodeSample(
+                <<<'CODE_SAMPLE'
+ini_get('y2k_compliance');
+ini_set('y2k_compliance', 1);
+CODE_SAMPLE
+                ,
+                '',
+                [
+                    '$keysToRemove' => ['y2k_compliance'],
+                ]
+            ), ]
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    /**
+     * @param FuncCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isNames($node, ['ini_get', 'ini_set'])) {
+            return null;
+        }
+
+        if (! isset($node->args[0])) {
+            return null;
+        }
+
+        $keyValue = $this->getValue($node->args[0]->value);
+        if (! in_array($keyValue, $this->keysToRemove, true)) {
+            return null;
+        }
+
+        $this->removeNode($node);
+
+        return null;
+    }
+}

--- a/tests/Rector/FuncCall/RemoveFuncCallArgRector/Fixture/remove_ldap.php.inc
+++ b/tests/Rector/FuncCall/RemoveFuncCallArgRector/Fixture/remove_ldap.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Core\Tests\Rector\FuncCall\RemoveFuncCallArgRector\Fixture;
+
+class SomeClass
+{
+    public function run()
+    {
+        $ber_identifier = 'random_value';
+        $name = ldap_first_attribute($this->_ldap->getResource(), $this->_current, $ber_identifier);
+
+        return $name;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Rector\FuncCall\RemoveFuncCallArgRector\Fixture;
+
+class SomeClass
+{
+    public function run()
+    {
+        $ber_identifier = 'random_value';
+        $name = ldap_first_attribute($this->_ldap->getResource(), $this->_current);
+
+        return $name;
+    }
+}
+
+?>

--- a/tests/Rector/FuncCall/RemoveFuncCallArgRector/RemoveFuncCallArgRectorTest.php
+++ b/tests/Rector/FuncCall/RemoveFuncCallArgRector/RemoveFuncCallArgRectorTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Rector\FuncCall\RemoveFuncCallArgRector;
+
+use Iterator;
+use Rector\Core\Rector\FuncCall\RemoveFuncCallArgRector;
+use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;
+use SplFileInfo;
+
+final class RemoveFuncCallArgRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideDataForTest()
+     */
+    public function test(string $file): void
+    {
+        $this->doTestFile($file);
+    }
+
+    /**
+     * @return Iterator<SplFileInfo>
+     */
+    public function provideDataForTest(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    protected function getRectorsWithConfiguration(): array
+    {
+        return [
+            RemoveFuncCallArgRector::class => [
+                '$argumentPositionByFunctionName' => [
+                    'ldap_first_attribute' => [2],
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/Rector/FuncCall/RemoveIniGetSetFuncCallRector/Fixture/keep_other.php.inc
+++ b/tests/Rector/FuncCall/RemoveIniGetSetFuncCallRector/Fixture/keep_other.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Core\Tests\Rector\FuncCall\RemoveIniGetSetFuncCallRector\Fixture;
+
+ini_get('bla');
+ini_set('y2kcompliance', 0);
+ini_fet('y2kcompliance', 0);
+
+function ini_fet($key, $value)
+{
+}

--- a/tests/Rector/FuncCall/RemoveIniGetSetFuncCallRector/Fixture/remove_listed.php.inc
+++ b/tests/Rector/FuncCall/RemoveIniGetSetFuncCallRector/Fixture/remove_listed.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Core\Tests\Rector\FuncCall\RemoveIniGetSetFuncCallRector\Fixture;
+
+$aRandomVar = false;
+
+ini_get('safe_mode');
+ini_set('y2k_compliance', 1);
+ini_set('magic_quotes_runtime', 0);
+ini_set('safe_mode', $aRandomVar);
+
+?>
+-----
+<?php
+
+namespace Rector\Core\Tests\Rector\FuncCall\RemoveIniGetSetFuncCallRector\Fixture;
+
+$aRandomVar = false;
+
+?>

--- a/tests/Rector/FuncCall/RemoveIniGetSetFuncCallRector/RemoveIniGetSetFuncCallRectorTest.php
+++ b/tests/Rector/FuncCall/RemoveIniGetSetFuncCallRector/RemoveIniGetSetFuncCallRectorTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Rector\FuncCall\RemoveIniGetSetFuncCallRector;
+
+use Iterator;
+use Rector\Core\Rector\FuncCall\RemoveIniGetSetFuncCallRector;
+use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;
+use SplFileInfo;
+
+final class RemoveIniGetSetFuncCallRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideDataForTest()
+     */
+    public function test(string $file): void
+    {
+        $this->doTestFile($file);
+    }
+
+    /**
+     * @return Iterator<SplFileInfo>
+     */
+    public function provideDataForTest(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    protected function getRectorsWithConfiguration(): array
+    {
+        return [
+            RemoveIniGetSetFuncCallRector::class => [
+                '$keysToRemove' => ['y2k_compliance', 'safe_mode', 'magic_quotes_runtime'],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
These rules were created in cooperation with @afilina to help legacy code cleanup