### PR TITLE
Boolean Operands cause ChangeNestedForeachIfsToEarlyContinueRector to…

### DIFF
--- a/rules/solid/tests/Rector/Foreach_/ChangeNestedForeachIfsToEarlyContinueRector/Fixture/multi_exprs_with_bool_oprnds.php.inc
+++ b/rules/solid/tests/Rector/Foreach_/ChangeNestedForeachIfsToEarlyContinueRector/Fixture/multi_exprs_with_bool_oprnds.php.inc
@@ -38,7 +38,7 @@ class MultiExprsWithBoolOprnds implements RunnableInterface
 {
     public function run()
     {
-        $partPackageList = [ new \StdClass(), null, 'string', 0, [] ];
+        $partPackageList = [ new \StdClass(), 'string' ];
         $payload = [];
 
         foreach ($partPackageList as $partPackage) {

--- a/rules/solid/tests/Rector/Foreach_/ChangeNestedForeachIfsToEarlyContinueRector/Fixture/multi_exprs_with_bool_oprnds.php.inc
+++ b/rules/solid/tests/Rector/Foreach_/ChangeNestedForeachIfsToEarlyContinueRector/Fixture/multi_exprs_with_bool_oprnds.php.inc
@@ -8,7 +8,7 @@ class MultiExprsWithBoolOprnds implements RunnableInterface
 {
     public function run()
     {
-        $partPackageList = [ new \StdClass(), null, 'string', 0, [] ];
+        $partPackageList = [ new \StdClass(), 'string' ];
         $payload = [];
 
         foreach( $partPackageList as $partPackage )

--- a/rules/solid/tests/Rector/Foreach_/ChangeNestedForeachIfsToEarlyContinueRector/Fixture/multi_exprs_with_bool_oprnds.php.inc
+++ b/rules/solid/tests/Rector/Foreach_/ChangeNestedForeachIfsToEarlyContinueRector/Fixture/multi_exprs_with_bool_oprnds.php.inc
@@ -1,0 +1,65 @@
+<?php
+
+namespace Rector\SOLID\Tests\Rector\Foreach_\ChangeNestedForeachIfsToEarlyContinueRector\Fixture;
+
+use Rector\Core\Testing\Contract\RunnableInterface;
+
+class MultiExprsWithBoolOprnds implements RunnableInterface
+{
+    public function run()
+    {
+        $loaded = true;
+        $usePackages = true;
+        $notBad = true;
+        $partPackageList = [ new \StdClass(), null, 'string', 0, [] ];
+        $payload = [];
+
+        foreach( $partPackageList as $partPackage )
+        {
+            if(! is_null( $partPackage ) && ! is_object($partPackage) )
+            {
+                if ($loaded || ($usePackages && $notBad))
+                {
+                    $payload[] = $partPackage;
+                }
+            }
+        }
+
+        return json_encode($payload);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\SOLID\Tests\Rector\Foreach_\ChangeNestedForeachIfsToEarlyContinueRector\Fixture;
+
+use Rector\Core\Testing\Contract\RunnableInterface;
+
+class MultiExprsWithBoolOprnds implements RunnableInterface
+{
+    public function run()
+    {
+        $loaded = true;
+        $usePackages = true;
+        $notBad = true;
+        $partPackageList = [ new \StdClass(), null, 'string', 0, [] ];
+        $payload = [];
+
+        foreach ($partPackageList as $partPackage) {
+            if (!! is_null( $partPackage )) {
+            }
+            if (!! is_object($partPackage)) {
+            }
+            if ($loaded && ($usePackages && $notBad)) {
+                continue;
+            }
+            $payload[] = $partPackage;
+        }
+
+        return json_encode($payload);
+    }
+}
+
+?>

--- a/rules/solid/tests/Rector/Foreach_/ChangeNestedForeachIfsToEarlyContinueRector/Fixture/multi_exprs_with_bool_oprnds.php.inc
+++ b/rules/solid/tests/Rector/Foreach_/ChangeNestedForeachIfsToEarlyContinueRector/Fixture/multi_exprs_with_bool_oprnds.php.inc
@@ -8,9 +8,6 @@ class MultiExprsWithBoolOprnds implements RunnableInterface
 {
     public function run()
     {
-        $loaded = true;
-        $usePackages = true;
-        $notBad = true;
         $partPackageList = [ new \StdClass(), null, 'string', 0, [] ];
         $payload = [];
 
@@ -18,7 +15,7 @@ class MultiExprsWithBoolOprnds implements RunnableInterface
         {
             if(! is_null( $partPackage ) && ! is_object($partPackage) )
             {
-                if ($loaded || ($usePackages && $notBad))
+                if (1 == '1' || 2 == 't')
                 {
                     $payload[] = $partPackage;
                 }
@@ -41,9 +38,6 @@ class MultiExprsWithBoolOprnds implements RunnableInterface
 {
     public function run()
     {
-        $loaded = true;
-        $usePackages = true;
-        $notBad = true;
         $partPackageList = [ new \StdClass(), null, 'string', 0, [] ];
         $payload = [];
 
@@ -52,7 +46,7 @@ class MultiExprsWithBoolOprnds implements RunnableInterface
             }
             if (!! is_object($partPackage)) {
             }
-            if ($loaded && ($usePackages && $notBad)) {
+            if (1 == '1' && 2 == 't') {
                 continue;
             }
             $payload[] = $partPackage;


### PR DESCRIPTION
… produce code that gives a different output from the original code.