### PR TITLE
Fix typo in rector_rules_overview.md

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -11770,7 +11770,7 @@ services:
 ↓
 
 ```diff
- class SomeClass
+ class SomeExampleClass
  {
      public function someFunction()
      {

--- a/src/Rector/MethodBody/ReturnThisRemoveRector.php
+++ b/src/Rector/MethodBody/ReturnThisRemoveRector.php
@@ -40,7 +40,7 @@ final class ReturnThisRemoveRector extends AbstractRector
             [
                 new ConfiguredCodeSample(
                     <<<'PHP'
-class SomeClass
+class SomeExampleClass
 {
     public function someFunction()
     {
@@ -55,7 +55,7 @@ class SomeClass
 PHP
                     ,
                     <<<'PHP'
-class SomeClass
+class SomeExampleClass
 {
     public function someFunction()
     {


### PR DESCRIPTION
Change classname in ReturnThisRemoveRector example.
Looks like it should be the same with config in example above.