### PR TITLE
Fixed some edge cases of creating constant name from value

### DIFF
--- a/rules/solid/tests/Rector/Class_/RepeatedLiteralToClassConstantRector/Fixture/beginning_with_number.php.inc
+++ b/rules/solid/tests/Rector/Class_/RepeatedLiteralToClassConstantRector/Fixture/beginning_with_number.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\SOLID\Tests\Rector\Class_\RepeatedLiteralToClassConstantRector\Fixture;
+
+class BeginningWithNumber
+{
+    public function run($key, $items)
+    {
+        if ($key === '1mb') {
+            return $items['1mb'];
+        }
+
+        return $items['1mb'];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\SOLID\Tests\Rector\Class_\RepeatedLiteralToClassConstantRector\Fixture;
+
+class BeginningWithNumber
+{
+    /**
+     * @var string
+     */
+    private const CONST_1_MB = '1mb';
+    public function run($key, $items)
+    {
+        if ($key === self::CONST_1_MB) {
+            return $items[self::CONST_1_MB];
+        }
+
+        return $items[self::CONST_1_MB];
+    }
+}
+
+?>

--- a/rules/solid/tests/Rector/Class_/RepeatedLiteralToClassConstantRector/Fixture/with_dash_and_number.php.inc
+++ b/rules/solid/tests/Rector/Class_/RepeatedLiteralToClassConstantRector/Fixture/with_dash_and_number.php.inc
@@ -1,0 +1,61 @@
+<?php
+
+namespace Rector\SOLID\Tests\Rector\Class_\RepeatedLiteralToClassConstantRector\Fixture;
+
+class WithDashAndNumber
+{
+    public function run($key, $items)
+    {
+        if ($key === 'UTF-8') {
+            return $items['UTF-8'];
+        }
+
+        return $items['UTF-8'];
+    }
+
+    public function runFaster($key, $items)
+    {
+        if ($key === 'camelCase-4') {
+            return $items['camelCase-4'];
+        }
+
+        return $items['camelCase-4'];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\SOLID\Tests\Rector\Class_\RepeatedLiteralToClassConstantRector\Fixture;
+
+class WithDashAndNumber
+{
+    /**
+     * @var string
+     */
+    private const UTF_8 = 'UTF-8';
+    /**
+     * @var string
+     */
+    private const CAMEL_CASE_4 = 'camelCase-4';
+    public function run($key, $items)
+    {
+        if ($key === self::UTF_8) {
+            return $items[self::UTF_8];
+        }
+
+        return $items[self::UTF_8];
+    }
+
+    public function runFaster($key, $items)
+    {
+        if ($key === self::CAMEL_CASE_4) {
+            return $items[self::CAMEL_CASE_4];
+        }
+
+        return $items[self::CAMEL_CASE_4];
+    }
+}
+
+?>


### PR DESCRIPTION
Fixed constant names created from values:

| Bug | Value | Original constant | Fixed constant |
| - | - | - | - |
| empty string (syntax error) | "UTF-8" | | UTF-8 |
| trimmed number  | "camelCase-2" | CAMEL_CASE | CAMEL_CASE_2 |
| constant beginning with number (syntax error) | "1mb" | 1_MB | CONST_1_MB |