### PR TITLE
[Legacy] Add AddTopIncludeRector

### DIFF
--- a/rules/legacy/src/Rector/Include_/AddTopIncludeRector.php
+++ b/rules/legacy/src/Rector/Include_/AddTopIncludeRector.php
@@ -11,13 +11,12 @@ use PhpParser\Node\Stmt\Nop;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
 use PhpParser\PrettyPrinter\Standard;
+use Rector\Core\Exception\Rector\InvalidRectorConfigurationException;
 use Rector\Core\RectorDefinition\CodeSample;
 use Rector\Core\RectorDefinition\RectorDefinition;
-use Rector\Core\Exception\Rector\InvalidRectorConfigurationException;
 use Rector\FileSystemRector\Rector\AbstractFileSystemRector;
 use ReflectionClass;
 use Symplify\SmartFileSystem\SmartFileInfo;
-
 /**
  * @see https://github.com/rectorphp/rector/issues/3679
  *
@@ -63,7 +62,7 @@ final class AddTopIncludeRector extends AbstractFileSystemRector
     public function __construct(array $settings = [])
     {
         $this->settings = $settings;
-        $this->parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
+        $this->parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
         $this->prettyPrinter = new Standard();
     }
 

--- a/rules/legacy/src/Rector/Include_/AddTopIncludeRector.php
+++ b/rules/legacy/src/Rector/Include_/AddTopIncludeRector.php
@@ -17,6 +17,7 @@ use Rector\Core\RectorDefinition\RectorDefinition;
 use Rector\FileSystemRector\Rector\AbstractFileSystemRector;
 use ReflectionClass;
 use Symplify\SmartFileSystem\SmartFileInfo;
+
 /**
  * @see https://github.com/rectorphp/rector/issues/3679
  *

--- a/rules/legacy/src/Rector/Include_/AddTopIncludeRector.php
+++ b/rules/legacy/src/Rector/Include_/AddTopIncludeRector.php
@@ -54,12 +54,12 @@ final class AddTopIncludeRector extends AbstractFileSystemRector
     /**
      * @var Standard
      */
-    private $prettyPrinter;
+    private $standard;
 
     public function __construct(string $type = 'TYPE_INCLUDE', string $file = '"autoload.php"', array $match = [])
     {
         $this->parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
-        $this->prettyPrinter = new Standard();
+        $this->standard = new Standard();
         $reflection = new ReflectionClass(Include_::class);
         $constants = $reflection->getConstants();
 
@@ -68,8 +68,6 @@ final class AddTopIncludeRector extends AbstractFileSystemRector
                 ', ',
                 array_keys($constants)
             ));
-            $this->parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
-            $this->prettyPrinter = new Standard();
         }
 
         $this->type = $constants[$type];
@@ -168,11 +166,11 @@ PHP
             return '';
         }
 
-        return $this->prettyPrinter->prettyPrintExpr($expr);
+        return $this->standard->prettyPrintExpr($expr);
     }
 
-    private function isTopFileInclude(Include_ $includeNode): bool
+    private function isTopFileInclude(Include_ $include): bool
     {
-        return $this->file === $this->getStringFromExpression($includeNode->expr);
+        return $this->file === $this->getStringFromExpression($include->expr);
     }
 }

