### PR TITLE
Support exception names that begin with an abbreviation

### DIFF
--- a/rules/coding-style/tests/Rector/Catch_/CatchExceptionNameMatchingTypeRector/Fixture/pdo_exception.php.inc
+++ b/rules/coding-style/tests/Rector/Catch_/CatchExceptionNameMatchingTypeRector/Fixture/pdo_exception.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\CodingStyle\Tests\Rector\Catch_\CatchExceptionNameMatchingTypeRector\Fixture;
+
+class PdoClass
+{
+    public function run()
+    {
+        try {
+            // ...
+        } catch (PDOException $e) {
+            $e->getMessage();
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CodingStyle\Tests\Rector\Catch_\CatchExceptionNameMatchingTypeRector\Fixture;
+
+class PdoClass
+{
+    public function run()
+    {
+        try {
+            // ...
+        } catch (PDOException $pdoException) {
+            $pdoException->getMessage();
+        }
+    }
+}
+
+?>


### PR DESCRIPTION
[CatchExceptionNameMatchingTypeRector](https://github.com/rectorphp/rector/blob/master/docs/rector_rules_overview.md#catchexceptionnamematchingtyperector)

- `PDOException`
- `SQLException`