### PR TITLE
Fixed ClassMethodPropertyFetchManipulator to omit property assign by method call

### DIFF
--- a/rules/php74/tests/Rector/Property/TypedPropertyRector/Fixture/property_from_method_call.php.inc
+++ b/rules/php74/tests/Rector/Property/TypedPropertyRector/Fixture/property_from_method_call.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
+
+final class PropertyFromMethodCall
+{
+    private $object;
+
+    public function __construct()
+    {
+        $this->object = $this->createObject();
+    }
+
+    private function createObject()
+    {
+        return new \stdClass();
+    }
+}

--- a/src/PhpParser/Node/Manipulator/ClassMethodPropertyFetchManipulator.php
+++ b/src/PhpParser/Node/Manipulator/ClassMethodPropertyFetchManipulator.php
@@ -6,6 +6,8 @@ namespace Rector\Core\PhpParser\Node\Manipulator;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\NodeTraverser;
@@ -52,6 +54,10 @@ final class ClassMethodPropertyFetchManipulator
             }
 
             if (! $this->nodeNameResolver->isName($node->var, $propertyName)) {
+                return null;
+            }
+
+            if ($node->expr instanceof MethodCall || $node->expr instanceof StaticCall) {
                 return null;
             }
 


### PR DESCRIPTION
Before the fix, the following error occurred:

```
In NodeNameResolver.php line 223:
                                                                                                    
  [Rector\Core\Exception\ShouldNotHappenException]                                                  
  Pick more specific node than "PhpParser\Node\Expr\StaticCall", e.g. "$node->name"                 
```