### PR TITLE
PHPStan compatibility fixes

### DIFF
--- a/packages/node-type-resolver/src/PHPStan/Type/TypeFactory.php
+++ b/packages/node-type-resolver/src/PHPStan/Type/TypeFactory.php
@@ -16,6 +16,7 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
+use PHPStan\Type\VerbosityLevel;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\PHPStan\TypeFactoryStaticHelper;
 
@@ -73,7 +74,7 @@ final class TypeFactory
                 $type = $this->removeValueFromConstantType($type);
             }
 
-            $typeHash = md5(serialize($type));
+            $typeHash = md5($type->describe(VerbosityLevel::cache()));
 
             $uniqueTypes[$typeHash] = $type;
         }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -28,9 +28,8 @@ parameters:
 
     checkGenericClassInNonGenericObjectType: false
 
-    autoload_directories:
+    scanDirectories:
         - stubs
-        - compiler/src
 
     paths:
         - bin

--- a/stubs/PHPUnit/Framework/TestListener.php
+++ b/stubs/PHPUnit/Framework/TestListener.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace PHPUnit\Framework;
 
-if (class_exists('PHPUnit\Framework\TestListener')) {
+if (interface_exists('PHPUnit\Framework\TestListener')) {
     return;
 }
 
-final class TestListener
+interface TestListener
 {
 
 }


### PR DESCRIPTION
PHPStan 0.12.26 makes user's lives easier by a mile. See [the release notes](https://github.com/phpstan/phpstan/releases/tag/0.12.26) and [the accompanying article](https://phpstan.org/blog/zero-config-analysis-with-static-reflection).