### PR TITLE
Fixes #4013 ConsoleExecuteReturnIntRector ignores already type casted variable

### DIFF
--- a/rules/symfony/src/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
+++ b/rules/symfony/src/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
@@ -113,7 +113,6 @@ PHP
             }
 
             if ($node->expr instanceof Int_) {
-                $hasReturn = true;
                 return null;
             }
 

--- a/rules/symfony/src/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
+++ b/rules/symfony/src/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
@@ -112,6 +112,11 @@ PHP
                 return null;
             }
 
+            if ($node->expr instanceof Int_) {
+                $hasReturn = true;
+                return null;
+            }
+
             // is there return without nesting?
             if ($this->areNodesEqual($node->getAttribute(AttributeKey::PARENT_NODE), $classMethod)) {
                 $hasReturn = true;

--- a/rules/symfony/tests/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/skip-already-typehinted.php.inc
+++ b/rules/symfony/tests/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/skip-already-typehinted.php.inc
@@ -1,0 +1,65 @@
+<?php
+
+namespace Rector\Symfony\Tests\Rector\ClassMethod\ConsoleExecuteReturnIntRector\Fixture;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+abstract class AbstractSkipAlreadyTypeHintedCommand extends Command
+{
+    public function execute(InputInterface $input, OutputInterface $output):int
+    {
+        return 1;
+    }
+}
+
+final class SkipAlreadyTypeHintedCommand extends AbstractSkipAlreadyTypeHintedCommand
+{
+    protected static $defaultName = 'shq:user:create';
+
+    public function execute(InputInterface $input, OutputInterface $output):int
+    {
+        $initialized = parent::execute($input, $output);
+        if (0 !== $initialized) {
+            return (int) $initialized;
+        }
+
+        return 0;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Symfony\Tests\Rector\ClassMethod\ConsoleExecuteReturnIntRector\Fixture;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+abstract class AbstractSkipAlreadyTypeHintedCommand extends Command
+{
+    public function execute(InputInterface $input, OutputInterface $output):int
+    {
+        return 1;
+    }
+}
+
+final class SkipAlreadyTypeHintedCommand extends AbstractSkipAlreadyTypeHintedCommand
+{
+    protected static $defaultName = 'shq:user:create';
+
+    public function execute(InputInterface $input, OutputInterface $output):int
+    {
+        $initialized = parent::execute($input, $output);
+        if (0 !== $initialized) {
+            return (int) $initialized;
+        }
+
+        return 0;
+    }
+}
+
+?>

--- a/rules/symfony/tests/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/skip-already-typehinted.php.inc
+++ b/rules/symfony/tests/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/skip-already-typehinted.php.inc
@@ -29,37 +29,3 @@ final class SkipAlreadyTypeHintedCommand extends AbstractSkipAlreadyTypeHintedCo
     }
 }
 
-?>
------
-<?php
-
-namespace Rector\Symfony\Tests\Rector\ClassMethod\ConsoleExecuteReturnIntRector\Fixture;
-
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
-
-abstract class AbstractSkipAlreadyTypeHintedCommand extends Command
-{
-    public function execute(InputInterface $input, OutputInterface $output):int
-    {
-        return 1;
-    }
-}
-
-final class SkipAlreadyTypeHintedCommand extends AbstractSkipAlreadyTypeHintedCommand
-{
-    protected static $defaultName = 'shq:user:create';
-
-    public function execute(InputInterface $input, OutputInterface $output):int
-    {
-        $initialized = parent::execute($input, $output);
-        if (0 !== $initialized) {
-            return (int) $initialized;
-        }
-
-        return 0;
-    }
-}
-
-?>


### PR DESCRIPTION
Fixes #4013