### PR TITLE
Configurable downgrade

### DIFF
--- a/rules/downgrade/src/Rector/Property/DowngradeTypedPropertyRector.php
+++ b/rules/downgrade/src/Rector/Property/DowngradeTypedPropertyRector.php
@@ -6,12 +6,12 @@ namespace Rector\Downgrade\Rector\Property;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Property;
-use Rector\Core\Rector\AbstractRector;
-use Rector\Core\RectorDefinition\CodeSample;
-use Rector\NodeTypeResolver\Node\AttributeKey;
-use Rector\Core\RectorDefinition\RectorDefinition;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\RectorDefinition\CodeSample;
+use Rector\Core\RectorDefinition\RectorDefinition;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 
 /**
  * @see \Rector\Downgrade\Tests\Rector\Property\DowngradeTypedPropertyRector\DowngradeTypedPropertyRectorTest

--- a/rules/downgrade/tests/Rector/Property/NoDocBlockDowngradeTypedPropertyRector/DowngradeTypedPropertyRectorTest.php
+++ b/rules/downgrade/tests/Rector/Property/NoDocBlockDowngradeTypedPropertyRector/DowngradeTypedPropertyRectorTest.php
@@ -32,7 +32,7 @@ final class DowngradeTypedPropertyRectorTest extends AbstractRectorTestCase
     {
         return [
             DowngradeTypedPropertyRector::class => [
-                DowngradeTypedPropertyRector::ADD_DOC_BLOCK => true,
+                DowngradeTypedPropertyRector::ADD_DOC_BLOCK => false,
             ],
         ];
     }

--- a/rules/downgrade/tests/Rector/Property/NoDocBlockDowngradeTypedPropertyRector/DowngradeTypedPropertyRectorTest.php
+++ b/rules/downgrade/tests/Rector/Property/NoDocBlockDowngradeTypedPropertyRector/DowngradeTypedPropertyRectorTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Downgrade\Tests\Rector\Property\DowngradeTypedPropertyRector;
+namespace Rector\Downgrade\Tests\Rector\Property\NoDocBlockDowngradeTypedPropertyRector;
 
 use Iterator;
 use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;

--- a/rules/downgrade/tests/Rector/Property/NoDocBlockDowngradeTypedPropertyRector/Fixture/classname_nullable_type.php.inc
+++ b/rules/downgrade/tests/Rector/Property/NoDocBlockDowngradeTypedPropertyRector/Fixture/classname_nullable_type.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Downgrade\Tests\Rector\Property\DowngradeTypedPropertyRector\Fixture;
+
+use Rector\Downgrade\Tests\Rector\Property\DowngradeTypedPropertyRector\Source\AnotherClass;
+
+class ClassNameNullableTypeClass
+{
+    private ?AnotherClass $property;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Downgrade\Tests\Rector\Property\DowngradeTypedPropertyRector\Fixture;
+
+use Rector\Downgrade\Tests\Rector\Property\DowngradeTypedPropertyRector\Source\AnotherClass;
+
+class ClassNameNullableTypeClass
+{
+    private $property;
+}
+
+?>

--- a/rules/downgrade/tests/Rector/Property/NoDocBlockDowngradeTypedPropertyRector/Fixture/classname_nullable_type.php.inc
+++ b/rules/downgrade/tests/Rector/Property/NoDocBlockDowngradeTypedPropertyRector/Fixture/classname_nullable_type.php.inc
@@ -1,8 +1,8 @@
 <?php
 
-namespace Rector\Downgrade\Tests\Rector\Property\DowngradeTypedPropertyRector\Fixture;
+namespace Rector\Downgrade\Tests\Rector\Property\NoDocBlockDowngradeTypedPropertyRector\Fixture;
 
-use Rector\Downgrade\Tests\Rector\Property\DowngradeTypedPropertyRector\Source\AnotherClass;
+use Rector\Downgrade\Tests\Rector\Property\NoDocBlockDowngradeTypedPropertyRector\Source\AnotherClass;
 
 class ClassNameNullableTypeClass
 {
@@ -13,9 +13,9 @@ class ClassNameNullableTypeClass
 -----
 <?php
 
-namespace Rector\Downgrade\Tests\Rector\Property\DowngradeTypedPropertyRector\Fixture;
+namespace Rector\Downgrade\Tests\Rector\Property\NoDocBlockDowngradeTypedPropertyRector\Fixture;
 
-use Rector\Downgrade\Tests\Rector\Property\DowngradeTypedPropertyRector\Source\AnotherClass;
+use Rector\Downgrade\Tests\Rector\Property\NoDocBlockDowngradeTypedPropertyRector\Source\AnotherClass;
 
 class ClassNameNullableTypeClass
 {

--- a/rules/downgrade/tests/Rector/Property/NoDocBlockDowngradeTypedPropertyRector/Fixture/classname_type.php.inc
+++ b/rules/downgrade/tests/Rector/Property/NoDocBlockDowngradeTypedPropertyRector/Fixture/classname_type.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Downgrade\Tests\Rector\Property\DowngradeTypedPropertyRector\Fixture;
+
+class ClassNameClass {
+    private \Rector\Downgrade\Tests\Rector\Property\DowngradeTypedPropertyRector\Source\AnotherClass $property;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Downgrade\Tests\Rector\Property\DowngradeTypedPropertyRector\Fixture;
+
+class ClassNameClass {
+    private $property;
+}
+
+?>

--- a/rules/downgrade/tests/Rector/Property/NoDocBlockDowngradeTypedPropertyRector/Fixture/classname_type.php.inc
+++ b/rules/downgrade/tests/Rector/Property/NoDocBlockDowngradeTypedPropertyRector/Fixture/classname_type.php.inc
@@ -1,16 +1,16 @@
 <?php
 
-namespace Rector\Downgrade\Tests\Rector\Property\DowngradeTypedPropertyRector\Fixture;
+namespace Rector\Downgrade\Tests\Rector\Property\NoDocBlockDowngradeTypedPropertyRector\Fixture;
 
 class ClassNameClass {
-    private \Rector\Downgrade\Tests\Rector\Property\DowngradeTypedPropertyRector\Source\AnotherClass $property;
+    private \Rector\Downgrade\Tests\Rector\Property\NoDocBlockDowngradeTypedPropertyRector\Source\AnotherClass $property;
 }
 
 ?>
 -----
 <?php
 
-namespace Rector\Downgrade\Tests\Rector\Property\DowngradeTypedPropertyRector\Fixture;
+namespace Rector\Downgrade\Tests\Rector\Property\NoDocBlockDowngradeTypedPropertyRector\Fixture;
 
 class ClassNameClass {
     private $property;

--- a/rules/downgrade/tests/Rector/Property/NoDocBlockDowngradeTypedPropertyRector/Fixture/docblock_exists.php.inc
+++ b/rules/downgrade/tests/Rector/Property/NoDocBlockDowngradeTypedPropertyRector/Fixture/docblock_exists.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Downgrade\Tests\Rector\Property\DowngradeTypedPropertyRector\Fixture;
+namespace Rector\Downgrade\Tests\Rector\Property\NoDocBlockDowngradeTypedPropertyRector\Fixture;
 
 class DocBlockExists {
     /**
@@ -13,7 +13,7 @@ class DocBlockExists {
 -----
 <?php
 
-namespace Rector\Downgrade\Tests\Rector\Property\DowngradeTypedPropertyRector\Fixture;
+namespace Rector\Downgrade\Tests\Rector\Property\NoDocBlockDowngradeTypedPropertyRector\Fixture;
 
 class DocBlockExists {
     /**

--- a/rules/downgrade/tests/Rector/Property/NoDocBlockDowngradeTypedPropertyRector/Fixture/docblock_exists.php.inc
+++ b/rules/downgrade/tests/Rector/Property/NoDocBlockDowngradeTypedPropertyRector/Fixture/docblock_exists.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Downgrade\Tests\Rector\Property\DowngradeTypedPropertyRector\Fixture;
+
+class DocBlockExists {
+    /**
+     * This property is the best one
+     */
+    private ?string $property;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Downgrade\Tests\Rector\Property\DowngradeTypedPropertyRector\Fixture;
+
+class DocBlockExists {
+    /**
+     * This property is the best one
+     */
+    private $property;
+}
+
+?>

