### PR TITLE
Create WrapEncapsedVariableInCurlyBracesRector

### DIFF
--- a/config/set/coding-style.php
+++ b/config/set/coding-style.php
@@ -12,6 +12,7 @@ use Rector\CodingStyle\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsPar
 use Rector\CodingStyle\Rector\ClassMethod\NewlineBeforeNewAssignSetRector;
 use Rector\CodingStyle\Rector\ClassMethod\RemoveDoubleUnderscoreInMethodNameRector;
 use Rector\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector;
+use Rector\CodingStyle\Rector\Encapsed\WrapEncapsedVariableInCurlyBracesRector;
 use Rector\CodingStyle\Rector\FuncCall\CallUserFuncCallToVariadicRector;
 use Rector\CodingStyle\Rector\FuncCall\ConsistentImplodeRector;
 use Rector\CodingStyle\Rector\FuncCall\ConsistentPregDelimiterRector;
@@ -72,6 +73,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(VarConstantCommentRector::class);
 
     $services->set(EncapsedStringsToSprintfRector::class);
+
+    $services->set(WrapEncapsedVariableInCurlyBracesRector::class);
 
     $services->set(NewlineBeforeNewAssignSetRector::class);
 

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# All 527 Rectors Overview
+# All 528 Rectors Overview
 
 - [Projects](#projects)
 - [General](#general)
@@ -11,7 +11,7 @@
 - [CakePHP](#cakephp) (6)
 - [Celebrity](#celebrity) (3)
 - [CodeQuality](#codequality) (54)
-- [CodingStyle](#codingstyle) (35)
+- [CodingStyle](#codingstyle) (36)
 - [DeadCode](#deadcode) (40)
 - [Decomplex](#decomplex) (1)
 - [Decouple](#decouple) (1)
@@ -2347,6 +2347,23 @@ Changes use of call to version compare function to use of PHP version constant
 -        version_compare(PHP_VERSION, '5.3.0', '<');
 +        PHP_VERSION_ID < 50300;
      }
+ }
+```
+
+<br><br>
+
+### `WrapEncapsedVariableInCurlyBracesRector`
+
+- class: [`Rector\CodingStyle\Rector\Encapsed\WrapEncapsedVariableInCurlyBracesRector`](/../master/rules/coding-style/src/Rector/Encapsed/WrapEncapsedVariableInCurlyBracesRector.php)
+- [test fixtures](/../master/rules/coding-style/tests/Rector/Encapsed/WrapEncapsedVariableInCurlyBracesRector/Fixture)
+
+Wrap encapsed variables in curly braces
+
+```diff
+ function run($world)
+ {
+-    echo "Hello $world!"
++    echo "Hello {$world}!"
  }
 ```
 

--- a/rules/coding-style/src/Rector/Encapsed/WrapEncapsedVariableInCurlyBracesRector.php
+++ b/rules/coding-style/src/Rector/Encapsed/WrapEncapsedVariableInCurlyBracesRector.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CodingStyle\Rector\Encapsed;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Scalar\Encapsed;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\RectorDefinition\CodeSample;
+use Rector\Core\RectorDefinition\RectorDefinition;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+
+/**
+ * @see \Rector\CodingStyle\Tests\Rector\Encapsed\WrapEncapsedVariableInCurlyBracesRector\WrapEncapsedVariableInCurlyBracesRectorTest
+ */
+final class WrapEncapsedVariableInCurlyBracesRector extends AbstractRector
+{
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Wrap encapsed variables in curly braces', [
+            new CodeSample(
+                <<<'PHP'
+function run($world)
+{
+    echo "Hello $world!"
+}
+PHP
+                ,
+                <<<'PHP'
+function run($world)
+{
+    echo "Hello {$world}!"
+}
+PHP
+            ),
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [Encapsed::class];
+    }
+
+    /**
+     * @param Encapsed $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $startTokenPos = $node->getStartTokenPos();
+        $hasVariableBeenWrapped = false;
+
+        foreach ($node->parts as $index => $nodePart) {
+            if ($nodePart instanceof Variable) {
+                $previousNode = $nodePart->getAttribute(AttributeKey::PREVIOUS_NODE);
+                $previousNodeEndTokenPosition = $previousNode === null ? $startTokenPos : $previousNode->getEndTokenPos();
+
+                if ($previousNodeEndTokenPosition + 1 === $nodePart->getStartTokenPos()) {
+                    $hasVariableBeenWrapped = true;
+
+                    $node->parts[$index] = new Variable($nodePart->name);
+                }
+            }
+        }
+
+        if (! $hasVariableBeenWrapped) {
+            return null;
+        }
+
+        return $node;
+    }
+}

--- a/rules/coding-style/tests/Rector/Encapsed/WrapEncapsedVariableInCurlyBracesRector/Fixture/fixture.php.inc
+++ b/rules/coding-style/tests/Rector/Encapsed/WrapEncapsedVariableInCurlyBracesRector/Fixture/fixture.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\CodingStyle\Tests\Rector\Encapsed\WrapEncapsedVariableInCurlyBracesRector\Fixture;
+
+function run($world)
+{
+    return "Hello $world!";
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CodingStyle\Tests\Rector\Encapsed\WrapEncapsedVariableInCurlyBracesRector\Fixture;
+
+function run($world)
+{
+    return "Hello {$world}!";
+}
+
+?>

--- a/rules/coding-style/tests/Rector/Encapsed/WrapEncapsedVariableInCurlyBracesRector/Fixture/multiple_variables.php.inc
+++ b/rules/coding-style/tests/Rector/Encapsed/WrapEncapsedVariableInCurlyBracesRector/Fixture/multiple_variables.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\CodingStyle\Tests\Rector\Encapsed\WrapEncapsedVariableInCurlyBracesRector\Fixture;
+
+function multiple_variables($hello, $world)
+{
+    return "$hello $world!";
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CodingStyle\Tests\Rector\Encapsed\WrapEncapsedVariableInCurlyBracesRector\Fixture;
+
+function multiple_variables($hello, $world)
+{
+    return "{$hello} {$world}!";
+}
+
+?>

--- a/rules/coding-style/tests/Rector/Encapsed/WrapEncapsedVariableInCurlyBracesRector/Fixture/skip_braces_already_present.php.inc
+++ b/rules/coding-style/tests/Rector/Encapsed/WrapEncapsedVariableInCurlyBracesRector/Fixture/skip_braces_already_present.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\CodingStyle\Tests\Rector\Encapsed\WrapEncapsedVariableInCurlyBracesRector\Fixture;
+
+function skip_braces_already_present($world)
+{
+    return "Hello {$world}!";
+}

--- a/rules/coding-style/tests/Rector/Encapsed/WrapEncapsedVariableInCurlyBracesRector/Fixture/skip_single_quotes.php.inc
+++ b/rules/coding-style/tests/Rector/Encapsed/WrapEncapsedVariableInCurlyBracesRector/Fixture/skip_single_quotes.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\CodingStyle\Tests\Rector\Encapsed\WrapEncapsedVariableInCurlyBracesRector\Fixture;
+
+function skip_single_quotes($world)
+{
+    return 'Hello $world!';
+}

--- a/rules/coding-style/tests/Rector/Encapsed/WrapEncapsedVariableInCurlyBracesRector/Fixture/some_variables_with_braces.php.inc
+++ b/rules/coding-style/tests/Rector/Encapsed/WrapEncapsedVariableInCurlyBracesRector/Fixture/some_variables_with_braces.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\CodingStyle\Tests\Rector\Encapsed\WrapEncapsedVariableInCurlyBracesRector\Fixture;
+
+function some_variables_with_braces($hello, $world)
+{
+    return "$hello {$world}!";
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CodingStyle\Tests\Rector\Encapsed\WrapEncapsedVariableInCurlyBracesRector\Fixture;
+
+function some_variables_with_braces($hello, $world)
+{
+    return "{$hello} {$world}!";
+}
+
+?>

--- a/rules/coding-style/tests/Rector/Encapsed/WrapEncapsedVariableInCurlyBracesRector/WrapEncapsedVariableInCurlyBracesRectorTest.php
+++ b/rules/coding-style/tests/Rector/Encapsed/WrapEncapsedVariableInCurlyBracesRector/WrapEncapsedVariableInCurlyBracesRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\CodingStyle\Tests\Rector\Encapsed\WrapEncapsedVariableInCurlyBracesRector;
+
+use Iterator;
+use Rector\CodingStyle\Rector\Encapsed\WrapEncapsedVariableInCurlyBracesRector;
+use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class WrapEncapsedVariableInCurlyBracesRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    protected function getRectorClass(): string
+    {
+        return WrapEncapsedVariableInCurlyBracesRector::class;
+    }
+}


### PR DESCRIPTION
After discussion at https://github.com/symplify/symplify/issues/2006, here is a new Rector to convert the following:

```diff
 function run($world)
 {
-    echo "Hello $world!";
+    echo "Hello {$world}!";
 }
```