### PR TITLE
[CakePHP] Convert array options to fluent method calls 

### DIFF
--- a/config/set/cakephp/cakephp-fluent-options.yaml
+++ b/config/set/cakephp/cakephp-fluent-options.yaml
@@ -1,0 +1,54 @@
+services:
+    Rector\CakePHP\Rector\MethodCall\ArrayToFluentCallRector:
+        $configurableClasses:
+            'Cake\ORM\Association':
+                bindingKey: setBindingKey
+                cascadeCallbacks: setCascadeCallbacks
+                className: setClassName
+                conditions: setConditions
+                dependent: setDependent
+                finder: setFinder
+                foreignKey: setForeignKey
+                joinType: setJoinType
+                propertyName: setProperty
+                sourceTable: setSource
+                strategy: setStrategy
+                targetTable: setTarget
+
+                # BelongsToMany and HasMany only
+                saveStrategy: setSaveStrategy
+                sort: setSort
+
+                # BelongsToMany only
+                targetForeignKey: setTargetForeignKey
+                through: setThrough
+
+            'Cake\ORM\Query':
+                fields: select
+                conditions: where
+                join: join
+                order: order
+                limit: limit
+                offset: offset
+                group: group
+                having: having
+                contain: contain
+                page: page
+
+        $factoryMethods:
+            'Cake\ORM\Table':
+                belongsTo:
+                    argumentPosition: 2
+                    class: 'Cake\ORM\Association'
+                belongsToMany:
+                    argumentPosition: 2
+                    class: 'Cake\ORM\Association'
+                hasMany:
+                    argumentPosition: 2
+                    class: 'Cake\ORM\Association'
+                hasOne:
+                    argumentPosition: 2
+                    class: 'Cake\ORM\Association'
+                find:
+                    argumentPosition: 2
+                    class: 'Cake\ORM\Query'

