### PR TITLE
Failing test: Multiple resets of the same func in a array

### DIFF
--- a/rules/php70/tests/Rector/FuncCall/NonVariableToVariableOnFunctionCallRector/Fixture/array_with_func_calls.php.inc
+++ b/rules/php70/tests/Rector/FuncCall/NonVariableToVariableOnFunctionCallRector/Fixture/array_with_func_calls.php.inc
@@ -1,0 +1,34 @@
+<?php
+
+namespace Rector\Php70\Tests\Rector\FuncCall\NonVariableToVariableOnFunctionCallRector\Fixture;
+
+function wrap($str) {}
+
+function baz() {
+    return [
+        reset(wrap('foo')),
+        reset(wrap('bar')),
+        reset(wrap('baz')),
+    ];
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Php70\Tests\Rector\FuncCall\NonVariableToVariableOnFunctionCallRector\Fixture;
+
+function wrap($str) {}
+
+function baz() {
+    $wrap = wrap('foo');
+    $wrap2 = wrap('bar');
+    $wrap3 = wrap('baz');
+    return [
+        reset($wrap),
+        reset($wrap2),
+        reset($wrap3),
+    ];
+}
+
+?>


### PR DESCRIPTION
Current behavior

<img width="638" alt="Screenshot 2020-08-21 at 19 31 39" src="https://user-images.githubusercontent.com/4499203/90913479-f9ba3480-e3e4-11ea-9efd-441a21bf8fcc.png">


As far as I see, after adding the first `$wrap` variable, the following line does not see a newly added variable

https://github.com/SilverFire/rector/blob/e5ba9e9f1a97b37db84d301f29d7103cab49ff90/src/Rector/AbstractRector.php#L261-L261