### PR TITLE
[Code Quality] If the whole concatenated string is longer than 120 chars, skip it

### DIFF
--- a/rules/code-quality/tests/Rector/Concat/JoinStringConcatRector/Fixture/skip_when_one_of_the_lines_becomes_longer_than_120.php.inc
+++ b/rules/code-quality/tests/Rector/Concat/JoinStringConcatRector/Fixture/skip_when_one_of_the_lines_becomes_longer_than_120.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\CodeQuality\Tests\Rector\Concat\JoinStringConcatRector\Fixture;
+
+class SkipWhenOneOfTheLinesBecomesLongerThan120
+{
+    public function run()
+    {
+        $name = 'How it works? ' .
+            '1. It adds $uuid property to entities. ' .
+            '2. It makes things better. ' .
+            'And finally: ' .
+            'Require for step-by-step migration from int to uuid. ' .
+            'In following step it should be renamed to $id and replace it';
+    }
+}


### PR DESCRIPTION
This enhancement of `JoinStringConcatRector` prevents string joining if the whole concatenated string is longer than 120 chars

Useful for multi-line docs, CLI calls, etc.