### PR TITLE
[CodingStyle] Create new TernaryConditionVariableAssignmentRector

### DIFF
--- a/config/set/coding-style/coding-style.yaml
+++ b/config/set/coding-style/coding-style.yaml
@@ -4,6 +4,7 @@ services:
     Rector\CodingStyle\Rector\Identical\IdenticalFalseToBooleanNotRector: null
     Rector\CodingStyle\Rector\Switch_\BinarySwitchToIfElseRector: null
     Rector\CodingStyle\Rector\FuncCall\ConsistentImplodeRector: null
+    Rector\CodingStyle\Rector\Ternary\TernaryConditionVariableAssignmentRector: null
     Rector\CodingStyle\Rector\Use_\RemoveUnusedAliasRector: null
 
     # requires configuration

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# All 524 Rectors Overview
+# All 525 Rectors Overview
 
 - [Projects](#projects)
 - [General](#general)
@@ -11,7 +11,7 @@
 - [CakePHP](#cakephp) (6)
 - [Celebrity](#celebrity) (3)
 - [CodeQuality](#codequality) (54)
-- [CodingStyle](#codingstyle) (34)
+- [CodingStyle](#codingstyle) (35)
 - [DeadCode](#deadcode) (40)
 - [Decomplex](#decomplex) (1)
 - [Decouple](#decouple) (1)
@@ -2214,6 +2214,23 @@ Prefer quote that are not inside the string
 +         $name = "' Sara";
      }
  }
+```
+
+<br><br>
+
+### `TernaryConditionVariableAssignmentRector`
+
+- class: [`Rector\CodingStyle\Rector\Ternary\TernaryConditionVariableAssignmentRector`](/../master/rules/coding-style/src/Rector/Ternary/TernaryConditionVariableAssignmentRector.php)
+- [test fixtures](/../master/rules/coding-style/tests/Rector/Ternary/TernaryConditionVariableAssignmentRector/Fixture)
+
+Assign outcome of ternary condition to variable, where applicable
+
+```diff
+function ternary($value)
+{
+-    $value ? $a = 1 : $a = 0;
++    $a = $value ? 1 : 0;
+}
 ```
 
 <br><br>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -73,6 +73,13 @@ parameters:
 
     ignoreErrors:
         # false positive
+        -
+            message: '#Class with base \"[a-zA-Z0-9\\_]+\" name is already used in#'
+            paths:
+                - src/Console/Application.php
+                - src/PhpParser/Parser/Parser.php
+
+        # false positive
 #        - '#Call to function method_exists\(\) with string and (.*?) will always evaluate to false#'
         - '#PHPDoc tag \@param for parameter \$node with type float is incompatible with native type PhpParser\\Node#'
 

--- a/rules/coding-style/src/Rector/Ternary/TernaryConditionVariableAssignmentRector.php
+++ b/rules/coding-style/src/Rector/Ternary/TernaryConditionVariableAssignmentRector.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CodingStyle\Rector\Ternary;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\Ternary;
+use PhpParser\Node\Expr\Variable;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\RectorDefinition\CodeSample;
+use Rector\Core\RectorDefinition\RectorDefinition;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+
+/**
+ * @see \Rector\CodingStyle\Tests\Rector\Ternary\TernaryConditionVariableAssignmentRector\TernaryConditionVariableAssignmentRectorTest
+ */
+final class TernaryConditionVariableAssignmentRector extends AbstractRector
+{
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Assign outcome of ternary condition to variable, where applicable', [
+            new CodeSample(
+                <<<'PHP'
+function ternary($value)
+{
+    $value ? $a = 1 : $a = 0;
+}
+PHP
+                ,
+                <<<'PHP'
+function ternary($value)
+{
+    $a = $value ? 1 : 0;
+}
+PHP
+            ),
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [Ternary::class];
+    }
+
+    /**
+     * @param Ternary $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $nodeIf = $node->if;
+        $nodeElse = $node->else;
+
+        if (! $nodeIf instanceof Assign || ! $nodeElse instanceof Assign) {
+            return null;
+        }
+
+        $nodeIfVar = $nodeIf->var;
+        $nodeElseVar = $nodeElse->var;
+
+        if (! $nodeIfVar instanceof Variable || ! $nodeElseVar instanceof Variable) {
+            return null;
+        }
+
+        if ($nodeIfVar->name !== $nodeElseVar->name) {
+            return null;
+        }
+
+        $previousNode = $node->getAttribute(AttributeKey::PREVIOUS_NODE);
+        if ($previousNode !== null) {
+            return null;
+        }
+
+        $node->if = $nodeIf->expr;
+        $node->else = $nodeElse->expr;
+
+        $variable = new Variable($nodeIfVar->name);
+
+        return new Assign($variable, $node);
+    }
+}

--- a/rules/coding-style/tests/Rector/Ternary/TernaryConditionVariableAssignmentRector/Fixture/fixture.php.inc
+++ b/rules/coding-style/tests/Rector/Ternary/TernaryConditionVariableAssignmentRector/Fixture/fixture.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\CodingStyle\Rector\Ternary\TernaryConditionVariableAssignmentRector\Fixture;
+
+function ternary($value)
+{
+    $value ? $a = 1 : $a = 0;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CodingStyle\Rector\Ternary\TernaryConditionVariableAssignmentRector\Fixture;
+
+function ternary($value)
+{
+    $a = $value ? 1 : 0;
+}
+
+?>

--- a/rules/coding-style/tests/Rector/Ternary/TernaryConditionVariableAssignmentRector/Fixture/skip_different_variable_names.php.inc
+++ b/rules/coding-style/tests/Rector/Ternary/TernaryConditionVariableAssignmentRector/Fixture/skip_different_variable_names.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\CodingStyle\Rector\Ternary\TernaryConditionVariableAssignmentRector\Fixture;
+
+function skip_different_variable_names($value)
+{
+    $value ? $a = 1 : $b = 0;
+}

--- a/rules/coding-style/tests/Rector/Ternary/TernaryConditionVariableAssignmentRector/Fixture/skip_ternary_with_variable_assignment.php.inc
+++ b/rules/coding-style/tests/Rector/Ternary/TernaryConditionVariableAssignmentRector/Fixture/skip_ternary_with_variable_assignment.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\CodingStyle\Rector\Ternary\TernaryConditionVariableAssignmentRector\Fixture;
+
+function skip_ternary_with_variable_assignment($value)
+{
+    $x = $value ? $a = 1 : $a = 0;
+}

--- a/rules/coding-style/tests/Rector/Ternary/TernaryConditionVariableAssignmentRector/Fixture/skip_ternary_without_variable_assignment.php.inc
+++ b/rules/coding-style/tests/Rector/Ternary/TernaryConditionVariableAssignmentRector/Fixture/skip_ternary_without_variable_assignment.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\CodingStyle\Rector\Ternary\TernaryConditionVariableAssignmentRector\Fixture;
+
+function skip_ternary_without_variable_assignment($value)
+{
+    $value ? 1 : $a = 0;
+}

--- a/rules/coding-style/tests/Rector/Ternary/TernaryConditionVariableAssignmentRector/TernaryConditionVariableAssignmentRectorTest.php
+++ b/rules/coding-style/tests/Rector/Ternary/TernaryConditionVariableAssignmentRector/TernaryConditionVariableAssignmentRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CodingStyle\Tests\Rector\Ternary\TernaryConditionVariableAssignmentRector;
+
+use Iterator;
+use Rector\CodingStyle\Rector\Ternary\TernaryConditionVariableAssignmentRector;
+use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class TernaryConditionVariableAssignmentRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    protected function getRectorClass(): string
+    {
+        return TernaryConditionVariableAssignmentRector::class;
+    }
+}


### PR DESCRIPTION
After discussion at https://github.com/symplify/symplify/issues/2006, here is a new Rector to convert the following:

```php
$value ? $a = 1 : $a = 0; // Before

$a = $value ? 1 : 0; // After
```