### PR TITLE
[PHPUnit] Add self call fixtures for AssertEqualsToSame rule

### DIFF
--- a/rules/phpunit/src/Rector/MethodCall/AssertEqualsToSameRector.php
+++ b/rules/phpunit/src/Rector/MethodCall/AssertEqualsToSameRector.php
@@ -7,6 +7,7 @@ namespace Rector\PHPUnit\Rector\MethodCall;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Type\FloatType;
 use PHPStan\Type\IntegerType;
@@ -71,11 +72,11 @@ final class AssertEqualsToSameRector extends AbstractPHPUnitRector
      */
     public function getNodeTypes(): array
     {
-        return [MethodCall::class];
+        return [MethodCall::class, StaticCall::class];
     }
 
     /**
-     * @param MethodCall $node
+     * @param MethodCall|StaticCall $node
      */
     public function refactor(Node $node): ?Node
     {

--- a/rules/phpunit/tests/Rector/MethodCall/AssertEqualsToSameRector/Fixture/fixture_2.php.inc
+++ b/rules/phpunit/tests/Rector/MethodCall/AssertEqualsToSameRector/Fixture/fixture_2.php.inc
@@ -1,0 +1,51 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\MethodCall\AssertEqualsToSameRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class MyTest2 extends TestCase
+{
+    public function test()
+    {
+        $int = 1;
+        $expectedInt = 1;
+        self::assertEquals($expectedInt, $int);
+
+        $float = 1.1;
+        $expectedFloat = 1.1;
+        self::assertEquals($expectedFloat, $float);
+
+        $string = 'abc';
+        $expectedString = 'abc';
+        self::assertEquals($expectedString, $string);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\MethodCall\AssertEqualsToSameRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class MyTest2 extends TestCase
+{
+    public function test()
+    {
+        $int = 1;
+        $expectedInt = 1;
+        self::assertSame($expectedInt, $int);
+
+        $float = 1.1;
+        $expectedFloat = 1.1;
+        self::assertSame($expectedFloat, $float);
+
+        $string = 'abc';
+        $expectedString = 'abc';
+        self::assertSame($expectedString, $string);
+    }
+}
+
+?>

--- a/rules/phpunit/tests/Rector/MethodCall/AssertEqualsToSameRector/Fixture/skip_2.php.inc
+++ b/rules/phpunit/tests/Rector/MethodCall/AssertEqualsToSameRector/Fixture/skip_2.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rector\PHPUnit\Tests\Rector\MethodCall\AssertEqualsToSameRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class MySkipTest2 extends TestCase
+{
+    public function test()
+    {
+        $null = null;
+        $expectedNull = null;
+        self::assertEquals($expectedNull, $null);
+
+        $bool = true;
+        $expectedBool = true;
+        self::assertEquals($expectedBool, $bool);
+
+        $array = [];
+        $expectedArray = [];
+        self::assertEquals($expectedArray, $array);
+    }
+}


### PR DESCRIPTION
# Changed log

- There're two approaches about calling PHPUnit assertion methods.
One is about the `$this` and another is about the `self`.
- The ` AssertEqualsToSameRector` class should add fixtures about `self` method call.