### PR TITLE
[PHP] Handle arrow functions in AddDefaultValueForUndefinedVariableRector 

### DIFF
--- a/rules/php56/src/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector.php
+++ b/rules/php56/src/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector.php
@@ -6,6 +6,7 @@ namespace Rector\Php56\Rector\FunctionLike;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrowFunction;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\AssignRef;
 use PhpParser\Node\Expr\Cast\Unset_ as UnsetCast;
@@ -79,7 +80,7 @@ PHP
      */
     public function getNodeTypes(): array
     {
-        return [FunctionLike::class];
+        return [ClassMethod::class, Function_::class, Closure::class];
     }
 
     /**
@@ -117,7 +118,7 @@ PHP
         $undefinedVariables = [];
         $this->traverseNodesWithCallable((array) $node->stmts, function (Node $node) use (&$undefinedVariables): ?int {
             // entering new scope - break!
-            if ($node instanceof FunctionLike) {
+            if ($node instanceof FunctionLike && ! $node instanceof ArrowFunction) {
                 return NodeTraverser::STOP_TRAVERSAL;
             }
 

--- a/rules/php56/tests/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/arrow_function.php.inc
+++ b/rules/php56/tests/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/arrow_function.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\Php56\Tests\Rector\FunctionLike\AddDefaultValueForUndefinedVariableRector\Fixture;
+
+function run()
+{
+    $a = 1;
+    $func = fn($b) => $a + $b + $c;
+
+    return $func(2);
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Php56\Tests\Rector\FunctionLike\AddDefaultValueForUndefinedVariableRector\Fixture;
+
+function run()
+{
+    $c = null;
+    $a = 1;
+    $func = fn($b) => $a + $b + $c;
+
+    return $func(2);
+}
+
+?>


### PR DESCRIPTION
* do not try to set variables in arrow functions, fixes error `Undefined property: PhpParser\Node\Expr\ArrowFunction::$stmts at AddDefaultValueForUndefinedVariableRector.php:118`
* consider that arrow functions inherit the parent scope