### PR TITLE
move services by suffix bug demonstration

### DIFF
--- a/rector-ci.php
+++ b/rector-ci.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
+use Rector\Autodiscovery\Rector\FileSystem\MoveServicesBySuffixToDirectoryRector;
 use Rector\CodingStyle\Rector\ClassMethod\ReturnArrayClassMethodToYieldRector;
 use Rector\CodingStyle\Rector\String_\SplitStringClassConstantToClassConstFetchRector;
 use Rector\Core\Configuration\Option;
@@ -70,4 +71,18 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
         OrderPrivateMethodsByUseRector::class,
     ]);
+
+    $services
+        ->set(MoveServicesBySuffixToDirectoryRector::class)
+        ->call(
+            'configure',
+            [[
+                MoveServicesBySuffixToDirectoryRector::GROUP_NAMES_BY_SUFFIX => [
+                    'Repository',
+                    'Command',
+                    'Mapper',
+                    'Controller',
+                ],
+            ]]
+        );
 };

--- a/rules/autodiscovery/src/Rector/FileSystem/MoveServicesBySuffixToDirectoryRector.php
+++ b/rules/autodiscovery/src/Rector/FileSystem/MoveServicesBySuffixToDirectoryRector.php
@@ -77,6 +77,7 @@ PHP
 
     public function configure(array $configuration): void
     {
+		dump($configuration);
         $this->groupNamesBySuffix = $configuration[self::GROUP_NAMES_BY_SUFFIX] ?? [];
         dump('configure', $this->groupNamesBySuffix);
     }

--- a/rules/autodiscovery/src/Rector/FileSystem/MoveServicesBySuffixToDirectoryRector.php
+++ b/rules/autodiscovery/src/Rector/FileSystem/MoveServicesBySuffixToDirectoryRector.php
@@ -64,6 +64,7 @@ PHP
 
     public function refactor(SmartFileInfo $smartFileInfo): void
     {
+        dump('refactor', $this->groupNamesBySuffix);die;
         $nodes = $this->parseFileInfoToNodes($smartFileInfo);
 
         $class = $this->betterNodeFinder->findFirstInstanceOf($nodes, Class_::class);
@@ -77,6 +78,7 @@ PHP
     public function configure(array $configuration): void
     {
         $this->groupNamesBySuffix = $configuration[self::GROUP_NAMES_BY_SUFFIX] ?? [];
+        dump('configure', $this->groupNamesBySuffix);
     }
 
     /**


### PR DESCRIPTION
`MoveServicesBySuffixToDirectoryRector` does not work, actually it seems any `AbstractFileMovingFileSystemRector` does not. Tests shows false negative, I cannot reproduce it by test, but I can reproduce it by this "dirty" example. I have put two dumps to demonstate that when rector starts, configuration is set, but is not afterwards. Configuration variable is lost somewhere during rector run.. Here is screen:

![rector-move-services-bug](https://user-images.githubusercontent.com/16163762/89206054-f9cecd80-d5b8-11ea-8402-2892ed3026a8.png)
