### PR TITLE
[CodingStyle] Make UnderscoreToPascalCaseVariableNameRector skip native variables, like _SERVER

### DIFF
--- a/rules/coding-style/src/Rector/Variable/UnderscoreToPascalCaseVariableNameRector.php
+++ b/rules/coding-style/src/Rector/Variable/UnderscoreToPascalCaseVariableNameRector.php
@@ -7,6 +7,7 @@ namespace Rector\CodingStyle\Rector\Variable;
 use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Variable;
+use Rector\Core\Php\ReservedKeywordAnalyzer;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\RectorDefinition\CodeSample;
 use Rector\Core\RectorDefinition\RectorDefinition;
@@ -17,6 +18,16 @@ use Rector\Core\Util\StaticRectorStrings;
  */
 final class UnderscoreToPascalCaseVariableNameRector extends AbstractRector
 {
+    /**
+     * @var ReservedKeywordAnalyzer
+     */
+    private $reservedKeywordAnalyzer;
+
+    public function __construct(ReservedKeywordAnalyzer $reservedKeywordAnalyzer)
+    {
+        $this->reservedKeywordAnalyzer = $reservedKeywordAnalyzer;
+    }
+
     public function getDefinition(): RectorDefinition
     {
         return new RectorDefinition('Change under_score names to pascalCase', [
@@ -64,6 +75,10 @@ PHP
         }
 
         if (! Strings::contains($nodeName, '_')) {
+            return null;
+        }
+
+        if ($this->reservedKeywordAnalyzer->isNativeVariable($nodeName)) {
             return null;
         }
 

--- a/rules/coding-style/tests/Rector/Variable/UnderscoreToPascalCaseVariableNameRector/Fixture/skip_underscored_reserved_names.php.inc
+++ b/rules/coding-style/tests/Rector/Variable/UnderscoreToPascalCaseVariableNameRector/Fixture/skip_underscored_reserved_names.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\CodingStyle\Tests\Rector\Variable\UnderscoreToPascalCaseVariableNameRector\Fixture;
+
+final class SkipUnderscoredReservedNames
+{
+    public function run()
+    {
+        return $_SERVER['host'];
+    }
+}

--- a/src/Php/ReservedKeywordAnalyzer.php
+++ b/src/Php/ReservedKeywordAnalyzer.php
@@ -81,6 +81,16 @@ final class ReservedKeywordAnalyzer
         'yield',
     ];
 
+    /**
+     * @var string[]
+     */
+    private const NATIVE_VARIABLE_NAMES = ['_ENV', '_POST', '_GET', '_COOKIE', '_SERVER', '_FILES', '_REQUEST'];
+
+    public function isNativeVariable(string $name): bool
+    {
+        return in_array($name, self::NATIVE_VARIABLE_NAMES, true);
+    }
+
     public function isReserved(string $keyword): bool
     {
         $keyword = strtolower($keyword);


### PR DESCRIPTION
Follow up to #https://github.com/rectorphp/rector/pull/3653