### PR TITLE
Replace types with container access from fe72e003e. fixes #4090

### DIFF
--- a/rules/symfony/src/Rector/MethodCall/ContainerGetToConstructorInjectionRector.php
+++ b/rules/symfony/src/Rector/MethodCall/ContainerGetToConstructorInjectionRector.php
@@ -26,7 +26,10 @@ final class ContainerGetToConstructorInjectionRector extends AbstractToConstruct
     /**
      * @var string[]
      */
-    private $containerAwareParentTypes = [];
+    private $containerAwareParentTypes = [
+        'Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand',
+        'Symfony\Bundle\FrameworkBundle\Controller\Controller',
+    ];
 
     public function getDefinition(): RectorDefinition
     {

--- a/rules/symfony/src/Rector/MethodCall/GetToConstructorInjectionRector.php
+++ b/rules/symfony/src/Rector/MethodCall/GetToConstructorInjectionRector.php
@@ -23,7 +23,10 @@ final class GetToConstructorInjectionRector extends AbstractToConstructorInjecti
     /**
      * @var string[]
      */
-    private $getMethodAwareTypes = [];
+    private $getMethodAwareTypes = [
+        'Symfony\Bundle\FrameworkBundle\Controller\Controller',
+        'Symfony\Bundle\FrameworkBundle\Controller\ControllerTrait',
+    ];
 
     public function getDefinition(): RectorDefinition
     {


### PR DESCRIPTION
The properties `$containerAwareParentTypes` & `$getMethodAwareTypes` are set as property defaults, so that if they were explicitly enabled (without using config/set/symfony-constructor-injection.php), they would still work as expected without additional setup needed.

Other 'ContainerAware' classes may be useful to add, such as `\Symfony\Component\DependencyInjection\ContainerAwareTrait` & '\Symfony\Component\DependencyInjection\ContainerAwareInterface'. 