### PR TITLE
[Legacy] Adding RemoveIncludeRector

### DIFF
--- a/rules/legacy/src/Rector/Include_/RemoveIncludeRector.php
+++ b/rules/legacy/src/Rector/Include_/RemoveIncludeRector.php
@@ -29,7 +29,7 @@ final class RemoveIncludeRector extends AbstractRector
                 new CodeSample(
                                         <<<'PHP'
 // Comment before require
-return 'somefile.php';
+include 'somefile.php';
 // Comment after require
 PHP
                                 ,

--- a/rules/legacy/src/Rector/Include_/RemoveIncludeRector.php
+++ b/rules/legacy/src/Rector/Include_/RemoveIncludeRector.php
@@ -18,10 +18,6 @@ use Rector\Core\RectorDefinition\RectorDefinition;
  */
 final class RemoveIncludeRector extends AbstractRector
 {
-    /**
-     * From this method documentation is generated.
-     * @return string[]
-     */
     public function getDefinition(): RectorDefinition
     {
         return new RectorDefinition(

--- a/rules/legacy/src/Rector/Include_/RemoveIncludeRector.php
+++ b/rules/legacy/src/Rector/Include_/RemoveIncludeRector.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Legacy\Rector\Include_;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Include_;
+use PhpParser\Node\Stmt\Nop;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\RectorDefinition\CodeSample;
+use Rector\Core\RectorDefinition\RectorDefinition;
+
+/**
+ * @see https://github.com/rectorphp/rector/issues/3679
+ *
+ * @see \Rector\Legacy\Tests\Rector\Include_\RemoveIncludeRector\RemoveIncludeRectorTest
+ */
+final class RemoveIncludeRector extends AbstractRector
+{
+    /**
+     * From this method documentation is generated.
+     * @return string[]
+     */
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition(
+            'Remove includes (include, include_once, require, require_once) from source', [
+                new CodeSample(
+                                        <<<'PHP'
+// Comment before require
+return 'somefile.php';
+// Comment after require
+PHP
+                                ,
+                                <<<'PHP'
+// Comment before require
+
+// Comment after require
+PHP
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [Include_::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        $nopWithAttributes = new Nop();
+        $comments = $node->getAttribute('comments');
+        if ($comments) {
+            $nopWithAttributes->setAttribute('comments', $comments);
+            $this->addNodeAfterNode($nopWithAttributes, $node);
+        }
+        $this->removeNode($node);
+
+        return $node;
+    }
+}

--- a/rules/legacy/tests/Rector/Include_/RemoveIncludeRector/Fixture/fixture.php.inc
+++ b/rules/legacy/tests/Rector/Include_/RemoveIncludeRector/Fixture/fixture.php.inc
@@ -2,8 +2,9 @@
 
 namespace Rector\Legacy\Tests\Rector\Include_\RemoveIncludeRector\Fixture;
 
+$files = glob(__DIR__ . '/expect*.php');
 // comment before include
-include 'somefile.php';
+include array_pop($files);
 // comment after include
 
 ?>
@@ -12,6 +13,7 @@ include 'somefile.php';
 
 namespace Rector\Legacy\Tests\Rector\Include_\RemoveIncludeRector\Fixture;
 
+$files = glob(__DIR__ . '/expect*.php');
 // comment before include
 
 // comment after include

--- a/rules/legacy/tests/Rector/Include_/RemoveIncludeRector/Fixture/fixture.php.inc
+++ b/rules/legacy/tests/Rector/Include_/RemoveIncludeRector/Fixture/fixture.php.inc
@@ -2,20 +2,20 @@
 
 namespace Rector\Legacy\Tests\Rector\Include_\RemoveIncludeRector\Fixture;
 
-$files = glob(__DIR__ . '/expect*.php');
+file_put_contents('somefile.php', '<?php // some comment');
 // comment before include
-include array_pop($files);
+include 'somefile.php';
 // comment after include
-
+unlink('somefile.php');
 ?>
 -----
 <?php
 
 namespace Rector\Legacy\Tests\Rector\Include_\RemoveIncludeRector\Fixture;
 
-$files = glob(__DIR__ . '/expect*.php');
+file_put_contents('somefile.php', '<?php // some comment');
 // comment before include
 
 // comment after include
-
+unlink('somefile.php');
 ?>

--- a/rules/legacy/tests/Rector/Include_/RemoveIncludeRector/Fixture/fixture.php.inc
+++ b/rules/legacy/tests/Rector/Include_/RemoveIncludeRector/Fixture/fixture.php.inc
@@ -2,20 +2,32 @@
 
 namespace Rector\Legacy\Tests\Rector\Include_\RemoveIncludeRector\Fixture;
 
-file_put_contents('somefile.php', '<?php // some comment');
-// comment before include
+class SomeClass
+{
+
+    private function someMethod() : void
+    {
+        // comment before include
 include 'somefile.php';
-// comment after include
-unlink('somefile.php');
+        // comment after include
+    }
+
+}
 ?>
 -----
 <?php
 
 namespace Rector\Legacy\Tests\Rector\Include_\RemoveIncludeRector\Fixture;
 
-file_put_contents('somefile.php', '<?php // some comment');
-// comment before include
+class SomeClass
+{
 
-// comment after include
-unlink('somefile.php');
+    private function someMethod() : void
+    {
+        // comment before include
+
+        // comment after include
+    }
+
+}
 ?>

--- a/rules/legacy/tests/Rector/Include_/RemoveIncludeRector/Fixture/fixture.php.inc
+++ b/rules/legacy/tests/Rector/Include_/RemoveIncludeRector/Fixture/fixture.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Legacy\Tests\Rector\Include_\RemoveIncludeRector\Fixture;
+
+// comment before include
+include 'somefile.php';
+// comment after include
+
+?>
+-----
+<?php
+
+namespace Rector\Legacy\Tests\Rector\Include_\RemoveIncludeRector\Fixture;
+
+// comment before include
+
+// comment after include
+
+?>

--- a/rules/legacy/tests/Rector/Include_/RemoveIncludeRector/RemoveIncludeRectorTest.php
+++ b/rules/legacy/tests/Rector/Include_/RemoveIncludeRector/RemoveIncludeRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Legacy\Tests\Rector\Include_\RemoveIncludeRector;
+
+use Iterator;
+use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;
+use Rector\Legacy\Rector\Include_\RemoveIncludeRector;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class RemoveIncludeRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    protected function getRectorClass(): string
+    {
+        return RemoveIncludeRector::class;
+    }
+}


### PR DESCRIPTION
The example uses comments because I noticed it was deleting comments attached as attributes to the Include_ node.  If there is a comment before the include, there will be a blank line where the include was, otherwise the line is removed.