### PR TITLE
Bump to phpstan 0.12.33, nikic/php-parser to 4.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "jean85/pretty-package-versions": "^1.2",
         "nette/robot-loader": "^3.2",
         "nette/utils": "^3.1",
-        "nikic/php-parser": "^4.7",
+        "nikic/php-parser": "4.6",
         "ondram/ci-detector": "^3.4",
         "phpstan/phpdoc-parser": "^0.4.7",
         "phpstan/phpstan-phpunit": "^0.12.10",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "jean85/pretty-package-versions": "^1.2",
         "nette/robot-loader": "^3.2",
         "nette/utils": "^3.1",
-        "nikic/php-parser": "4.5",
+        "nikic/php-parser": "^4.7",
         "ondram/ci-detector": "^3.4",
         "phpstan/phpdoc-parser": "^0.4.7",
         "phpstan/phpstan-phpunit": "^0.12.10",
@@ -37,7 +37,7 @@
         "symplify/set-config-resolver": "^8.1.15",
         "symplify/smart-file-system": "^8.1.15",
         "tracy/tracy": "^2.7",
-        "phpstan/phpstan": "0.12.32"
+        "phpstan/phpstan": "^0.12.33"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -386,3 +386,4 @@ parameters:
         - '#Method Rector\\Nette\\NodeResolver\\FormVariableInputNameTypeResolver\:\:resolveFromGetComponentMethodCall\(\) should return array<string, string\> but returns array<int\|string, string\>#'
         - '#Method Rector\\Core\\PhpParser\\Node\\BetterNodeFinder\:\:findPreviousAssignToExpr\(\) should return PhpParser\\Node\\Expr\\Assign\|null but returns PhpParser\\Node\|null#'
         - '#Method Rector\\Nette\\FormControlTypeResolver\\GetComponentMethodCallFormControlTypeResolver\:\:resolve\(\) should return array<string, string\> but returns array<int\|string, string\>#'
+        - '#Class with base "LexerFactory" name is already used in "PHPStan\\Parser\\LexerFactory", "Rector\\Core\\PhpParser\\Parser\\LexerFactory"\. Use unique name to make classes easy to recognize#'

--- a/rules/dead-code/src/Rector/StaticCall/RemoveParentCallWithoutParentRector.php
+++ b/rules/dead-code/src/Rector/StaticCall/RemoveParentCallWithoutParentRector.php
@@ -93,7 +93,7 @@ PHP
         }
 
         if ($this->isAnonymousClass($classLike)) {
-            //currently the classMethodManipulator isn't able to find usages of anonymous classes
+            // currently the classMethodManipulator isn't able to find usages of anonymous classes
             return null;
         }
 


### PR DESCRIPTION
- Resolves #3771
- Resolves #3668 
- Resolves #3643 
- Resolves #3640 

To get to php-parser 4.7, now we have to wait for @phpstan release with supporting it.

@ondrejmirtes Hi Ondra. It would fix BC breaks php-parser and phpstan's scoped parser. These is race condition since php-aprser 4.6 and different classes are picked to autoload.

Latest 0.12.33 seems to be locked with php-parser 4.6.x, as constant is missing.

![image](https://user-images.githubusercontent.com/924196/88475615-fd67b200-cf31-11ea-87c9-8d54237ae5f2.png)

Any ETA on this? 
