### PR TITLE
[Experimental] Add safe_types option

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,67 @@ parameters:
     php_version_features: '7.2' # your version is 7.3
 ```
 
+### Safe Types
+
+In defualts setting:
+
+```yaml
+# rector.yaml
+parameters:
+    safe_types: false
+```
+
+All docblocks are taken seriously, e.g. with [typed properties](https://github.com/rectorphp/rector/blob/master/docs/rector_rules_overview.md#typedpropertyrector) rule:
+
+```diff
+ <?php
+
+ class ValueObject
+ {
+-    public $value;
++    public string $value;
+
+    /**
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+}
+```
+
+Do you want to use only explicit PHP type declaration? Enable `safe_types`:
+
+```yaml
+# rector.yaml
+parameters:
+    safe_types: true
+```
+
+Then, docblocks are skipped:
+
+```diff
+ <?php
+
+ class ValueObject
+ {
+     public $value;
+
+-    public $count;
++    public int $count;
+
+    /**
+     * @param string $value
+     */
+    public function __construct($value, string $count)
+    {
+        $this->value = $value;
+        $this->count = $count
+    }
+}
+```
+
 ### Import Use Statements
 
 FQN classes are not imported by default. If you don't want to do it manually after every Rector run, enable it by:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -36,3 +36,6 @@ parameters:
 
     # what PHP version is used for features, composer.json version, then local PHP version is used by default
     php_version_features: null
+
+    # false = use types from docblocks; true = only from PHP types, e.g. for typed properties
+    safe_types: false

--- a/packages/node-type-resolver/src/NodeScopeAndMetadataDecorator.php
+++ b/packages/node-type-resolver/src/NodeScopeAndMetadataDecorator.php
@@ -17,15 +17,15 @@ use Rector\NodeTypeResolver\NodeVisitor\NamespaceNodeVisitor;
 use Rector\NodeTypeResolver\NodeVisitor\ParentAndNextNodeVisitor;
 use Rector\NodeTypeResolver\NodeVisitor\PhpDocInfoNodeVisitor;
 use Rector\NodeTypeResolver\NodeVisitor\StatementNodeVisitor;
-use Rector\NodeTypeResolver\PHPStan\Scope\NodeScopeResolver;
+use Rector\NodeTypeResolver\PHPStan\Scope\PHPStanNodeScopeResolver;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class NodeScopeAndMetadataDecorator
 {
     /**
-     * @var NodeScopeResolver
+     * @var PHPStanNodeScopeResolver
      */
-    private $nodeScopeResolver;
+    private $phpStanNodeScopeResolver;
 
     /**
      * @var CloningVisitor
@@ -78,7 +78,7 @@ final class NodeScopeAndMetadataDecorator
     private $methodCallNodeVisitor;
 
     public function __construct(
-        NodeScopeResolver $nodeScopeResolver,
+        PHPStanNodeScopeResolver $phpStanNodeScopeResolver,
         ParentAndNextNodeVisitor $parentAndNextNodeVisitor,
         CloningVisitor $cloningVisitor,
         FunctionMethodAndClassNodeVisitor $functionMethodAndClassNodeVisitor,
@@ -90,7 +90,7 @@ final class NodeScopeAndMetadataDecorator
         Configuration $configuration,
         MethodCallNodeVisitor $methodCallNodeVisitor
     ) {
-        $this->nodeScopeResolver = $nodeScopeResolver;
+        $this->phpStanNodeScopeResolver = $phpStanNodeScopeResolver;
         $this->parentAndNextNodeVisitor = $parentAndNextNodeVisitor;
         $this->cloningVisitor = $cloningVisitor;
         $this->functionMethodAndClassNodeVisitor = $functionMethodAndClassNodeVisitor;
@@ -119,7 +119,7 @@ final class NodeScopeAndMetadataDecorator
 
         // node scoping is needed only for Scope
         if ($needsScope || $this->configuration->areAnyPhpRectorsLoaded()) {
-            $nodes = $this->nodeScopeResolver->processNodes($nodes, $smartFileInfo);
+            $nodes = $this->phpStanNodeScopeResolver->processNodes($nodes, $smartFileInfo);
         }
 
         $nodeTraverser = new NodeTraverser();

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -313,3 +313,4 @@ parameters:
         - '#Cognitive complexity for "Rector\\NetteKdyby\\ContributeEventClassResolver\:\:resolveGetterMethodByEventClassAndParam\(\)" is \d+, keep it under 9#'
         - '#Parameter \#1 \$type of class PhpParser\\Node\\NullableType constructor expects PhpParser\\Node\\Identifier\|PhpParser\\Node\\Name\|string, PhpParser\\Node\\Identifier\|PhpParser\\Node\\Name\|PhpParser\\Node\\NullableType\|PhpParser\\Node\\UnionType given#'
         - '#Parameter \#1 \$oldMethod of class Rector\\PHPOffice\\ValueObject\\ConditionalSetValue constructor expects string, bool\|int\|string given#'
+        - '#Parameter \#2 \$scope of method PHPStan\\Analyser\\NodeScopeResolver\:\:processNodes\(\) expects PHPStan\\Analyser\\MutatingScope, PHPStan\\Analyser\\Scope given#'

--- a/rules/php74/tests/Rector/Property/TypedPropertyRector/FixtureSafeTypes/complete_strict_type.php.inc
+++ b/rules/php74/tests/Rector/Property/TypedPropertyRector/FixtureSafeTypes/complete_strict_type.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\FixtureSafeTypes;
+
+final class CompleteStrictType
+{
+    private $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\FixtureSafeTypes;
+
+final class CompleteStrictType
+{
+    private string $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+}
+
+?>

--- a/rules/php74/tests/Rector/Property/TypedPropertyRector/FixtureSafeTypes/make_sure_docs_is_kept.php.inc
+++ b/rules/php74/tests/Rector/Property/TypedPropertyRector/FixtureSafeTypes/make_sure_docs_is_kept.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\FixtureSafeTypes;
+
+final class MakeSureDocsIsKept
+{
+    private $name;
+
+    /**
+     * @var string
+     */
+    private $surname;
+
+    /**
+     * @param string $surname
+     */
+    public function __construct(string $name, $surname)
+    {
+        $this->name = $name;
+        $this->surname = $surname;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\FixtureSafeTypes;
+
+final class MakeSureDocsIsKept
+{
+    private string $name;
+
+    /**
+     * @var string
+     */
+    private $surname;
+
+    /**
+     * @param string $surname
+     */
+    public function __construct(string $name, $surname)
+    {
+        $this->name = $name;
+        $this->surname = $surname;
+    }
+}
+
+?>

--- a/rules/php74/tests/Rector/Property/TypedPropertyRector/FixtureSafeTypes/skip_for_doc.php.inc
+++ b/rules/php74/tests/Rector/Property/TypedPropertyRector/FixtureSafeTypes/skip_for_doc.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\FixtureSafeTypes;
+
+final class SkipForDoc
+{
+    private $name;
+
+    /**
+     * @param string $name
+     */
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+}

--- a/rules/php74/tests/Rector/Property/TypedPropertyRector/SafeTypesTest.php
+++ b/rules/php74/tests/Rector/Property/TypedPropertyRector/SafeTypesTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector;
+
+use Iterator;
+use Rector\Core\Configuration\Option;
+use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;
+use Rector\Php74\Rector\Property\TypedPropertyRector;
+
+final class SafeTypesTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $file): void
+    {
+        $this->setParameter(Option::SAFE_TYPES, true);
+        $this->doTestFile($file);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/FixtureSafeTypes');
+    }
+
+    protected function getRectorsWithConfiguration(): array
+    {
+        return [
+            TypedPropertyRector::class => [
+                '$classLikeTypeOnly' => false,
+            ],
+        ];
+    }
+}

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -44,6 +44,11 @@ final class Option
     /**
      * @var string
      */
+    public const SAFE_TYPES = 'safe_types';
+
+    /**
+     * @var string
+     */
     public const IMPORT_SHORT_CLASSES_PARAMETER = 'import_short_classes';
 
     /**


### PR DESCRIPTION
Do you want to use only explicit PHP type declaration? Enable `safe_types`:

```yaml
# rector.yaml
parameters:
    safe_types: true
```

Then, **docblocks are skipped** and only pure PHP is source of type truth:

```diff
 <?php

 class ValueObject
 {
     public $value;

-    public $count;
+    public int $count;

     /**
      * @param string $value
      */
     public function __construct($value, string $count)
     {
         $this->value = $value;
         $this->count = $count
     }
 }
```