--- a/rules/cakephp/src/Rector/MethodCall/ArrayToFluentCallRector.php
+++ b/rules/cakephp/src/Rector/MethodCall/ArrayToFluentCallRector.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CakePHP\Rector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Scalar\String_;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\RectorDefinition\CodeSample;
+use Rector\Core\RectorDefinition\RectorDefinition;
+
+/**
+ * @see \Rector\CakePHP\Tests\Rector\MethodCall\ArrayToFluentCallRector\ArrayToFluentCallRectorTest
+ */
+final class ArrayToFluentCallRector extends AbstractRector
+{
+    /**
+     * @var string
+     */
+    private const ARGUMENT_POSITION = 'argumentPosition';
+
+    /**
+     * @var string
+     */
+    private const CLASSNAME = 'class';
+
+    /**
+     * @var mixed[]
+     */
+    private $configurableClasses = [];
+
+    /**
+     * @var mixed[]
+     */
+    private $factoryMethods = [];
+
+    /**
+     * @param mixed[] $factoryMethods
+     */
+    public function __construct(array $configurableClasses = [], array $factoryMethods = [])
+    {
+        $this->configurableClasses = $configurableClasses;
+        $this->factoryMethods = $factoryMethods;
+    }
+
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Moves array options to fluent setter method calls.', [
+            new CodeSample(
+                <<<'PHP'
+class ArticlesTable extends \Cake\ORM\Table
+{
+    public function initialize(array $config)
+    {
+        $this->belongsTo('Authors', [
+            'foreignKey' => 'author_id',
+            'propertyName' => 'person'
+        ]);
+    }
+}
+PHP
+                ,
+                <<<'PHP'
+class ArticlesTable extends \Cake\ORM\Table
+{
+    public function initialize(array $config)
+    {
+        $this->belongsTo('Authors')
+            ->setForeignKey('author_id')
+            ->setProperty('person');
+    }
+}
+PHP
+            ),
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    /**
+     * @param MethodCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $config = $this->matchTypeAndMethodName($node);
+        if ($config === null) {
+            return null;
+        }
+
+        [$argumentPosition, $class] = $config;
+
+        $fluentMethods = $this->configurableClasses[$class] ?? [];
+        if (! $fluentMethods) {
+            return null;
+        }
+
+        return $this->replaceArrayToFluentMethodCalls($node, $argumentPosition, $fluentMethods);
+    }
+
+    /**
+     * @return mixed[]|null
+     */
+    private function matchTypeAndMethodName(MethodCall $methodCall): ?array
+    {
+        foreach ($this->factoryMethods as $className => $methodName) {
+            if (! $this->isObjectType($methodCall->var, $className)) {
+                continue;
+            }
+
+            /** @var string[] $methodNames */
+            $methodNames = array_keys($methodName);
+            if (! $this->isNames($methodCall->name, $methodNames)) {
+                continue;
+            }
+
+            $currentMethodName = $this->getName($methodCall->name);
+            if ($currentMethodName === null) {
+                continue;
+            }
+
+            $config = $methodName[$currentMethodName];
+            $argumentPosition = $config[self::ARGUMENT_POSITION] ?? 1;
+            $class = $config[self::CLASSNAME];
+
+            return [$argumentPosition, $class];
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string[] $fluentMethods
+     */
+    private function replaceArrayToFluentMethodCalls(
+        MethodCall $methodCall,
+        int $argumentPosition,
+        array $fluentMethods
+    ): ?MethodCall {
+        if (count($methodCall->args) !== $argumentPosition) {
+            return null;
+        }
+
+        $argumentValue = $methodCall->args[$argumentPosition - 1]->value;
+        if (! $argumentValue instanceof Array_) {
+            return null;
+        }
+
+        [$arrayItems, $fluentCalls] = $this->extractFluentMethods($argumentValue->items, $fluentMethods);
+
+        if ($arrayItems) {
+            $argumentValue->items = $arrayItems;
+        } else {
+            unset($methodCall->args[$argumentPosition - 1]);
+        }
+
+        if (! $fluentCalls) {
+            return null;
+        }
+
+        $node = $methodCall;
+
+        foreach ($fluentCalls as $method => $arg) {
+            $args = $this->createArgs([$arg]);
+            $node = $this->createMethodCall($node, $method, $args);
+        }
+
+        return $node;
+    }
+
+    /**
+     * @param ArrayItem[] $originalArrayItems
+     * @param string[] $arrayMap
+     */
+    private function extractFluentMethods(array $originalArrayItems, array $arrayMap): array
+    {
+        $newArrayItems = [];
+        $fluentCalls = [];
+
+        foreach ($originalArrayItems as $arrayItem) {
+            $key = $arrayItem->key;
+
+            if ($key instanceof String_ && isset($arrayMap[$key->value])) {
+                $fluentCalls[$arrayMap[$key->value]] = $arrayItem->value;
+            } else {
+                $newArrayItems[] = $arrayItem;
+            }
+        }
+
+        return [$newArrayItems, $fluentCalls];
+    }
+}

--- a/rules/cakephp/tests/Rector/MethodCall/ArrayToFluentCallRector/ArrayToFluentCallRectorTest.php
+++ b/rules/cakephp/tests/Rector/MethodCall/ArrayToFluentCallRector/ArrayToFluentCallRectorTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\ArrayToFluentCallRector;
+
+use Iterator;
+use Rector\CakePHP\Rector\MethodCall\ArrayToFluentCallRector;
+use Rector\CakePHP\Tests\Rector\MethodCall\ArrayToFluentCallRector\Source\ConfigurableClass;
+use Rector\CakePHP\Tests\Rector\MethodCall\ArrayToFluentCallRector\Source\FactoryClass;
+use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ArrayToFluentCallRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideDataForTest()
+     */
+    public function test(string $file): void
+    {
+        $this->doTestFile($file);
+    }
+
+    public function provideDataForTest(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @return mixed[]
+     */
+    protected function getRectorsWithConfiguration(): array
+    {
+        return [
+            ArrayToFluentCallRector::class => [
+                '$configurableClasses' => [
+                    ConfigurableClass::class => [
+                        'name' => 'setName',
+                        'size' => 'setSize',
+                    ],
+                ],
+                '$factoryMethods' => [
+                    FactoryClass::class => [
+                        'buildClass' => [
+                            'argumentPosition' => 2,
+                            'class' => ConfigurableClass::class,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/rules/cakephp/tests/Rector/MethodCall/ArrayToFluentCallRector/Fixture/fixture.php.inc
+++ b/rules/cakephp/tests/Rector/MethodCall/ArrayToFluentCallRector/Fixture/fixture.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\ArrayToFluentCallRector;
+
+function arrayToFluentCall()
+{
+    $factory = new Source\FactoryClass();
+
+    $factory->buildClass('foo');
+
+    $factory->buildClass('foo', []);
+
+    $factory->buildClass('foo', ['baz' => 1]);
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\ArrayToFluentCallRector;
+
+function arrayToFluentCall()
+{
+    $factory = new Source\FactoryClass();
+
+    $factory->buildClass('foo');
+
+    $factory->buildClass('foo');
+
+    $factory->buildClass('foo', ['baz' => 1]);
+}
+
+?>

--- a/rules/cakephp/tests/Rector/MethodCall/ArrayToFluentCallRector/Fixture/fixture2.php.inc
+++ b/rules/cakephp/tests/Rector/MethodCall/ArrayToFluentCallRector/Fixture/fixture2.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\ArrayToFluentCallRector;
+
+function arrayToFluentCall2()
+{
+    $factory = new Source\FactoryClass();
+
+    $factory->buildClass('foo', [
+        'name' => 'bar',
+        'size' => 2,
+    ]);
+
+    $factory->buildClass('foo', ['name' => 'bar'])
+        ->setSize(3)
+        ->doSomething();
+
+    $factory->buildClass('foo', [
+        'name' => 'bar',
+        'baz' => 4,
+    ]);
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\ArrayToFluentCallRector;
+
+function arrayToFluentCall2()
+{
+    $factory = new Source\FactoryClass();
+
+    $factory->buildClass('foo')->setName('bar')->setSize(2);
+
+    $factory->buildClass('foo')->setName('bar')
+        ->setSize(3)
+        ->doSomething();
+
+    $factory->buildClass('foo', ['baz' => 4])->setName('bar');
+}
+
+?>

--- a/rules/cakephp/tests/Rector/MethodCall/ArrayToFluentCallRector/Source/ConfigurableClass.php
+++ b/rules/cakephp/tests/Rector/MethodCall/ArrayToFluentCallRector/Source/ConfigurableClass.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\ArrayToFluentCallRector\Source;
+
+class ConfigurableClass
+{
+    public function setName(string $name): self
+    {
+        return $this;
+    }
+
+    public function setSize(int $size): self
+    {
+        return $this;
+    }
+
+    public function doSomething(): void
+    {
+    }
+}

--- a/rules/cakephp/tests/Rector/MethodCall/ArrayToFluentCallRector/Source/FactoryClass.php
+++ b/rules/cakephp/tests/Rector/MethodCall/ArrayToFluentCallRector/Source/FactoryClass.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace Rector\CakePHP\Tests\Rector\MethodCall\ArrayToFluentCallRector\Source;
+
+class FactoryClass
+{
+    public function buildClass($arg1, array $options = []): ConfigurableClass
+    {
+        $configurableClass = new ConfigurableClass();
+
+        $configurableClass->setName($options['name']);
+
+        return $configurableClass;
+    }
+}


### PR DESCRIPTION
CakePHP historically used arrays to configure various objects. Since 3.x, it also allows to use chain of fluent method calls to configure them, this also helps to avoid typos, enables type checks.

This rector converts
```php
$this->belongsTo('Authors', [
    'foreignKey' => 'author_id',
    'propertyName' => 'person'
]);
```
into call chain like
```php
$this->belongsTo('Authors')->setForeignKey('author_id')->setProperty('person');
```

Ideally output should be one call per line, but as I understand Rector only manipulates AST, not formatting.
```php
$this->belongsTo('Authors')
    ->setForeignKey('author_id')
    ->setProperty('person');
```