### PR TITLE
Fix variable name resolving for static method calls

### DIFF
--- a/rules/nette-kdyby/src/Naming/VariableNaming.php
+++ b/rules/nette-kdyby/src/Naming/VariableNaming.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Expr\Cast;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\NullsafeMethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Ternary;
@@ -24,6 +25,7 @@ use PHPStan\Type\Type;
 use Rector\CodingStyle\Naming\ClassNaming;
 use Rector\Core\Exception\NotImplementedException;
 use Rector\Core\Exception\NotImplementedYetException;
+use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\PhpParser\Node\Value\ValueResolver;
 use Rector\Core\Util\StaticRectorStrings;
 use Rector\NodeNameResolver\NodeNameResolver;
@@ -145,7 +147,10 @@ final class VariableNaming
             return $this->resolveFromPropertyFetch($node);
         }
 
-        if ($node instanceof MethodCall) {
+        if ($node instanceof MethodCall
+            || $node instanceof NullsafeMethodCall
+            || $node instanceof StaticCall
+        ) {
             return $this->resolveFromMethodCall($node);
         }
 
@@ -243,13 +248,20 @@ final class VariableNaming
         return $varName . ucfirst($propertyName);
     }
 
-    private function resolveFromMethodCall(MethodCall $methodCall): ?string
+    private function resolveFromMethodCall(Expr $expr): ?string
     {
-        if ($methodCall->name instanceof MethodCall) {
-            return $this->resolveFromMethodCall($methodCall->name);
+        if (! $expr instanceof MethodCall
+            && ! $expr instanceof NullsafeMethodCall
+            && ! $expr instanceof StaticCall
+        ) {
+            throw new ShouldNotHappenException('Only method calls are supported');
         }
 
-        $methodName = $this->nodeNameResolver->getName($methodCall->name);
+        if ($expr->name instanceof MethodCall) {
+            return $this->resolveFromMethodCall($expr->name);
+        }
+
+        $methodName = $this->nodeNameResolver->getName($expr->name);
         if (! is_string($methodName)) {
             return null;
         }

--- a/rules/nette-kdyby/src/Naming/VariableNaming.php
+++ b/rules/nette-kdyby/src/Naming/VariableNaming.php
@@ -254,7 +254,13 @@ final class VariableNaming
             && ! $expr instanceof NullsafeMethodCall
             && ! $expr instanceof StaticCall
         ) {
-            throw new ShouldNotHappenException('Only method calls are supported');
+            $allowedTypes = [MethodCall::class, NullsafeMethodCall::class, StaticCall::class];
+
+            throw new ShouldNotHappenException(sprintf(
+                'Only "%s" are supported, "%s" given',
+                implode('", "', $allowedTypes),
+                get_class($expr)
+            ));
         }
 
         if ($expr->name instanceof MethodCall) {

--- a/rules/php70/tests/Rector/FuncCall/NonVariableToVariableOnFunctionCallRector/Fixture/reset_over_static_call.php.inc
+++ b/rules/php70/tests/Rector/FuncCall/NonVariableToVariableOnFunctionCallRector/Fixture/reset_over_static_call.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\Php70\Tests\Rector\FuncCall\NonVariableToVariableOnFunctionCallRector\Fixture;
+
+class ResetOverStaticCall {
+    public static function test() {}
+}
+
+function run() {
+    return reset(ResetOverStaticCall::test());
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Php70\Tests\Rector\FuncCall\NonVariableToVariableOnFunctionCallRector\Fixture;
+
+class ResetOverStaticCall {
+    public static function test() {}
+}
+
+function run() {
+    $test = ResetOverStaticCall::test();
+    return reset($test);
+}
+
+?>


### PR DESCRIPTION
Fixes error

```
 [ERROR] Could not process "test.php" file, due to:                                            
         "Pick more specific node than "PhpParser\Node\Expr\StaticCall", e.g. "$node->name"      
```

for the case in the attached test