### PR TITLE
Symfony FormTypeInstanceToClassConstRector: Include AbstractController in allowed object types

### DIFF
--- a/rules/symfony/src/Rector/MethodCall/FormTypeInstanceToClassConstRector.php
+++ b/rules/symfony/src/Rector/MethodCall/FormTypeInstanceToClassConstRector.php
@@ -86,11 +86,20 @@ PHP
      */
     public function refactor(Node $node): ?Node
     {
-        if ($this->isObjectTypes($node->var, ['Symfony\Bundle\FrameworkBundle\Controller\Controller', 'Symfony\Bundle\FrameworkBundle\Controller\AbstractController']) && $this->isName($node->name, 'createForm')) {
+        if ($this->isObjectTypes(
+            $node->var,
+            [
+                'Symfony\Bundle\FrameworkBundle\Controller\Controller',
+                'Symfony\Bundle\FrameworkBundle\Controller\AbstractController',
+            ]
+        ) && $this->isName($node->name, 'createForm')) {
             return $this->processNewInstance($node, 0, 2);
         }
 
-        if (! $this->isObjectTypes($node->var, ['Symfony\Component\Form\FormBuilderInterface', 'Symfony\Component\Form\FormInterface'])) {
+        if (! $this->isObjectTypes(
+            $node->var,
+            ['Symfony\Component\Form\FormBuilderInterface', 'Symfony\Component\Form\FormInterface']
+        )) {
             return null;
         }
 

--- a/rules/symfony/src/Rector/MethodCall/FormTypeInstanceToClassConstRector.php
+++ b/rules/symfony/src/Rector/MethodCall/FormTypeInstanceToClassConstRector.php
@@ -26,11 +26,6 @@ use Rector\Core\Rector\AbstractRector;
 use Rector\Core\RectorDefinition\CodeSample;
 use Rector\Core\RectorDefinition\RectorDefinition;
 use ReflectionClass;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormInterface;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @see https://github.com/symfony/symfony/commit/adf20c86fb0d8dc2859aa0d2821fe339d3551347
@@ -91,11 +86,11 @@ PHP
      */
     public function refactor(Node $node): ?Node
     {
-        if ($this->isObjectTypes($node->var, [Controller::class, AbstractController::class]) && $this->isName($node->name, 'createForm')) {
+        if ($this->isObjectTypes($node->var, ['Symfony\Bundle\FrameworkBundle\Controller\Controller', 'Symfony\Bundle\FrameworkBundle\Controller\AbstractController']) && $this->isName($node->name, 'createForm')) {
             return $this->processNewInstance($node, 0, 2);
         }
 
-        if (! $this->isObjectTypes($node->var, [FormBuilderInterface::class, FormInterface::class])) {
+        if (! $this->isObjectTypes($node->var, ['Symfony\Component\Form\FormBuilderInterface', 'Symfony\Component\Form\FormInterface'])) {
             return null;
         }
 
@@ -219,7 +214,7 @@ PHP
         }
 
         $formBuilderParamBuilder = $this->builderFactory->param('builder');
-        $formBuilderParamBuilder->setType(new FullyQualified(FormBuilderInterface::class));
+        $formBuilderParamBuilder->setType(new FullyQualified('Symfony\Component\Form\FormBuilderInterface'));
 
         $formBuilderParam = $formBuilderParamBuilder->getNode();
 
@@ -253,7 +248,7 @@ PHP
         }
 
         $resolverParamBuilder = $this->builderFactory->param('resolver');
-        $resolverParamBuilder->setType(new FullyQualified(OptionsResolver::class));
+        $resolverParamBuilder->setType(new FullyQualified('Symfony\Component\OptionsResolver\OptionsResolver'));
 
         $resolverParam = $resolverParamBuilder->getNode();
 

--- a/rules/symfony/src/Rector/MethodCall/FormTypeInstanceToClassConstRector.php
+++ b/rules/symfony/src/Rector/MethodCall/FormTypeInstanceToClassConstRector.php
@@ -26,6 +26,7 @@ use Rector\Core\Rector\AbstractRector;
 use Rector\Core\RectorDefinition\CodeSample;
 use Rector\Core\RectorDefinition\RectorDefinition;
 use ReflectionClass;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
@@ -90,7 +91,7 @@ PHP
      */
     public function refactor(Node $node): ?Node
     {
-        if ($this->isObjectType($node->var, Controller::class) && $this->isName($node->name, 'createForm')) {
+        if ($this->isObjectTypes($node->var, [Controller::class, AbstractController::class]) && $this->isName($node->name, 'createForm')) {
             return $this->processNewInstance($node, 0, 2);
         }
 

--- a/tests/Rector/MethodBody/FluentReplaceRector/FluentReplaceRectorTest.php
+++ b/tests/Rector/MethodBody/FluentReplaceRector/FluentReplaceRectorTest.php
@@ -7,7 +7,6 @@ namespace Rector\Core\Tests\Rector\MethodBody\FluentReplaceRector;
 use Iterator;
 use Rector\Core\Rector\MethodBody\FluentReplaceRector;
 use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;
-use Rector\Core\Tests\Rector\MethodBody\FluentReplaceRector\Source\FluentInterfaceClass;
 use Rector\Core\Tests\Rector\MethodBody\FluentReplaceRector\Source\FluentInterfaceClassInterface;
 
 final class FluentReplaceRectorTest extends AbstractRectorTestCase


### PR DESCRIPTION
Fixes #3570 by adding `Symfony\Bundle\FrameworkBundle\Controller\AbstractController` as a valid object type.