### PR TITLE
[PHP 8.0] Add ChangeSwitchToMatchRector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
         "jean85/pretty-package-versions": "^1.2",
         "nette/robot-loader": "^3.2",
         "nette/utils": "^3.1",
-        "nikic/php-parser": "4.6",
+        "nikic/php-parser": "^4.7",
         "ondram/ci-detector": "^3.4",
-        "phpstan/phpdoc-parser": "^0.4.7",
+        "phpstan/phpdoc-parser": "^0.4.8",
         "phpstan/phpstan-phpunit": "^0.12.10",
         "psr/simple-cache": "^1.0",
         "sebastian/diff": "^3.0|^4.0",
@@ -37,7 +37,7 @@
         "symplify/set-config-resolver": "^8.1.15",
         "symplify/smart-file-system": "^8.1.15",
         "tracy/tracy": "^2.7",
-        "phpstan/phpstan": "^0.12.33"
+        "phpstan/phpstan": "^0.12.34"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16",
@@ -54,6 +54,9 @@
         "symplify/monorepo-builder": "^8.1.15",
         "symplify/phpstan-extensions": "^8.1.15",
         "thecodingmachine/phpstan-strict-rules": "^0.12"
+    },
+    "replace": {
+        "rector/rector-prefixed": "self.version"
     },
     "autoload": {
         "psr-4": {

--- a/config/set/php80.php
+++ b/config/set/php80.php
@@ -12,6 +12,7 @@ use Rector\Php80\Rector\FunctionLike\UnionTypesRector;
 use Rector\Php80\Rector\Identical\StrEndsWithRector;
 use Rector\Php80\Rector\Identical\StrStartsWithRector;
 use Rector\Php80\Rector\NotIdentical\StrContainsRector;
+use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
 use Rector\Php80\Rector\Ternary\GetDebugTypeRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
@@ -39,4 +40,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(RemoveUnusedVariableInCatchRector::class);
 
     $services->set(ClassPropertyAssignToConstructorPromotionRector::class);
+
+    $services->set(ChangeSwitchToMatchRector::class);
 };

--- a/docs/nodes_overview.md
+++ b/docs/nodes_overview.md
@@ -376,6 +376,25 @@ list($someVariable)
  * `$items` - `/** @var (ArrayItem|null)[] List of items to assign to */`
 <br>
 
+### `PhpParser\Node\Expr\Match_`
+
+ * requires arguments on construct
+
+
+#### Example PHP Code
+
+```php
+match ($variable) {
+    1 => 'yes',
+}
+```
+
+#### Public Properties
+
+ * `$cond` - `/** @var Node\Expr */`
+ * `$arms` - `/** @var MatchArm[] */`
+<br>
+
 ### `PhpParser\Node\Expr\MethodCall`
 
  * requires arguments on construct
@@ -2507,6 +2526,23 @@ identifier
 
  * `$name` - `/** @var string Identifier as string */`
  * `$specialClassNames` - ``
+<br>
+
+### `PhpParser\Node\MatchArm`
+
+ * requires arguments on construct
+
+
+#### Example PHP Code
+
+```php
+1 => 'yes'
+```
+
+#### Public Properties
+
+ * `$conds` - `/** @var null|Node\Expr[] */`
+ * `$body` - `/** @var Node\Expr */`
 <br>
 
 ### `PhpParser\Node\NullableType`

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# All 541 Rectors Overview
+# All 542 Rectors Overview
 
 - [Projects](#projects)
 ---
@@ -54,7 +54,7 @@
 - [Php72](#php72) (11)
 - [Php73](#php73) (10)
 - [Php74](#php74) (15)
-- [Php80](#php80) (11)
+- [Php80](#php80) (12)
 - [PhpDeglobalize](#phpdeglobalize) (1)
 - [PhpSpecToPHPUnit](#phpspectophpunit) (7)
 - [Polyfill](#polyfill) (2)
@@ -10554,6 +10554,47 @@ Change annotation to attribute
 +<<ORM\Entity>>
  class SomeClass
  {
+ }
+```
+
+<br><br>
+
+### `ChangeSwitchToMatchRector`
+
+- class: [`Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector`](/../master/rules/php80/src/Rector/Switch_/ChangeSwitchToMatchRector.php)
+- [test fixtures](/../master/rules/php80/tests/Rector/Switch_/ChangeSwitchToMatchRector/Fixture)
+
+Change `switch()` to `match()`
+
+```diff
+ class SomeClass
+ {
+     public function run()
+     {
+-        $statement = switch ($this->lexer->lookahead['type']) {
+-            case Lexer::T_SELECT:
+-                $statement = $this->SelectStatement();
+-                break;
+-
+-            case Lexer::T_UPDATE:
+-                $statement = $this->UpdateStatement();
+-                break;
+-
+-            case Lexer::T_DELETE:
+-                $statement = $this->DeleteStatement();
+-                break;
+-
+-            default:
+-                $this->syntaxError('SELECT, UPDATE or DELETE');
+-                break;
+-        }
++        $statement = match ($this->lexer->lookahead['type']) {
++            Lexer::T_SELECT => $this->SelectStatement(),
++            Lexer::T_UPDATE => $this->UpdateStatement(),
++            Lexer::T_DELETE => $this->DeleteStatement(),
++            default => $this->syntaxError('SELECT, UPDATE or DELETE'),
++        };
+     }
  }
 ```
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -318,7 +318,7 @@ parameters:
 
         - '#Method (.*?) specified in iterable type Symfony\\Component\\Process\\Process#'
         - '#Cannot cast PhpParser\\Node\\Expr\\Error\|PhpParser\\Node\\Identifier to string#'
-        - '#Class cognitive complexity for "DumpNodesCommand" is 103, keep it under 50#'
+        - '#Class cognitive complexity for "DumpNodesCommand" is \d+, keep it under 50#'
         - '#Cognitive complexity for "Rector\\Utils\\DocumentationGenerator\\Command\\DumpNodesCommand\:\:execute\(\)" is \d+, keep it under 9#'
 
         - '#Method Rector\\Utils\\DocumentationGenerator\\Node\\NodeClassProvider\:\:getNodeClasses\(\) should return array<class\-string\> but returns array<int, \(int\|string\)\>#'
@@ -379,3 +379,4 @@ parameters:
         - '#Static property Symplify\\PackageBuilder\\Tests\\AbstractKernelTestCase\:\:\$container \(Psr\\Container\\ContainerInterface\) does not accept Rector\\Naming\\Tests\\Rector\\Class_\\RenamePropertyToMatchTypeRector\\Source\\ContainerInterface\|Symfony\\Component\\DependencyInjection\\Container#'
         - '#Static property Rector\\Core\\Testing\\PHPUnit\\AbstractGenericRectorTestCase\:\:\$allRectorContainer \(Rector\\Naming\\Tests\\Rector\\Class_\\RenamePropertyToMatchTypeRector\\Source\\ContainerInterface\|Symfony\\Component\\DependencyInjection\\Container\|null\) does not accept Psr\\Container\\ContainerInterface#'
         - '#Separate function "Symfony\\Component\\DependencyInjection\\Loader\\Configurator\\ref\(\)" in method call to standalone row to improve readability#'
+        - '#Class with base "(.*?)" name is already used in "_HumbugBox(.*?)#'

--- a/rules/php80/src/Rector/Switch_/ChangeSwitchToMatchRector.php
+++ b/rules/php80/src/Rector/Switch_/ChangeSwitchToMatchRector.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Php80\Rector\Switch_;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\Match_;
+use PhpParser\Node\MatchArm;
+use PhpParser\Node\Stmt\Break_;
+use PhpParser\Node\Stmt\Case_;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Switch_;
+use Rector\Core\Exception\ShouldNotHappenException;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\RectorDefinition\CodeSample;
+use Rector\Core\RectorDefinition\RectorDefinition;
+
+/**
+ * @see https://wiki.php.net/rfc/match_expression_v2
+ *
+ * @see \Rector\Php80\Tests\Rector\Switch_\ChangeSwitchToMatchRector\ChangeSwitchToMatchRectorTest
+ */
+final class ChangeSwitchToMatchRector extends AbstractRector
+{
+    /**
+     * @var Expr|null
+     */
+    private $assignExpr;
+
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Change switch() to match()', [
+            new CodeSample(
+                <<<'PHP'
+class SomeClass
+{
+    public function run()
+    {
+        $statement = switch ($this->lexer->lookahead['type']) {
+            case Lexer::T_SELECT:
+                $statement = $this->SelectStatement();
+                break;
+
+            case Lexer::T_UPDATE:
+                $statement = $this->UpdateStatement();
+                break;
+
+            case Lexer::T_DELETE:
+                $statement = $this->DeleteStatement();
+                break;
+
+            default:
+                $this->syntaxError('SELECT, UPDATE or DELETE');
+                break;
+        }
+    }
+}
+PHP
+,
+                <<<'PHP'
+class SomeClass
+{
+    public function run()
+    {
+        $statement = match ($this->lexer->lookahead['type']) {
+            Lexer::T_SELECT => $this->SelectStatement(),
+            Lexer::T_UPDATE => $this->UpdateStatement(),
+            Lexer::T_DELETE => $this->DeleteStatement(),
+            default => $this->syntaxError('SELECT, UPDATE or DELETE'),
+        };
+    }
+}
+PHP
+
+            ),
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [Switch_::class];
+    }
+
+    /**
+     * @param Switch_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $this->assignExpr = null;
+
+        if (! $this->hasEachCaseBreak($node)) {
+            return null;
+        }
+
+        if (! $this->hasSingleStmtCases($node)) {
+            return null;
+        }
+
+        if (! $this->hasSingleAssignVariableInStmtCase($node)) {
+            return null;
+        }
+
+        $matchArms = $this->createMatchArmsFromCases($node->cases);
+        $match = new Match_($node->cond, $matchArms);
+        if ($this->assignExpr) {
+            return new Assign($this->assignExpr, $match);
+        }
+
+        return $match;
+    }
+
+    private function hasEachCaseBreak(Switch_ $switch): bool
+    {
+        foreach ($switch->cases as $case) {
+            foreach ($case->stmts as $caseStmt) {
+                if (! $caseStmt instanceof Break_) {
+                    continue;
+                }
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param Case_[] $cases
+     * @return MatchArm[]
+     */
+    private function createMatchArmsFromCases(array $cases): array
+    {
+        $matchArms = [];
+        foreach ($cases as $case) {
+            $stmt = $case->stmts[0];
+            if (! $stmt instanceof Expression) {
+                throw new ShouldNotHappenException();
+            }
+
+            $expr = $stmt->expr;
+
+            if ($expr instanceof Assign) {
+                $this->assignExpr = $expr->var;
+                $expr = $expr->expr;
+            }
+
+            $condList = $case->cond === null ? null : [$case->cond];
+            $matchArms[] = new MatchArm($condList, $expr);
+        }
+
+        return $matchArms;
+    }
+
+    private function hasSingleStmtCases(Switch_ $switch): bool
+    {
+        foreach ($switch->cases as $case) {
+            $stmtsWithoutBreak = array_filter($case->stmts, function (Node $node) {
+                return ! $node instanceof Break_;
+            });
+
+            if (count($stmtsWithoutBreak) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function hasSingleAssignVariableInStmtCase(Switch_ $switch): bool
+    {
+        $assignVariableNames = [];
+
+        foreach ($switch->cases as $case) {
+            /** @var Expression $onlyStmt */
+            $onlyStmt = $case->stmts[0];
+            $expr = $onlyStmt->expr;
+
+            if (! $expr instanceof Assign) {
+                continue;
+            }
+
+            $assignVariableNames[] = $this->getName($expr->var);
+        }
+
+        $assignVariableNames = array_unique($assignVariableNames);
+
+        return count($assignVariableNames) <= 1;
+    }
+}

--- a/rules/php80/tests/Rector/Switch_/ChangeSwitchToMatchRector/ChangeSwitchToMatchRectorTest.php
+++ b/rules/php80/tests/Rector/Switch_/ChangeSwitchToMatchRector/ChangeSwitchToMatchRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Php80\Tests\Rector\Switch_\ChangeSwitchToMatchRector;
+
+use Iterator;
+use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;
+use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class ChangeSwitchToMatchRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    protected function getRectorClass(): string
+    {
+        return ChangeSwitchToMatchRector::class;
+    }
+}

--- a/rules/php80/tests/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/fixture.php.inc
+++ b/rules/php80/tests/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/fixture.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rector\Php80\Tests\Rector\Switch_\ChangeSwitchToMatchRector\Fixture;
+
+class SomeClass
+{
+    public function run()
+    {
+        switch ($this->lexer->lookahead['type']) {
+            case Lexer::T_DELETE:
+                $statement = $this->DeleteStatement();
+                break;
+
+            default:
+                $this->syntaxError('SELECT, UPDATE or DELETE');
+                break;
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Php80\Tests\Rector\Switch_\ChangeSwitchToMatchRector\Fixture;
+
+class SomeClass
+{
+    public function run()
+    {
+        $statement = match ($this->lexer->lookahead['type']) {
+            Lexer::T_DELETE => $this->DeleteStatement(),
+            default => $this->syntaxError('SELECT, UPDATE or DELETE'),
+        };
+    }
+}
+
+?>

--- a/rules/php80/tests/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/skip_2_and_more_stmts.php.inc
+++ b/rules/php80/tests/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/skip_2_and_more_stmts.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Php80\Tests\Rector\Switch_\ChangeSwitchToMatchRector\Fixture;
+
+class Skip2AndMoreStmts
+{
+    public function run()
+    {
+        switch ($this->lexer->lookahead['type']) {
+            case Lexer::T_DELETE:
+                $statement = $this->DeleteStatement();
+                $statement = $this->DeleteStatement();
+            break;
+        }
+    }
+}

--- a/rules/php80/tests/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/skip_different_variable_assign.php.inc
+++ b/rules/php80/tests/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/skip_different_variable_assign.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Php80\Tests\Rector\Switch_\ChangeSwitchToMatchRector\Fixture;
+
+class SkipDifferentVariableAssign
+{
+    public function run()
+    {
+        switch ($this->lexer->lookahead['type']) {
+            case 'a':
+                $statementA = $this->DeleteStatement();
+            case 'b':
+                $statementB = $this->DeleteStatement();
+            break;
+        }
+    }
+}

--- a/rules/php80/tests/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/skip_missing_break.php.inc
+++ b/rules/php80/tests/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/skip_missing_break.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Php80\Tests\Rector\Switch_\ChangeSwitchToMatchRector\Fixture;
+
+class SkipMissingBreak
+{
+    public function run()
+    {
+        switch ($this->lexer->lookahead['type']) {
+            case Lexer::T_DELETE:
+                $statement = $this->DeleteStatement();
+        }
+    }
+}

--- a/utils/documentation-generator/src/Command/DumpNodesCommand.php
+++ b/utils/documentation-generator/src/Command/DumpNodesCommand.php
@@ -31,6 +31,7 @@ use PhpParser\Node\Expr\Include_;
 use PhpParser\Node\Expr\Instanceof_;
 use PhpParser\Node\Expr\Isset_;
 use PhpParser\Node\Expr\List_;
+use PhpParser\Node\Expr\Match_;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\PostDec;
@@ -48,6 +49,7 @@ use PhpParser\Node\Expr\UnaryPlus;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Expr\YieldFrom;
 use PhpParser\Node\Identifier;
+use PhpParser\Node\MatchArm;
 use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\NullableType;
@@ -244,6 +246,8 @@ final class DumpNodesCommand extends AbstractCommand
                 $useUseNode = new UseUse(new Name('UsedNamespace'));
                 $someVariableNode = new Variable(self::SOME_VARIABLE);
 
+                $matchArm = new MatchArm([new LNumber(1)], new String_('yes'));
+
                 if ($nodeClass === NullableType::class) {
                     $node = new NullableType('SomeType');
                 } elseif ($nodeClass === Const_::class) {
@@ -270,6 +274,10 @@ final class DumpNodesCommand extends AbstractCommand
                     $node = new TraitUse([new Name('trait')]);
                 } elseif ($nodeClass === Switch_::class) {
                     $node = new Switch_(new Variable(self::VARIABLE), [new Case_(new LNumber(1))]);
+                } elseif ($nodeClass === Match_::class) {
+                    $node = new Match_(new Variable(self::VARIABLE), [$matchArm]);
+                } elseif ($nodeClass === MatchArm::class) {
+                    $node = $matchArm;
                 } elseif ($nodeClass === Echo_::class) {
                     $node = new Echo_([new String_('hello')]);
                 } elseif ($nodeClass === StaticVar::class) {


### PR DESCRIPTION
Covers https://github.com/nikic/PHP-Parser/pull/672, https://wiki.php.net/rfc/match_expression_v2

```diff
 class SomeClass
 {
     public function run()
     {
-        $statement = switch ($this->lexer->lookahead['type']) {
-            case Lexer::T_SELECT:
-                $statement = $this->SelectStatement();
-                break;
-            default:
-                $this->syntaxError('SELECT, UPDATE or DELETE');
-                break;
-        }
+        $statement = match ($this->lexer->lookahead['type']) {
+            Lexer::T_SELECT => $this->SelectStatement(),
+            default => $this->syntaxError('SELECT, UPDATE or DELETE'),
+        };
     }
 }
```

Ref #3127 