### PR TITLE
Fixes #3930 : TypedPropertyRector should not remove DocBlock comment when it specifies the values contained in an array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ rector-recipe.php
 
 # testing
 abz
+/rector-temp-phpstan*.neon

--- a/rules/php74/src/Rector/Property/TypedPropertyRector.php
+++ b/rules/php74/src/Rector/Property/TypedPropertyRector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Php74\Rector\Property;
 
+use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Name;
 use PhpParser\Node\NullableType;
@@ -252,7 +253,7 @@ PHP
     {
         $possibleTypes = explode('|', (string) $varTagValueNode->type);
         foreach ($possibleTypes as $type) {
-            if (substr($type, -2) === '[]' && class_exists(rtrim($type, '[]'))) {
+            if (Strings::substring($type, -2) === '[]' && class_exists(rtrim($type, '[]'))) {
                 return true;
             }
         }

--- a/rules/php74/src/Rector/Property/TypedPropertyRector.php
+++ b/rules/php74/src/Rector/Property/TypedPropertyRector.php
@@ -253,7 +253,7 @@ PHP
     {
         if ($varTagValueNode->type instanceof AttributeAwareUnionTypeNode) {
             foreach ($varTagValueNode->type->types as $type) {
-                if (class_exists(rtrim((string) $type, '[]'))) {
+                if (property_exists($type, 'type') && class_exists($type->type->name)) {
                     return true;
                 }
             }

--- a/rules/php74/src/Rector/Property/TypedPropertyRector.php
+++ b/rules/php74/src/Rector/Property/TypedPropertyRector.php
@@ -254,7 +254,7 @@ PHP
     {
         if ($varTagValueNode->type instanceof AttributeAwareUnionTypeNode) {
             foreach ($varTagValueNode->type->types as $type) {
-                if ($type instanceof AttributeAwareArrayTypeNode && class_exists($type->type->name)) {
+                if ($type instanceof AttributeAwareArrayTypeNode && class_exists((string) $type->type)) {
                     return true;
                 }
             }

--- a/rules/php74/src/Rector/Property/TypedPropertyRector.php
+++ b/rules/php74/src/Rector/Property/TypedPropertyRector.php
@@ -16,6 +16,7 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
+use Rector\AttributeAwarePhpDoc\Ast\Type\AttributeAwareArrayTypeNode;
 use Rector\AttributeAwarePhpDoc\Ast\Type\AttributeAwareUnionTypeNode;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
@@ -253,7 +254,7 @@ PHP
     {
         if ($varTagValueNode->type instanceof AttributeAwareUnionTypeNode) {
             foreach ($varTagValueNode->type->types as $type) {
-                if (property_exists($type, 'type') && class_exists($type->type->name)) {
+                if ($type instanceof AttributeAwareArrayTypeNode && class_exists($type->type->name)) {
                     return true;
                 }
             }

--- a/rules/php74/src/Rector/Property/TypedPropertyRector.php
+++ b/rules/php74/src/Rector/Property/TypedPropertyRector.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\Php74\Rector\Property;
 
-use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Name;
 use PhpParser\Node\NullableType;
@@ -251,10 +250,11 @@ PHP
 
     private function isNonBasicArrayType(Property $property, VarTagValueNode $varTagValueNode): bool
     {
-        $possibleTypes = explode('|', (string) $varTagValueNode->type);
-        foreach ($possibleTypes as $type) {
-            if (Strings::substring($type, -2) === '[]' && class_exists(rtrim($type, '[]'))) {
-                return true;
+        if (property_exists($varTagValueNode->type, 'types')) {
+            foreach ($varTagValueNode->type->types as $type) {
+                if (class_exists(rtrim((string) $type, '[]'))) {
+                    return true;
+                }
             }
         }
 

--- a/rules/php74/src/Rector/Property/TypedPropertyRector.php
+++ b/rules/php74/src/Rector/Property/TypedPropertyRector.php
@@ -16,6 +16,7 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
+use Rector\AttributeAwarePhpDoc\Ast\Type\AttributeAwareUnionTypeNode;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\RectorDefinition\CodeSample;
@@ -250,7 +251,7 @@ PHP
 
     private function isNonBasicArrayType(Property $property, VarTagValueNode $varTagValueNode): bool
     {
-        if (property_exists($varTagValueNode->type, 'types')) {
+        if ($varTagValueNode->type instanceof AttributeAwareUnionTypeNode) {
             foreach ($varTagValueNode->type->types as $type) {
                 if (class_exists(rtrim((string) $type, '[]'))) {
                     return true;

--- a/rules/php74/src/Rector/Property/TypedPropertyRector.php
+++ b/rules/php74/src/Rector/Property/TypedPropertyRector.php
@@ -250,6 +250,13 @@ PHP
 
     private function isNonBasicArrayType(Property $property, VarTagValueNode $varTagValueNode): bool
     {
+        $possibleTypes = explode('|', (string) $varTagValueNode->type);
+        foreach ($possibleTypes as $type) {
+            if (substr($type, -2) === '[]' && class_exists(rtrim($type, '[]'))) {
+                return true;
+            }
+        }
+
         if (! $this->isArrayTypeNode($varTagValueNode)) {
             return false;
         }

--- a/rules/php74/tests/Rector/Property/TypedPropertyRector/Fixture/do_not_remove_class_docblock_array.php.inc
+++ b/rules/php74/tests/Rector/Property/TypedPropertyRector/Fixture/do_not_remove_class_docblock_array.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
 
-final class SkipClassDocblockArray
+final class DonotRemoveClassDocblockArray
 {
     /**
      * @var \DateTime[]|null
@@ -16,7 +16,7 @@ final class SkipClassDocblockArray
 
 namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
 
-final class SkipClassDocblockArray
+final class DonotRemoveClassDocblockArray
 {
     /**
      * @var \DateTime[]|null

--- a/rules/php74/tests/Rector/Property/TypedPropertyRector/Fixture/skip_class_docblock_array.php.inc
+++ b/rules/php74/tests/Rector/Property/TypedPropertyRector/Fixture/skip_class_docblock_array.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
+
+final class SkipClassDocblockArray
+{
+    /**
+     * @var \DateTime[]|null
+     */
+    private $times2;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
+
+final class SkipClassDocblockArray
+{
+    /**
+     * @var \DateTime[]|null
+     */
+    private ?array $times2 = null;
+}
+
+?>


### PR DESCRIPTION
Fixes #3930

Signed-off-by: Abdul Malik Ikhsan <samsonasik@gmail.com>