### PR TITLE
Failing test: Reset in a condition produces a LogicException

### DIFF
--- a/rules/php70/tests/Rector/FuncCall/NonVariableToVariableOnFunctionCallRector/Fixture/reset_in_condition.php.inc
+++ b/rules/php70/tests/Rector/FuncCall/NonVariableToVariableOnFunctionCallRector/Fixture/reset_in_condition.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Php70\Tests\Rector\FuncCall\NonVariableToVariableOnFunctionCallRector\Fixture;
+
+function resetInCondition()
+{
+    if (reset([true])) {
+        return true;
+    }
+
+    return false;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Php70\Tests\Rector\FuncCall\NonVariableToVariableOnFunctionCallRector\Fixture;
+
+function resetInCondition()
+{
+    $tmp = [true];
+    if (reset($tmp)) {
+        return true;
+    }
+
+    return false;
+}
+
+?>


### PR DESCRIPTION
Hi guys!

Caught an exception with `NonVariableToVariableOnFunctionCallRector` over the code, I'm submitting here as a failing test.
I'm not good at `php-parser` yet so can't figure out how to fix it. See the stack trace below:

```
LogicException : leaveNode() may only return an array if the parent structure is an array
 /Users/silverfire/prj/github/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:163
 /Users/silverfire/prj/github/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:223
 /Users/silverfire/prj/github/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:114
 /Users/silverfire/prj/github/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:223
 /Users/silverfire/prj/github/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:114
 /Users/silverfire/prj/github/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:223
 /Users/silverfire/prj/github/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php:91
 /Users/silverfire/prj/github/rector/rector/packages/post-rector/src/Application/PostFileProcessor.php:36
 /Users/silverfire/prj/github/rector/rector/src/Application/FileProcessor.php:157
 /Users/silverfire/prj/github/rector/rector/src/Testing/PHPUnit/AbstractRectorTestCase.php:101
 /Users/silverfire/prj/github/rector/rector/src/Testing/PHPUnit/AbstractRectorTestCase.php:47
 /Users/silverfire/prj/github/rector/rector/rules/php70/tests/Rector/FuncCall/NonVariableToVariableOnFunctionCallRector/NonVariableToVariableOnFunctionCallRectorTest.php:19
```