### PR TITLE
I found a bug with the ChangeNestedForeachIfsToEarlyContinueRector

### DIFF
--- a/rules/solid/tests/Rector/Foreach_/ChangeNestedForeachIfsToEarlyContinueRector/Fixture/comment_inside_if_statement.php.inc
+++ b/rules/solid/tests/Rector/Foreach_/ChangeNestedForeachIfsToEarlyContinueRector/Fixture/comment_inside_if_statement.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace Rector\SOLID\Tests\Rector\Foreach_\ChangeNestedForeachIfsToEarlyContinueRector\Fixture;
+
+class CommentInsideIfStatement
+{
+    public function run()
+    {
+        $items = [];
+
+        foreach ($values as $value) {
+            if ($value === 5) //why am I doing this?
+            {
+                if ($value2 === 10) {
+                    $items[] = 'maybe';
+                }
+            }
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\SOLID\Tests\Rector\Foreach_\ChangeNestedForeachIfsToEarlyContinueRector\Fixture;
+
+class CommentInsideIfStatement
+{
+    public function run()
+    {
+        $items = [];
+
+        foreach ($values as $value) {
+            if ($value !== 5) {
+                //why am I doing this?
+                continue;
+            }
+            if ($value2 !== 10) {
+                continue;
+            }
+            $items[] = 'maybe';
+        }
+    }
+}
+
+?>


### PR DESCRIPTION
When there is a comment inside the if statement before the brace, it misses a brace creating the early continue statement.

https://getrector.org/demo/9757fa4a-ed15-4130-8bdc-ae150305360e