### PR TITLE
[CodingStyle] Create new WrapVariableVariableNameInCurlyBracesRector

### DIFF
--- a/config/set/coding-style/coding-style.php
+++ b/config/set/coding-style/coding-style.php
@@ -31,6 +31,7 @@ use Rector\CodingStyle\Rector\Ternary\TernaryConditionVariableAssignmentRector;
 use Rector\CodingStyle\Rector\Use_\RemoveUnusedAliasRector;
 use Rector\CodingStyle\Rector\Use_\SplitGroupedUseImportsRector;
 use Rector\CodingStyle\Rector\Variable\UnderscoreToPascalCaseVariableNameRector;
+use Rector\CodingStyle\Rector\Variable\WrapVariableVariableNameInCurlyBracesRector;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
@@ -98,6 +99,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(UnderscoreToPascalCasePropertyNameRector::class);
 
     $services->set(UnderscoreToPascalCaseVariableNameRector::class);
+
+    $services->set(WrapVariableVariableNameInCurlyBracesRector::class);
 
     $services->set(RemoveDoubleUnderscoreInMethodNameRector::class);
 };

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -11,7 +11,7 @@
 - [CakePHP](#cakephp) (6)
 - [Celebrity](#celebrity) (3)
 - [CodeQuality](#codequality) (54)
-- [CodingStyle](#codingstyle) (35)
+- [CodingStyle](#codingstyle) (36)
 - [DeadCode](#deadcode) (40)
 - [Decomplex](#decomplex) (1)
 - [Decouple](#decouple) (1)
@@ -2328,6 +2328,25 @@ Use ++ increment instead of `$var += 1`
 +     */
      const HI = 'hi';
  }
+```
+
+<br><br>
+
+### `WrapVariableVariableNameInCurlyBracesRector`
+
+- class: [`Rector\CodingStyle\Rector\Variable\WrapVariableVariableNameInCurlyBracesRector`](/../master/rules/coding-style/src/Rector/Variable/WrapVariableVariableNameInCurlyBracesRector.php)
+- [test fixtures](/../master/rules/coding-style/tests/Rector/Variable/WrapVariableVariableNameInCurlyBracesRector/Fixture)
+
+Ensure variable variables are wrapped in curly braces
+
+```diff
+function run($foo)
+{
+-    // Valid in PHP 5 only
+-    global $$foo->bar;
++    // Valid in PHP 5 and 7
++    global ${$foo->bar};
+}
 ```
 
 <br><br>

--- a/rules/coding-style/src/Rector/Variable/WrapVariableVariableNameInCurlyBracesRector.php
+++ b/rules/coding-style/src/Rector/Variable/WrapVariableVariableNameInCurlyBracesRector.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CodingStyle\Rector\Variable;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\Variable;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\RectorDefinition\CodeSample;
+use Rector\Core\RectorDefinition\RectorDefinition;
+
+/**
+ * @see \Rector\CodingStyle\Tests\Rector\Variable\WrapVariableVariableNameInCurlyBracesRector\WrapVariableVariableNameInCurlyBracesRectorTest
+ * @see https://www.php.net/manual/en/language.variables.variable.php
+ */
+final class WrapVariableVariableNameInCurlyBracesRector extends AbstractRector
+{
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Ensure variable variables are wrapped in curly braces', [
+            new CodeSample(
+                <<<'PHP'
+function run($foo)
+{
+    global $$foo->bar;
+}
+PHP
+                ,
+                <<<'PHP'
+function run($foo)
+{
+    global ${$foo->bar};
+}
+PHP
+            ),
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [Variable::class];
+    }
+
+    /**
+     * @param Variable $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $nodeName = $node->name;
+
+        if (! $nodeName instanceof PropertyFetch && ! $nodeName instanceof Variable) {
+            return null;
+        }
+
+        if ($node->getEndTokenPos() !== $nodeName->getEndTokenPos()) {
+            return null;
+        }
+
+        if ($nodeName instanceof PropertyFetch) {
+            return new Variable(new PropertyFetch($nodeName->var, $nodeName->name));
+        }
+
+        if ($nodeName instanceof Variable) {
+            return new Variable(new Variable($nodeName->name));
+        }
+
+        return null;
+    }
+}

--- a/rules/coding-style/tests/Rector/Variable/WrapVariableVariableNameInCurlyBracesRector/Fixture/skip_global_variable_variables_with_braces.php.inc
+++ b/rules/coding-style/tests/Rector/Variable/WrapVariableVariableNameInCurlyBracesRector/Fixture/skip_global_variable_variables_with_braces.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\CodingStyle\Rector\Variable\WrapVariableVariableNameInCurlyBracesRector\Fixture;
+
+function skip_global_variable_variables_with_braces($foo)
+{
+    global ${$foo->bar};
+}

--- a/rules/coding-style/tests/Rector/Variable/WrapVariableVariableNameInCurlyBracesRector/Fixture/skip_property_fetch_variable.php.inc
+++ b/rules/coding-style/tests/Rector/Variable/WrapVariableVariableNameInCurlyBracesRector/Fixture/skip_property_fetch_variable.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\CodingStyle\Rector\Variable\WrapVariableVariableNameInCurlyBracesRector\Fixture;
+
+function skip_property_fetch_variable($foo)
+{
+    return $foo->bar;
+}

--- a/rules/coding-style/tests/Rector/Variable/WrapVariableVariableNameInCurlyBracesRector/Fixture/skip_variable.php.inc
+++ b/rules/coding-style/tests/Rector/Variable/WrapVariableVariableNameInCurlyBracesRector/Fixture/skip_variable.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\CodingStyle\Rector\Variable\WrapVariableVariableNameInCurlyBracesRector\Fixture;
+
+function skip_variable($foo)
+{
+    return $foo;
+}

--- a/rules/coding-style/tests/Rector/Variable/WrapVariableVariableNameInCurlyBracesRector/Fixture/skip_variable_variables_with_braces.php.inc
+++ b/rules/coding-style/tests/Rector/Variable/WrapVariableVariableNameInCurlyBracesRector/Fixture/skip_variable_variables_with_braces.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\CodingStyle\Rector\Variable\WrapVariableVariableNameInCurlyBracesRector\Fixture;
+
+function skip_variable_variables_with_braces($value)
+{
+    ${$value} = true;
+}

--- a/rules/coding-style/tests/Rector/Variable/WrapVariableVariableNameInCurlyBracesRector/Fixture/variable_variables.php.inc
+++ b/rules/coding-style/tests/Rector/Variable/WrapVariableVariableNameInCurlyBracesRector/Fixture/variable_variables.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\CodingStyle\Rector\Variable\WrapVariableVariableNameInCurlyBracesRector\Fixture;
+
+function variable_variables($value)
+{
+    $$value = true;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CodingStyle\Rector\Variable\WrapVariableVariableNameInCurlyBracesRector\Fixture;
+
+function variable_variables($value)
+{
+    ${$value} = true;
+}
+
+?>

--- a/rules/coding-style/tests/Rector/Variable/WrapVariableVariableNameInCurlyBracesRector/WrapVariableVariableNameInCurlyBracesRectorTest.php
+++ b/rules/coding-style/tests/Rector/Variable/WrapVariableVariableNameInCurlyBracesRector/WrapVariableVariableNameInCurlyBracesRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CodingStyle\Tests\Rector\Variable\WrapVariableVariableNameInCurlyBracesRector;
+
+use Iterator;
+use Rector\CodingStyle\Rector\Variable\WrapVariableVariableNameInCurlyBracesRector;
+use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class WrapVariableVariableNameInCurlyBracesRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    protected function getRectorClass(): string
+    {
+        return WrapVariableVariableNameInCurlyBracesRector::class;
+    }
+}


### PR DESCRIPTION
After discussion at https://github.com/symplify/symplify/issues/2006, here is a new Rector to convert the following:

```php
function run($foo)
{
    // Before: valid in PHP 5 only
    global $$foo->bar;

    // After: valid in PHP 5 and 7
    global ${$foo->bar};
}
```

The Rector also wraps other [variable variables](https://www.php.net/manual/en/language.variables.variable.php) in curly braces.

```php
$$value = true; // Before

${$value} = true; // After
```