### PR TITLE
Prevent negative values for IndentLevel

### DIFF
--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -154,6 +154,7 @@ final class BetterStandardPrinter extends Standard
      */
     protected function setIndentLevel(int $level): void
     {
+        $level = max($level, 0);
         $this->indentLevel = $level;
         $this->nl = "\n" . str_repeat($this->tabOrSpaceIndentCharacter, $level);
     }


### PR DESCRIPTION
This fixes the following warning.

Warning: str_repeat(): Second argument has to be greater than or equal to 0 in vendor\rector\rector\src\PhpParser\Printer\BetterStandardPrinter.php on line 158

Not sure why my source is producing this, but very old PHP 4 -> 5.6 code that is poorly formatted.  I may be able to come up with a case that reproduces it, but it does not seem worth the effort, as it is a very local fix and should not impact anything else.