--- a/rules/downgrade/tests/Rector/Property/NoDocBlockDowngradeTypedPropertyRector/Fixture/fixture.php.inc
+++ b/rules/downgrade/tests/Rector/Property/NoDocBlockDowngradeTypedPropertyRector/Fixture/fixture.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Downgrade\Tests\Rector\Property\DowngradeTypedPropertyRector\Fixture;
+
+class SomeClass
+{
+    private string $property;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Downgrade\Tests\Rector\Property\DowngradeTypedPropertyRector\Fixture;
+
+class SomeClass
+{
+    private $property;
+}
+
+?>

--- a/rules/downgrade/tests/Rector/Property/NoDocBlockDowngradeTypedPropertyRector/Fixture/fixture.php.inc
+++ b/rules/downgrade/tests/Rector/Property/NoDocBlockDowngradeTypedPropertyRector/Fixture/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Downgrade\Tests\Rector\Property\DowngradeTypedPropertyRector\Fixture;
+namespace Rector\Downgrade\Tests\Rector\Property\NoDocBlockDowngradeTypedPropertyRector\Fixture;
 
 class SomeClass
 {
@@ -11,7 +11,7 @@ class SomeClass
 -----
 <?php
 
-namespace Rector\Downgrade\Tests\Rector\Property\DowngradeTypedPropertyRector\Fixture;
+namespace Rector\Downgrade\Tests\Rector\Property\NoDocBlockDowngradeTypedPropertyRector\Fixture;
 
 class SomeClass
 {

--- a/rules/downgrade/tests/Rector/Property/NoDocBlockDowngradeTypedPropertyRector/Fixture/nullable_type.php.inc
+++ b/rules/downgrade/tests/Rector/Property/NoDocBlockDowngradeTypedPropertyRector/Fixture/nullable_type.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Downgrade\Tests\Rector\Property\DowngradeTypedPropertyRector\Fixture;
+namespace Rector\Downgrade\Tests\Rector\Property\NoDocBlockDowngradeTypedPropertyRector\Fixture;
 
 class NullableTypeClass {
     private ?string $property;
@@ -10,7 +10,7 @@ class NullableTypeClass {
 -----
 <?php
 
-namespace Rector\Downgrade\Tests\Rector\Property\DowngradeTypedPropertyRector\Fixture;
+namespace Rector\Downgrade\Tests\Rector\Property\NoDocBlockDowngradeTypedPropertyRector\Fixture;
 
 class NullableTypeClass {
     private $property;

--- a/rules/downgrade/tests/Rector/Property/NoDocBlockDowngradeTypedPropertyRector/Fixture/nullable_type.php.inc
+++ b/rules/downgrade/tests/Rector/Property/NoDocBlockDowngradeTypedPropertyRector/Fixture/nullable_type.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Downgrade\Tests\Rector\Property\DowngradeTypedPropertyRector\Fixture;
+
+class NullableTypeClass {
+    private ?string $property;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Downgrade\Tests\Rector\Property\DowngradeTypedPropertyRector\Fixture;
+
+class NullableTypeClass {
+    private $property;
+}
+
+?>

--- a/rules/downgrade/tests/Rector/Property/NoDocBlockDowngradeTypedPropertyRector/Source/AnotherClass.php
+++ b/rules/downgrade/tests/Rector/Property/NoDocBlockDowngradeTypedPropertyRector/Source/AnotherClass.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Rector\Downgrade\Tests\Rector\Property\NoDocBlockDowngradeTypedPropertyRector\Source;
+
+
+class AnotherClass
+{
+
+}


### PR DESCRIPTION
Fixes #4094 

Please check the following:

- Option called `ADD_DOC_BLOCK`
- Default value: `true`
- To configure it, I've added in `rector.php`:

```php
// Don't output the docBlocks when removing typed properties
$services = $containerConfigurator->services();
$services->set(DowngradeTypedPropertyRector::class)
    ->call('configure', [[
        DowngradeTypedPropertyRector::ADD_DOC_BLOCK => false,
    ]]);
```

Is this right? (Btw, it took me some time to find out about how to configure rectors, this info is not in the README... maybe you want to add a section to explain?)

- The tests have 2 configuration values (`true` and `false`). I couldn't find an example of a same test for different configurations. So I kept the original test (`DowngradeTypedPropertyRector`), and duplicated it under as `NoDocBlockDowngradeTypedPropertyRector\DowngradeTypedPropertyRector`. Is this ok?