### PR TITLE
Fix regex to account for windows.

### DIFF
--- a/src/Testing/ValueObject/SplitLine.php
+++ b/src/Testing/ValueObject/SplitLine.php
@@ -9,5 +9,5 @@ final class SplitLine
     /**
      * @var string
      */
-    public const SPLIT_LINE = '#-----' . PHP_EOL . '#';
+    public const SPLIT_LINE = "#-----\r?\n#";
 }


### PR DESCRIPTION
The fixtures files are all \n, so when the tests were run from windows none matched with PHP_EOL.
The new regex will match line endings of either OS.

Fixes issue found in pull request https://github.com/rectorphp/rector/pull/3465#issuecomment-642125847 but it seemed separate enough that I thought it should be its own pull request.