### PR TITLE
Don't type hint to traits

### DIFF
--- a/rules/type-declaration/src/Rector/FunctionLike/ParamTypeDeclarationRector.php
+++ b/rules/type-declaration/src/Rector/FunctionLike/ParamTypeDeclarationRector.php
@@ -10,10 +10,12 @@ use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use Rector\Core\RectorDefinition\CodeSample;
 use Rector\Core\RectorDefinition\RectorDefinition;
 use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\PHPStan\Type\ShortenedObjectType;
 use Rector\PHPStanStaticTypeMapper\PHPStanStaticTypeMapper;
 use Rector\TypeDeclaration\ChildPopulator\ChildParamPopulator;
 use Rector\TypeDeclaration\TypeInferer\ParamTypeInferer;
@@ -141,6 +143,16 @@ PHP
         $inferedType = $this->paramTypeInferer->inferParam($param);
         if ($inferedType instanceof MixedType) {
             return;
+        }
+
+        if ($inferedType instanceof ObjectType) {
+            $fqcn = $inferedType instanceof ShortenedObjectType
+                ? $inferedType->getFullyQualifiedName()
+                : $inferedType->getClassName();
+            $reflectionClass = new \ReflectionClass($fqcn);
+            if ($reflectionClass->isTrait()) {
+                return;
+            }
         }
 
         $paramTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode(

--- a/rules/type-declaration/src/Rector/FunctionLike/ParamTypeDeclarationRector.php
+++ b/rules/type-declaration/src/Rector/FunctionLike/ParamTypeDeclarationRector.php
@@ -20,6 +20,7 @@ use Rector\PHPStanStaticTypeMapper\PHPStanStaticTypeMapper;
 use Rector\TypeDeclaration\ChildPopulator\ChildParamPopulator;
 use Rector\TypeDeclaration\TypeInferer\ParamTypeInferer;
 use Rector\TypeDeclaration\ValueObject\NewType;
+use ReflectionClass;
 
 /**
  * @see \Rector\TypeDeclaration\Tests\Rector\FunctionLike\ParamTypeDeclarationRector\ParamTypeDeclarationRectorTest
@@ -149,7 +150,7 @@ PHP
             $fqcn = $inferedType instanceof ShortenedObjectType
                 ? $inferedType->getFullyQualifiedName()
                 : $inferedType->getClassName();
-            $reflectionClass = new \ReflectionClass($fqcn);
+            $reflectionClass = new ReflectionClass($fqcn);
             if ($reflectionClass->isTrait()) {
                 return;
             }

--- a/rules/type-declaration/tests/Rector/FunctionLike/ParamTypeDeclarationRector/Fixture/trait.php.inc
+++ b/rules/type-declaration/tests/Rector/FunctionLike/ParamTypeDeclarationRector/Fixture/trait.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\TypeDeclaration\Tests\Rector\ClassMethod\ParamTypeDeclarationRector\Fixture;
+
+trait SomeTrait
+{
+
+}
+
+class SomeClass
+{
+    /**
+     * @param SomeTrait $param
+     */
+    function someFunction($param)
+    {
+    }
+}
+
+?>


### PR DESCRIPTION
Fixes #3431

I'm not sure about my logic here of checking if it's a trait at all. I tried to use the inferred type's getClassReflection method, but that was null, and I felt like it should not be.