--- a/rules/legacy/src/Rector/Include_/AddTopIncludeRector.php
+++ b/rules/legacy/src/Rector/Include_/AddTopIncludeRector.php
@@ -170,10 +170,10 @@ PHP,
 
     private function getExpressionFromString(string $source): ?Expr
     {
-        $ast = $this->parser->parse("<?php {$source};\n");
+        $nodes = $this->parser->parse('<?php ' . $source . ';');
 
-        if (is_array($ast)) {
-            return $ast[0]->expr;
+        if (is_array($nodes)) {
+            return $nodes[0]->expr;
         }
 
         return null;

--- a/rules/legacy/src/Rector/Include_/AddTopIncludeRector.php
+++ b/rules/legacy/src/Rector/Include_/AddTopIncludeRector.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Legacy\Rector\Include_;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Include_;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Declare_;
+use PhpParser\Node\Stmt\DeclareDeclare;
+use PhpParser\Node\Stmt\GroupUse;
+use PhpParser\Node\Stmt\InlineHTML;
+use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\Node\Stmt\Nop;
+use PhpParser\Node\Stmt\Use_;
+use PhpParser\Node\Stmt\UseUse;
+use Rector\Core\Exception\Rector\InvalidRectorConfigurationException;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\RectorDefinition\CodeSample;
+use Rector\Core\RectorDefinition\RectorDefinition;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use ReflectionClass;
+
+/**
+ * @see https://github.com/rectorphp/rector/issues/3679
+ *
+ * @see \Rector\Legacy\Tests\Rector\Include_\AddTopIncludeRector\AddTopIncludeRectorTest
+ */
+final class AddTopIncludeRector extends AbstractRector
+{
+    /**
+     * @var bool
+     */
+    private $completed = false;
+
+    /**
+     * @var string
+     */
+    private $file = '';
+
+    /**
+     * @var string
+     */
+    private $lastFileProcessed = '';
+
+    /**
+     * @var int
+     */
+    private $type = 0;
+
+    /**
+     * @var string[]
+     */
+    private $classNodes = [
+        Declare_::class => true,
+        DeclareDeclare::class => true,
+        GroupUse::class => true,
+        InlineHTML::class => true,
+        Namespace_::class => true,
+        Use_::class => true,
+        UseUse::class => true,
+    ];
+
+    /**
+     * @var string[] to match
+     */
+    private $patterns = [];
+
+    /**
+     * @var array
+     */
+    private $configuration = [];
+
+    public function __construct(array $configuration = [])
+    {
+        $this->configuration = $configuration;
+    }
+
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Adds an include file at the top of matching files but not class definitions', [
+            new CodeSample(
+                '<?php
+
+if (isset($_POST["csrf"])) {
+    processPost($_POST);
+}',
+                '<?php
+
+include "autoloader.php";
+
+if (isset($_POST["csrf"])) {
+    processPost($_POST);
+}',
+                [
+                    '$configuration' => [
+                        'type' => 'TYPE_INCLUDE_FILE',
+                        'file' => 'autoload.php',
+                        'match' => ['filePathWildCards'],
+                    ],
+                ]
+            ),
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        $this->initialize();
+
+        return [Node::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        $fileInfo = $node->getAttribute(AttributeKey::FILE_INFO);
+        $path = $fileInfo ? $fileInfo->getRelativeFilePath() : '';
+
+        if ($path !== $this->lastFileProcessed) {
+            $this->lastFileProcessed = $path;
+            $this->completed = false;
+        }
+
+        if (! $this->matchFile($path)) {
+            $this->completed = true;
+
+            return null;
+        }
+
+        $name = get_class($node);
+        // things that are OK at the top of a file
+        if ($this->completed || isset($this->classNodes[$name])) {
+            return null;
+        }
+
+        // if we find a class or include, then no include needed
+        if ($name === Class_::class) {
+            $this->completed = true;
+
+            return null;
+        }
+
+        $this->completed = true;
+
+        $expr = new String_($this->file);
+        $includeNode = new Include_($expr, $this->type);
+
+        $this->addNodeBeforeNode($includeNode, $node);
+        $this->addNodeBeforeNode(new Nop(), $node);
+
+        return $node;
+    }
+
+    /**
+     * Match file against matches, no patterns provided, then it matches
+     */
+    private function matchFile(
+        string $path
+    ): bool {
+        if (empty($this->patterns)) {
+            return true;
+        }
+
+        foreach ($this->patterns as $pattern) {
+            if (fnmatch($pattern, $path, FNM_NOESCAPE)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function initialize(): void
+    {
+        if ($this->type) {
+            return;
+        }
+        $reflection = new ReflectionClass(Include_::class);
+        $constants = $reflection->getConstants();
+
+        if (empty($constants[$this->configuration['type'] ?? ''])) {
+            throw new InvalidRectorConfigurationException('Invalid type: must be one of ' . implode(
+                ', ',
+                array_keys($constants)
+            ));
+        }
+
+        if (empty($this->configuration['file'] ?? '')) {
+            throw new InvalidRectorConfigurationException('Invalid parameter: file must be provided');
+        }
+        $this->type = $constants[$this->configuration['type']];
+        $this->file = $this->configuration['file'];
+        if (isset($this->configuration['match']) && is_array($this->configuration['match'])) {
+            $this->patterns = $this->configuration['match'];
+        }
+    }
+}

--- a/rules/legacy/src/Rector/Include_/AddTopIncludeRector.php
+++ b/rules/legacy/src/Rector/Include_/AddTopIncludeRector.php
@@ -158,10 +158,9 @@ if (isset($_POST["csrf"])) {
     /**
      * Match file against matches, no patterns provided, then it matches
      */
-    private function matchFile(
-        string $path
-    ): bool {
-        if (empty($this->patterns)) {
+    private function matchFile(string $path): bool
+    {
+        if ([] === $this->patterns) {
             return true;
         }
 
@@ -182,14 +181,14 @@ if (isset($_POST["csrf"])) {
         $reflection = new ReflectionClass(Include_::class);
         $constants = $reflection->getConstants();
 
-        if (empty($constants[$this->configuration['type'] ?? ''])) {
+        if (! isset($constants[$this->configuration['type'] ?? ''])) {
             throw new InvalidRectorConfigurationException('Invalid type: must be one of ' . implode(
                 ', ',
                 array_keys($constants)
             ));
         }
 
-        if (empty($this->configuration['file'] ?? '')) {
+        if ('' === ($this->configuration['file'] ?? '')) {
             throw new InvalidRectorConfigurationException('Invalid parameter: file must be provided');
         }
         $this->type = $constants[$this->configuration['type']];

--- a/rules/legacy/src/Rector/Include_/AddTopIncludeRector.php
+++ b/rules/legacy/src/Rector/Include_/AddTopIncludeRector.php
@@ -71,14 +71,14 @@ final class AddTopIncludeRector extends AbstractFileSystemRector
     {
         return new RectorDefinition('Adds an include file at the top of matching files but not class definitions', [
             new CodeSample(
-                <<<'PHP'
+                <<<PHP
 <?php
 
 if (isset($_POST["csrf"])) {
     processPost($_POST);
 }
 PHP,
-                <<<'PHP'
+                <<<PHP
 <?php
 
 include "autoloader.php";

--- a/rules/legacy/src/Rector/Include_/AddTopIncludeRector.php
+++ b/rules/legacy/src/Rector/Include_/AddTopIncludeRector.php
@@ -64,8 +64,8 @@ final class AddTopIncludeRector extends AbstractFileSystemRector
         $constants = $reflection->getConstants();
 
         if (! isset($constants[$type])) {
-              throw new InvalidRectorConfigurationException('Invalid type: must be one of ' . implode(
-                  ', ',
+            throw new InvalidRectorConfigurationException('Invalid type: must be one of ' . implode(
+                ', ',
                 array_keys($constants)
             ));
             $this->parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);

--- a/rules/legacy/src/Rector/Include_/AddTopIncludeRector.php
+++ b/rules/legacy/src/Rector/Include_/AddTopIncludeRector.php
@@ -58,26 +58,26 @@ final class AddTopIncludeRector extends AbstractFileSystemRector
 
     public function __construct(string $type = 'TYPE_INCLUDE', string $file = '"autoload.php"', array $match = [])
     {
-		$this->parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
-		$this->prettyPrinter = new Standard();
-		$reflection = new ReflectionClass(Include_::class);
-		$constants = $reflection->getConstants();
+        $this->parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
+        $this->prettyPrinter = new Standard();
+        $reflection = new ReflectionClass(Include_::class);
+        $constants = $reflection->getConstants();
 
-		if (! isset($constants[$type])) {
-			throw new InvalidRectorConfigurationException('Invalid type: must be one of ' . implode(
-				', ',
-				array_keys($constants)
-			));
-			$this->parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
-			$this->prettyPrinter = new Standard();
-		}
+        if (! isset($constants[$type])) {
+              throw new InvalidRectorConfigurationException('Invalid type: must be one of ' . implode(
+                  ', ',
+                array_keys($constants)
+            ));
+            $this->parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
+            $this->prettyPrinter = new Standard();
+        }
 
-		$this->type = $constants[$type];
-		$this->file = $file;
-		$this->fileExpression = $this->getExpressionFromString($this->file);
-		// normalize the file we are including
-		$this->file = $this->getStringFromExpression($this->fileExpression);
-  		$this->patterns = $match;
+        $this->type = $constants[$type];
+        $this->file = $file;
+        $this->fileExpression = $this->getExpressionFromString($this->file);
+        // normalize the file we are including
+        $this->file = $this->getStringFromExpression($this->fileExpression);
+        $this->patterns = $match;
     }
 
     public function getDefinition(): RectorDefinition

--- a/rules/legacy/tests/Rector/Include_/AddTopIncludeRector/AddTopIncludeRectorTest.php
+++ b/rules/legacy/tests/Rector/Include_/AddTopIncludeRector/AddTopIncludeRectorTest.php
@@ -28,10 +28,8 @@ final class AddTopIncludeRectorTest extends AbstractFileSystemRectorTestCase
     {
         return [
             AddTopIncludeRector::class => [
-                '$settings' => [
-                    'type' => 'TYPE_INCLUDE',
-                    'file' => '__DIR__ . "/../autoloader.php"',
-                ],
+                '$type' => 'TYPE_INCLUDE',
+                '$file' => '__DIR__ . "/../autoloader.php"',
             ],
         ];
     }

--- a/rules/legacy/tests/Rector/Include_/AddTopIncludeRector/AddTopIncludeRectorTest.php
+++ b/rules/legacy/tests/Rector/Include_/AddTopIncludeRector/AddTopIncludeRectorTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Legacy\Tests\Rector\Include_\AddTopIncludeRector;
+
+use Iterator;
+use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;
+use Rector\Legacy\Rector\Include_\AddTopIncludeRector;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class AddTopIncludeRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    protected function getRectorsWithConfiguration(): array
+    {
+        return [
+            AddTopIncludeRector::class => [
+                '$configuration' => [
+                    'type' => 'TYPE_INCLUDE',
+                    'file' => 'autoloader.php',
+                ],
+            ],
+        ];
+    }
+}

--- a/rules/legacy/tests/Rector/Include_/AddTopIncludeRector/AddTopIncludeRectorTest.php
+++ b/rules/legacy/tests/Rector/Include_/AddTopIncludeRector/AddTopIncludeRectorTest.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Rector\Legacy\Tests\Rector\Include_\AddTopIncludeRector;
 
 use Iterator;
-use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;
+use Rector\Core\Testing\PHPUnit\AbstractFileSystemRectorTestCase;
 use Rector\Legacy\Rector\Include_\AddTopIncludeRector;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
-final class AddTopIncludeRectorTest extends AbstractRectorTestCase
+final class AddTopIncludeRectorTest extends AbstractFileSystemRectorTestCase
 {
     /**
      * @dataProvider provideData()
@@ -28,9 +28,9 @@ final class AddTopIncludeRectorTest extends AbstractRectorTestCase
     {
         return [
             AddTopIncludeRector::class => [
-                '$configuration' => [
+                '$settings' => [
                     'type' => 'TYPE_INCLUDE',
-                    'file' => 'autoloader.php',
+                    'file' => '__DIR__ . "/../autoloader.php"',
                 ],
             ],
         ];

--- a/rules/legacy/tests/Rector/Include_/AddTopIncludeRector/Expected/fixture.php.inc
+++ b/rules/legacy/tests/Rector/Include_/AddTopIncludeRector/Expected/fixture.php.inc
@@ -1,4 +1,7 @@
 <?php
+
+include __DIR__ . '/../autoloader.php';
+
 if (isset($_POST['csrf'])) {
 processPost($_POST);
 }

--- a/rules/legacy/tests/Rector/Include_/AddTopIncludeRector/Expected/has_class.php.inc
+++ b/rules/legacy/tests/Rector/Include_/AddTopIncludeRector/Expected/has_class.php.inc
@@ -1,0 +1,5 @@
+<?php
+
+class SomeClass
+{
+}

--- a/rules/legacy/tests/Rector/Include_/AddTopIncludeRector/Expected/has_class.php.inc
+++ b/rules/legacy/tests/Rector/Include_/AddTopIncludeRector/Expected/has_class.php.inc
@@ -1,5 +1,7 @@
 <?php
 
-class SomeClass
+namespace Rector\Legacy\Tests\Rector\Include_\AddTopIncludeRector\Fixture;
+
+class SomeOtherClass
 {
 }

--- a/rules/legacy/tests/Rector/Include_/AddTopIncludeRector/Expected/has_include.php.inc
+++ b/rules/legacy/tests/Rector/Include_/AddTopIncludeRector/Expected/has_include.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Legacy\Tests\Rector\Include_\AddTopIncludeRector\Fixture;
+
+class SomeClass
+{
+
+    private function someMethod() : void
+    {
+        include 'somefile.php';
+    }
+
+}

--- a/rules/legacy/tests/Rector/Include_/AddTopIncludeRector/Fixture/fixture.php.inc
+++ b/rules/legacy/tests/Rector/Include_/AddTopIncludeRector/Fixture/fixture.php.inc
@@ -1,0 +1,12 @@
+<?php
+if (isset($_POST['csrf'])) {
+processPost($_POST);
+}
+-----
+<?php
+
+include 'autoloader.php';
+
+if (isset($_POST['csrf'])) {
+processPost($_POST);
+}

--- a/rules/legacy/tests/Rector/Include_/AddTopIncludeRector/Fixture/has_class.php.inc
+++ b/rules/legacy/tests/Rector/Include_/AddTopIncludeRector/Fixture/has_class.php.inc
@@ -1,0 +1,5 @@
+<?php
+
+class SomeClass
+{
+}

--- a/rules/legacy/tests/Rector/Include_/AddTopIncludeRector/Fixture/has_class.php.inc
+++ b/rules/legacy/tests/Rector/Include_/AddTopIncludeRector/Fixture/has_class.php.inc
@@ -1,5 +1,7 @@
 <?php
 
-class SomeClass
+namespace Rector\Legacy\Tests\Rector\Include_\AddTopIncludeRector\Fixture;
+
+class SomeOtherClass
 {
 }

--- a/rules/legacy/tests/Rector/Include_/AddTopIncludeRector/Fixture/has_include.php.inc
+++ b/rules/legacy/tests/Rector/Include_/AddTopIncludeRector/Fixture/has_include.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Legacy\Tests\Rector\Include_\AddTopIncludeRector\Fixture;
+
+class SomeClass
+{
+
+    private function someMethod() : void
+    {
+        include __DIR__ . '/../autoloader.php';
+    }
+
+}

--- a/rules/legacy/tests/Rector/Include_/AddTopIncludeRector/autoloader.php
+++ b/rules/legacy/tests/Rector/Include_/AddTopIncludeRector/autoloader.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+// my autoloader


### PR DESCRIPTION
This will add an include type statement to any plain PHP file, but not class definitions.  It does add a new include statement each time it is run, but I think that is OK, as you may want to add more than one (but not sure why). Can be combined with the RemoveIncludeRector to nuke the old includes.