### PR TITLE
[MockeryToProphecy]  Remove close call to mockery from test classes

### DIFF
--- a/rules/mockery-to-prophecy/src/Rector/StaticCall/MockeryCloseRemoveRector.php
+++ b/rules/mockery-to-prophecy/src/Rector/StaticCall/MockeryCloseRemoveRector.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\MockeryToProphecy\Rector\StaticCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\StaticCall;
+use Rector\Core\Rector\AbstractPHPUnitRector;
+use Rector\Core\RectorDefinition\CodeSample;
+use Rector\Core\RectorDefinition\RectorDefinition;
+
+/**
+ * @see \Rector\MockeryToProphecy\Tests\Rector\StaticCall\MockeryToProphecyRector\MockeryToProphecyRectorTest
+ */
+final class MockeryCloseRemoveRector extends AbstractPHPUnitRector
+{
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [StaticCall::class];
+    }
+
+    /**
+     * @param StaticCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->isInTestClass($node)) {
+            return null;
+        }
+
+        if (! $this->isStaticCallNamed($node, 'Mockery', 'close')) {
+            return null;
+        }
+
+        $this->removeNode($node);
+
+        return null;
+    }
+
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition(
+            'Removes mockery close from test classes',
+            [
+                new CodeSample(
+                    <<<'PHP'
+public function tearDown() : void
+{
+    \Mockery::close();
+}
+PHP,
+                    <<<'PHP'
+public function tearDown() : void
+{
+}
+PHP
+                ),
+            ]
+        );
+    }
+}

--- a/rules/mockery-to-prophecy/tests/Rector/StaticCall/MockeryToProphecyRector/Fixture/MockeryClose.php.inc
+++ b/rules/mockery-to-prophecy/tests/Rector/StaticCall/MockeryToProphecyRector/Fixture/MockeryClose.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\MockeryToProphecy\Tests\Rector\StaticCall\MockeryToProphecyRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class MockeryClose extends TestCase
+{
+    public function tearDown(): void
+    {
+        \Mockery::close();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\MockeryToProphecy\Tests\Rector\StaticCall\MockeryToProphecyRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class MockeryClose extends TestCase
+{
+    public function tearDown(): void
+    {
+    }
+}
+
+?>

--- a/rules/mockery-to-prophecy/tests/Rector/StaticCall/MockeryToProphecyRector/MockeryToProphecyRectorTest.php
+++ b/rules/mockery-to-prophecy/tests/Rector/StaticCall/MockeryToProphecyRector/MockeryToProphecyRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\MockeryToProphecy\Tests\Rector\StaticCall\MockeryToProphecyRector;
+
+use Iterator;
+use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;
+use Rector\MockeryToProphecy\Rector\StaticCall\MockeryCloseRemoveRector;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class MockeryToProphecyRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $file): void
+    {
+        $this->doTestFileInfo($file);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    protected function getRectorClass(): string
+    {
+        return MockeryCloseRemoveRector::class;
+    }
+}


### PR DESCRIPTION
A second step in removing mockery, remove the call to `\Mockery::close()`