### PR TITLE
Abstract downgrade type + Implementation for object type

### DIFF
--- a/config/set/downgrade.php
+++ b/config/set/downgrade.php
@@ -2,11 +2,17 @@
 
 declare(strict_types=1);
 
+use Rector\Downgrade\Rector\FunctionLike\DowngradeParamObjectTypeDeclarationRector;
+use Rector\Downgrade\Rector\FunctionLike\DowngradeReturnObjectTypeDeclarationRector;
 use Rector\Downgrade\Rector\Property\DowngradeTypedPropertyRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
+
+    $services->set(DowngradeParamObjectTypeDeclarationRector::class);
+
+    $services->set(DowngradeReturnObjectTypeDeclarationRector::class);
 
     $services->set(DowngradeTypedPropertyRector::class);
 };

--- a/rules/downgrade/src/Contract/Rector/DowngradeRectorInterface.php
+++ b/rules/downgrade/src/Contract/Rector/DowngradeRectorInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Downgrade\Rector;
+namespace Rector\Downgrade\Contract\Rector;
 
 interface DowngradeRectorInterface
 {

--- a/rules/downgrade/src/Contract/Rector/DowngradeTypeRectorInterface.php
+++ b/rules/downgrade/src/Contract/Rector/DowngradeTypeRectorInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Downgrade\Contract\Rector;
+
+interface DowngradeTypeRectorInterface
+{
+    /**
+     * Name of the type to remove
+     */
+    public function getTypeNameToRemove(): string;
+}

--- a/rules/downgrade/src/Rector/DowngradeRectorInterface.php
+++ b/rules/downgrade/src/Rector/DowngradeRectorInterface.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Rector\Downgrade\Rector;
 
-trait DowngradeRectorTrait
+interface DowngradeRectorInterface
 {
     /**
      * Run the rector only when the feature is not supported
      */
-    abstract protected function getPhpVersionFeature(): string;
+    function getPhpVersionFeature(): string;
 }

--- a/rules/downgrade/src/Rector/DowngradeRectorInterface.php
+++ b/rules/downgrade/src/Rector/DowngradeRectorInterface.php
@@ -9,5 +9,5 @@ interface DowngradeRectorInterface
     /**
      * Run the rector only when the feature is not supported
      */
-    function getPhpVersionFeature(): string;
+    public function getPhpVersionFeature(): string;
 }

--- a/rules/downgrade/src/Rector/DowngradeRectorTrait.php
+++ b/rules/downgrade/src/Rector/DowngradeRectorTrait.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Downgrade\Rector;
+
+trait DowngradeRectorTrait
+{
+    /**
+     * Run the rector only when the feature is not supported
+     */
+    abstract protected function getPhpVersionFeature(): string;
+}

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
@@ -13,14 +13,12 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
-use Rector\Downgrade\Rector\DowngradeRectorTrait;
+use Rector\Downgrade\Rector\DowngradeRectorInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\TypeDeclaration\Rector\FunctionLike\AbstractTypeDeclarationRector;
 
-abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeDeclarationRector implements ConfigurableRectorInterface
+abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeDeclarationRector implements ConfigurableRectorInterface, DowngradeRectorInterface
 {
-    use DowngradeRectorTrait;
-
     /**
      * @var string
      */

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
@@ -13,7 +13,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
-use Rector\Downgrade\Rector\DowngradeRectorInterface;
+use Rector\Downgrade\Contract\Rector\DowngradeRectorInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\TypeDeclaration\Rector\FunctionLike\AbstractTypeDeclarationRector;
 

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
@@ -12,9 +12,10 @@ use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Downgrade\Rector\DowngradeRectorTrait;
+use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\TypeDeclaration\Rector\FunctionLike\AbstractTypeDeclarationRector;
 
-abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeDeclarationRector
+abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeDeclarationRector implements ConfigurableRectorInterface
 {
     use DowngradeRectorTrait;
 

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
@@ -111,7 +111,15 @@ abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeD
         }
 
         // If it is the NullableType, extract the name from its inner type
-        $typeName = $isNullableType ? $this->getName($param->type->type) : $this->getName($param->type);
+        if ($isNullableType) {
+            /**
+             * @var NullableType
+             */
+            $nullableType = $param->type;
+            $typeName = $this->getName($nullableType->type);
+        } else {
+            $typeName = $this->getName($param->type);
+        }
 
         // Check it is the type to be removed
         return $typeName !== $this->getParamTypeName();

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
@@ -111,7 +111,7 @@ abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeD
         }
 
         // If it is the NullableType, extract the name from its inner type
-        $typeName = $isNullableType ? $param->type->type->name : $param->type->name;
+        $typeName = $isNullableType ? $this->getName($param->type->type) : $this->getName($param->type);
 
         // Check it is the type to be removed
         return $typeName !== $this->getParamTypeName();

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
@@ -107,7 +107,7 @@ abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeD
 
         // It can either be the type, or the nullable type (eg: ?object)
         $isNullableType = $param->type instanceof NullableType;
-        if (!$param->type instanceof Identifier && !$isNullableType) {
+        if (! $param->type instanceof Identifier && ! $isNullableType) {
             return true;
         }
 

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Param;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\FunctionLike;
+use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -92,12 +93,17 @@ abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeD
             return true;
         }
 
-        if (!($param->type instanceof Identifier)) {
+        // It can either be the type, or the nullable type (eg: ?object)
+        $isNullableType = $param->type instanceof NullableType;
+        if (!($param->type instanceof Identifier || $isNullableType)) {
             return true;
         }
 
+        // If it is the NullableType, extract the name from its inner type
+        $typeName = $isNullableType ? $param->type->type->name : $param->type->name;
+
         // Check it is the type to be removed
-        return $param->type->name != $this->getParamTypeName();
+        return $typeName != $this->getParamTypeName();
     }
 
     /**

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Downgrade\Rector\FunctionLike;
+
+use PhpParser\Node;
+use PhpParser\Node\Param;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\ClassMethod;
+use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\TypeDeclaration\Rector\FunctionLike\AbstractTypeDeclarationRector;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+
+abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeDeclarationRector
+{
+    /**
+     * @var string
+     */
+    public const ADD_DOC_BLOCK = '$addDocBlock';
+
+    /**
+     * @var bool
+     */
+    private $addDocBlock = true;
+
+    /**
+     * @param ClassMethod|Function_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($node->params === null || $node->params === []) {
+            return null;
+        }
+
+        foreach ($node->params as $position => $param) {
+            $this->refactorParam($param, $node, (int) $position);
+        }
+
+        return null;
+    }
+
+    public function configure(array $configuration): void
+    {
+        $this->addDocBlock = $configuration[self::ADD_DOC_BLOCK] ?? true;
+    }
+
+    /**
+     * @param ClassMethod|Function_ $functionLike
+     */
+    private function refactorParam(Param $param, FunctionLike $functionLike, int $position): void
+    {
+        if ($this->shouldSkipParam($param, $functionLike, $position)) {
+            return;
+        }
+
+        if ($this->addDocBlock) {
+            $node = $functionLike;
+            /** @var PhpDocInfo|null $phpDocInfo */
+            $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
+            if ($phpDocInfo === null) {
+                $phpDocInfo = $this->phpDocInfoFactory->createEmpty($node);
+            }
+
+            $type = $this->staticTypeMapper->mapPhpParserNodePHPStanType($param->type);
+            $phpDocInfo->changeParamType($type, $param, $param->var->name);
+        }
+
+        $param->type = null;
+    }
+
+    private function shouldSkipParam(Param $param, FunctionLike $functionLike, int $position): bool
+    {
+        if ($this->vendorLockResolver->isClassMethodParamLockedIn($functionLike, $position)) {
+            return true;
+        }
+
+        if ($param->variadic) {
+            return true;
+        }
+
+        if ($param->type === null) {
+            return true;
+        }
+
+        if (!($param->type instanceof Identifier)) {
+            return true;
+        }
+
+        // Check it is the type to be removed
+        return $param->type->name != $this->getParamTypeName();
+    }
+
+    /**
+     * Name of the type to remove
+     */
+    abstract protected function getParamTypeName(): string;
+
+    protected function getRectorDefinitionDescription(): string
+    {
+        return sprintf(
+            'Remove the \'%s\' param type, add a @param tag instead',
+            $this->getParamTypeName()
+        );
+    }
+}

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
@@ -10,12 +10,14 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\ClassMethod;
-use Rector\Core\ValueObject\PhpVersionFeature;
-use Rector\TypeDeclaration\Rector\FunctionLike\AbstractTypeDeclarationRector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\Downgrade\Rector\DowngradeRectorTrait;
+use Rector\TypeDeclaration\Rector\FunctionLike\AbstractTypeDeclarationRector;
 
 abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeDeclarationRector
 {
+    use DowngradeRectorTrait;
+
     /**
      * @var string
      */
@@ -31,6 +33,10 @@ abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeD
      */
     public function refactor(Node $node): ?Node
     {
+        if ($this->isAtLeastPhpVersion($this->getPhpVersionFeature())) {
+            return $node;
+        }
+
         if ($node->params === null || $node->params === []) {
             return null;
         }

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
@@ -83,7 +83,8 @@ abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeD
 
             if (!is_null($param->type)) {
                 $type = $this->staticTypeMapper->mapPhpParserNodePHPStanType($param->type);
-                $phpDocInfo->changeParamType($type, $param, $this->getName($param->var));
+                $paramName = $this->getName($param->var) ?? '';
+                $phpDocInfo->changeParamType($type, $param, $paramName);
             }
         }
 

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
@@ -61,7 +61,7 @@ abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeD
 
     protected function getRectorDefinitionDescription(): string
     {
-        return sprintf('Remove the \'%s\' param type, add a @param tag instead', $this->getParamTypeName());
+        return sprintf("Remove the '%s' param type, add a @param tag instead", $this->getParamTypeName());
     }
 
     /**
@@ -107,7 +107,7 @@ abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeD
 
         // It can either be the type, or the nullable type (eg: ?object)
         $isNullableType = $param->type instanceof NullableType;
-        if (! ($param->type instanceof Identifier || $isNullableType)) {
+        if (!$param->type instanceof Identifier && !$isNullableType) {
             return true;
         }
 

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
@@ -83,7 +83,7 @@ abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeD
 
             if (!is_null($param->type)) {
                 $type = $this->staticTypeMapper->mapPhpParserNodePHPStanType($param->type);
-                $phpDocInfo->changeParamType($type, $param, $param->var->name);
+                $phpDocInfo->changeParamType($type, $param, $this->getName($param->var));
             }
         }
 

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
@@ -81,8 +81,10 @@ abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeD
                 $phpDocInfo = $this->phpDocInfoFactory->createEmpty($node);
             }
 
-            $type = $this->staticTypeMapper->mapPhpParserNodePHPStanType($param->type);
-            $phpDocInfo->changeParamType($type, $param, $param->var->name);
+            if (!is_null($param->type)) {
+                $type = $this->staticTypeMapper->mapPhpParserNodePHPStanType($param->type);
+                $phpDocInfo->changeParamType($type, $param, $param->var->name);
+            }
         }
 
         $param->type = null;

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
@@ -14,10 +14,11 @@ use PhpParser\Node\Stmt\Function_;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Downgrade\Contract\Rector\DowngradeRectorInterface;
+use Rector\Downgrade\Contract\Rector\DowngradeTypeRectorInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\TypeDeclaration\Rector\FunctionLike\AbstractTypeDeclarationRector;
 
-abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeDeclarationRector implements ConfigurableRectorInterface, DowngradeRectorInterface
+abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeDeclarationRector implements ConfigurableRectorInterface, DowngradeRectorInterface, DowngradeTypeRectorInterface
 {
     /**
      * @var string
@@ -54,14 +55,9 @@ abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeD
         $this->addDocBlock = $configuration[self::ADD_DOC_BLOCK] ?? true;
     }
 
-    /**
-     * Name of the type to remove
-     */
-    abstract protected function getParamTypeName(): string;
-
     protected function getRectorDefinitionDescription(): string
     {
-        return sprintf("Remove the '%s' param type, add a @param tag instead", $this->getParamTypeName());
+        return sprintf("Remove the '%s' param type, add a @param tag instead", $this->getTypeNameToRemove());
     }
 
     /**
@@ -121,6 +117,6 @@ abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeD
         }
 
         // Check it is the type to be removed
-        return $typeName !== $this->getParamTypeName();
+        return $typeName !== $this->getTypeNameToRemove();
     }
 }

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
@@ -5,16 +5,16 @@ declare(strict_types=1);
 namespace Rector\Downgrade\Rector\FunctionLike;
 
 use PhpParser\Node;
-use PhpParser\Node\Param;
-use PhpParser\Node\Identifier;
 use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\NullableType;
-use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
-use Rector\NodeTypeResolver\Node\AttributeKey;
-use Rector\Downgrade\Rector\DowngradeRectorTrait;
+use PhpParser\Node\Stmt\Function_;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Downgrade\Rector\DowngradeRectorTrait;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\TypeDeclaration\Rector\FunctionLike\AbstractTypeDeclarationRector;
 
 abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeDeclarationRector implements ConfigurableRectorInterface

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
@@ -5,15 +5,15 @@ declare(strict_types=1);
 namespace Rector\Downgrade\Rector\FunctionLike;
 
 use PhpParser\Node;
-use PhpParser\Node\Param;
-use PhpParser\Node\Identifier;
 use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\NullableType;
-use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
-use Rector\NodeTypeResolver\Node\AttributeKey;
-use Rector\Downgrade\Rector\DowngradeRectorTrait;
+use PhpParser\Node\Stmt\Function_;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Downgrade\Rector\DowngradeRectorTrait;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\TypeDeclaration\Rector\FunctionLike\AbstractTypeDeclarationRector;
 
 abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeDeclarationRector implements ConfigurableRectorInterface
@@ -56,6 +56,16 @@ abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeD
     }
 
     /**
+     * Name of the type to remove
+     */
+    abstract protected function getParamTypeName(): string;
+
+    protected function getRectorDefinitionDescription(): string
+    {
+        return sprintf('Remove the \'%s\' param type, add a @param tag instead', $this->getParamTypeName());
+    }
+
+    /**
      * @param ClassMethod|Function_ $functionLike
      */
     private function refactorParam(Param $param, FunctionLike $functionLike, int $position): void
@@ -95,7 +105,7 @@ abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeD
 
         // It can either be the type, or the nullable type (eg: ?object)
         $isNullableType = $param->type instanceof NullableType;
-        if (!($param->type instanceof Identifier || $isNullableType)) {
+        if (! ($param->type instanceof Identifier || $isNullableType)) {
             return true;
         }
 
@@ -103,19 +113,6 @@ abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeD
         $typeName = $isNullableType ? $param->type->type->name : $param->type->name;
 
         // Check it is the type to be removed
-        return $typeName != $this->getParamTypeName();
-    }
-
-    /**
-     * Name of the type to remove
-     */
-    abstract protected function getParamTypeName(): string;
-
-    protected function getRectorDefinitionDescription(): string
-    {
-        return sprintf(
-            'Remove the \'%s\' param type, add a @param tag instead',
-            $this->getParamTypeName()
-        );
+        return $typeName !== $this->getParamTypeName();
     }
 }

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
@@ -5,15 +5,16 @@ declare(strict_types=1);
 namespace Rector\Downgrade\Rector\FunctionLike;
 
 use PhpParser\Node;
-use PhpParser\Node\FunctionLike;
-use PhpParser\Node\Identifier;
-use PhpParser\Node\NullableType;
 use PhpParser\Node\Param;
-use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\FunctionLike;
+use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt\Function_;
-use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
-use Rector\Downgrade\Rector\DowngradeRectorTrait;
+use PhpParser\Node\Stmt\ClassMethod;
 use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\Downgrade\Rector\DowngradeRectorTrait;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\TypeDeclaration\Rector\FunctionLike\AbstractTypeDeclarationRector;
 
 abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeDeclarationRector implements ConfigurableRectorInterface

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
@@ -81,7 +81,7 @@ abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeD
                 $phpDocInfo = $this->phpDocInfoFactory->createEmpty($node);
             }
 
-            if (!is_null($param->type)) {
+            if ($param->type !== null) {
                 $type = $this->staticTypeMapper->mapPhpParserNodePHPStanType($param->type);
                 $paramName = $this->getName($param->var) ?? '';
                 $phpDocInfo->changeParamType($type, $param, $paramName);
@@ -113,9 +113,7 @@ abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeD
 
         // If it is the NullableType, extract the name from its inner type
         if ($isNullableType) {
-            /**
-             * @var NullableType
-             */
+            /** @var NullableType */
             $nullableType = $param->type;
             $typeName = $this->getName($nullableType->type);
         } else {

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
@@ -10,9 +10,10 @@ use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Downgrade\Rector\DowngradeRectorTrait;
+use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\TypeDeclaration\Rector\FunctionLike\AbstractTypeDeclarationRector;
 
-abstract class AbstractDowngradeReturnTypeDeclarationRector extends AbstractTypeDeclarationRector
+abstract class AbstractDowngradeReturnTypeDeclarationRector extends AbstractTypeDeclarationRector implements ConfigurableRectorInterface
 {
     use DowngradeRectorTrait;
 

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
@@ -12,10 +12,11 @@ use PhpParser\Node\Stmt\Function_;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Downgrade\Contract\Rector\DowngradeRectorInterface;
+use Rector\Downgrade\Contract\Rector\DowngradeTypeRectorInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\TypeDeclaration\Rector\FunctionLike\AbstractTypeDeclarationRector;
 
-abstract class AbstractDowngradeReturnTypeDeclarationRector extends AbstractTypeDeclarationRector implements ConfigurableRectorInterface, DowngradeRectorInterface
+abstract class AbstractDowngradeReturnTypeDeclarationRector extends AbstractTypeDeclarationRector implements ConfigurableRectorInterface, DowngradeRectorInterface, DowngradeTypeRectorInterface
 {
     /**
      * @var string
@@ -63,14 +64,9 @@ abstract class AbstractDowngradeReturnTypeDeclarationRector extends AbstractType
         $this->addDocBlock = $configuration[self::ADD_DOC_BLOCK] ?? true;
     }
 
-    /**
-     * Name of the type to remove
-     */
-    abstract protected function getReturnTypeName(): string;
-
     protected function getRectorDefinitionDescription(): string
     {
-        return sprintf("Remove the '%s' function type, add a @return tag instead", $this->getReturnTypeName());
+        return sprintf("Remove the '%s' function type, add a @return tag instead", $this->getTypeNameToRemove());
     }
 
     /**
@@ -93,6 +89,6 @@ abstract class AbstractDowngradeReturnTypeDeclarationRector extends AbstractType
         }
 
         // Check it is the type to be removed
-        return $typeName !== $this->getReturnTypeName();
+        return $typeName !== $this->getTypeNameToRemove();
     }
 }

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Downgrade\Rector\FunctionLike;
+
+use PhpParser\Node;
+use PhpParser\Node\Param;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\ClassMethod;
+use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\TypeDeclaration\Rector\FunctionLike\AbstractTypeDeclarationRector;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+
+abstract class AbstractDowngradeReturnTypeDeclarationRector extends AbstractTypeDeclarationRector
+{
+    /**
+     * @var string
+     */
+    public const ADD_DOC_BLOCK = '$addDocBlock';
+
+    /**
+     * @var bool
+     */
+    private $addDocBlock = true;
+
+    /**
+     * @param ClassMethod|Function_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($this->shouldSkip($node)) {
+            return null;
+        }
+
+        if ($this->addDocBlock) {
+            /** @var PhpDocInfo|null $phpDocInfo */
+            $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
+            if ($phpDocInfo === null) {
+                $phpDocInfo = $this->phpDocInfoFactory->createEmpty($node);
+            }
+
+            $type = $this->staticTypeMapper->mapPhpParserNodePHPStanType($node->returnType);
+            $phpDocInfo->changeReturnType($type);
+        }
+
+        $node->returnType = null;
+
+        return $node;
+    }
+
+    public function configure(array $configuration): void
+    {
+        $this->addDocBlock = $configuration[self::ADD_DOC_BLOCK] ?? true;
+    }
+
+    /**
+     * @param ClassMethod|Function_ $functionLike
+     */
+    private function shouldSkip(FunctionLike $functionLike): bool
+    {
+        if ($functionLike->returnType === null) {
+            return true;
+        }
+
+        return $functionLike->returnType->name != $this->getReturnTypeName();
+    }
+
+    /**
+     * Name of the type to remove
+     */
+    abstract protected function getReturnTypeName(): string;
+
+    protected function getRectorDefinitionDescription(): string
+    {
+        return sprintf(
+            'Remove the \'%s\' function type, add a @return tag instead',
+            $this->getReturnTypeName()
+        );
+    }
+}

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
@@ -70,7 +70,7 @@ abstract class AbstractDowngradeReturnTypeDeclarationRector extends AbstractType
 
     protected function getRectorDefinitionDescription(): string
     {
-        return sprintf('Remove the \'%s\' function type, add a @return tag instead', $this->getReturnTypeName());
+        return sprintf("Remove the '%s' function type, add a @return tag instead", $this->getReturnTypeName());
     }
 
     /**

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
@@ -7,12 +7,12 @@ namespace Rector\Downgrade\Rector\FunctionLike;
 use PhpParser\Node;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\NullableType;
-use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\ClassMethod;
-use Rector\NodeTypeResolver\Node\AttributeKey;
-use Rector\Downgrade\Rector\DowngradeRectorTrait;
+use PhpParser\Node\Stmt\Function_;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Downgrade\Rector\DowngradeRectorTrait;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\TypeDeclaration\Rector\FunctionLike\AbstractTypeDeclarationRector;
 
 abstract class AbstractDowngradeReturnTypeDeclarationRector extends AbstractTypeDeclarationRector implements ConfigurableRectorInterface

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
@@ -6,6 +6,7 @@ namespace Rector\Downgrade\Rector\FunctionLike;
 
 use PhpParser\Node;
 use PhpParser\Node\FunctionLike;
+use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -70,7 +71,12 @@ abstract class AbstractDowngradeReturnTypeDeclarationRector extends AbstractType
             return true;
         }
 
-        return $functionLike->returnType->name != $this->getReturnTypeName();
+        // It can either be the type, or the nullable type (eg: ?object)
+        $isNullableType = $functionLike->returnType instanceof NullableType;
+        $typeName = $isNullableType ? $functionLike->returnType->type->name : $functionLike->returnType->name;
+
+        // Check it is the type to be removed
+        return $typeName != $this->getReturnTypeName();
     }
 
     /**

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
@@ -11,14 +11,12 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
-use Rector\Downgrade\Rector\DowngradeRectorTrait;
+use Rector\Downgrade\Rector\DowngradeRectorInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\TypeDeclaration\Rector\FunctionLike\AbstractTypeDeclarationRector;
 
-abstract class AbstractDowngradeReturnTypeDeclarationRector extends AbstractTypeDeclarationRector implements ConfigurableRectorInterface
+abstract class AbstractDowngradeReturnTypeDeclarationRector extends AbstractTypeDeclarationRector implements ConfigurableRectorInterface, DowngradeRectorInterface
 {
-    use DowngradeRectorTrait;
-
     /**
      * @var string
      */

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
@@ -7,11 +7,11 @@ namespace Rector\Downgrade\Rector\FunctionLike;
 use PhpParser\Node;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\NullableType;
-use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\ClassMethod;
-use Rector\NodeTypeResolver\Node\AttributeKey;
-use Rector\Downgrade\Rector\DowngradeRectorTrait;
+use PhpParser\Node\Stmt\Function_;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Downgrade\Rector\DowngradeRectorTrait;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\TypeDeclaration\Rector\FunctionLike\AbstractTypeDeclarationRector;
 
 abstract class AbstractDowngradeReturnTypeDeclarationRector extends AbstractTypeDeclarationRector implements ConfigurableRectorInterface
@@ -63,6 +63,16 @@ abstract class AbstractDowngradeReturnTypeDeclarationRector extends AbstractType
     }
 
     /**
+     * Name of the type to remove
+     */
+    abstract protected function getReturnTypeName(): string;
+
+    protected function getRectorDefinitionDescription(): string
+    {
+        return sprintf('Remove the \'%s\' function type, add a @return tag instead', $this->getReturnTypeName());
+    }
+
+    /**
      * @param ClassMethod|Function_ $functionLike
      */
     private function shouldSkip(FunctionLike $functionLike): bool
@@ -76,19 +86,6 @@ abstract class AbstractDowngradeReturnTypeDeclarationRector extends AbstractType
         $typeName = $isNullableType ? $functionLike->returnType->type->name : $functionLike->returnType->name;
 
         // Check it is the type to be removed
-        return $typeName != $this->getReturnTypeName();
-    }
-
-    /**
-     * Name of the type to remove
-     */
-    abstract protected function getReturnTypeName(): string;
-
-    protected function getRectorDefinitionDescription(): string
-    {
-        return sprintf(
-            'Remove the \'%s\' function type, add a @return tag instead',
-            $this->getReturnTypeName()
-        );
+        return $typeName !== $this->getReturnTypeName();
     }
 }

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
@@ -84,7 +84,15 @@ abstract class AbstractDowngradeReturnTypeDeclarationRector extends AbstractType
 
         // It can either be the type, or the nullable type (eg: ?object)
         $isNullableType = $functionLike->returnType instanceof NullableType;
-        $typeName = $isNullableType ? $this->getName($functionLike->returnType->type) : $this->getName($functionLike->returnType);
+        if ($isNullableType) {
+            /**
+             * @var NullableType
+             */
+            $nullableType = $functionLike->returnType;
+            $typeName = $this->getName($nullableType->type);
+        } else {
+            $typeName = $this->getName($functionLike->returnType);
+        }
 
         // Check it is the type to be removed
         return $typeName !== $this->getReturnTypeName();

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
@@ -5,17 +5,17 @@ declare(strict_types=1);
 namespace Rector\Downgrade\Rector\FunctionLike;
 
 use PhpParser\Node;
-use PhpParser\Node\Param;
-use PhpParser\Node\Identifier;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\ClassMethod;
-use Rector\Core\ValueObject\PhpVersionFeature;
-use Rector\TypeDeclaration\Rector\FunctionLike\AbstractTypeDeclarationRector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\Downgrade\Rector\DowngradeRectorTrait;
+use Rector\TypeDeclaration\Rector\FunctionLike\AbstractTypeDeclarationRector;
 
 abstract class AbstractDowngradeReturnTypeDeclarationRector extends AbstractTypeDeclarationRector
 {
+    use DowngradeRectorTrait;
+
     /**
      * @var string
      */
@@ -31,6 +31,10 @@ abstract class AbstractDowngradeReturnTypeDeclarationRector extends AbstractType
      */
     public function refactor(Node $node): ?Node
     {
+        if ($this->isAtLeastPhpVersion($this->getPhpVersionFeature())) {
+            return $node;
+        }
+
         if ($this->shouldSkip($node)) {
             return null;
         }

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
@@ -47,8 +47,10 @@ abstract class AbstractDowngradeReturnTypeDeclarationRector extends AbstractType
                 $phpDocInfo = $this->phpDocInfoFactory->createEmpty($node);
             }
 
-            $type = $this->staticTypeMapper->mapPhpParserNodePHPStanType($node->returnType);
-            $phpDocInfo->changeReturnType($type);
+            if (!is_null($node->returnType)) {
+                $type = $this->staticTypeMapper->mapPhpParserNodePHPStanType($node->returnType);
+                $phpDocInfo->changeReturnType($type);
+            }
         }
 
         $node->returnType = null;

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
@@ -11,7 +11,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
-use Rector\Downgrade\Rector\DowngradeRectorInterface;
+use Rector\Downgrade\Contract\Rector\DowngradeRectorInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\TypeDeclaration\Rector\FunctionLike\AbstractTypeDeclarationRector;
 

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
@@ -47,7 +47,7 @@ abstract class AbstractDowngradeReturnTypeDeclarationRector extends AbstractType
                 $phpDocInfo = $this->phpDocInfoFactory->createEmpty($node);
             }
 
-            if (!is_null($node->returnType)) {
+            if ($node->returnType !== null) {
                 $type = $this->staticTypeMapper->mapPhpParserNodePHPStanType($node->returnType);
                 $phpDocInfo->changeReturnType($type);
             }
@@ -85,9 +85,7 @@ abstract class AbstractDowngradeReturnTypeDeclarationRector extends AbstractType
         // It can either be the type, or the nullable type (eg: ?object)
         $isNullableType = $functionLike->returnType instanceof NullableType;
         if ($isNullableType) {
-            /**
-             * @var NullableType
-             */
+            /** @var NullableType */
             $nullableType = $functionLike->returnType;
             $typeName = $this->getName($nullableType->type);
         } else {

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
@@ -7,11 +7,12 @@ namespace Rector\Downgrade\Rector\FunctionLike;
 use PhpParser\Node;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\NullableType;
-use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
-use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
-use Rector\Downgrade\Rector\DowngradeRectorTrait;
+use PhpParser\Node\Stmt\ClassMethod;
 use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\Downgrade\Rector\DowngradeRectorTrait;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\TypeDeclaration\Rector\FunctionLike\AbstractTypeDeclarationRector;
 
 abstract class AbstractDowngradeReturnTypeDeclarationRector extends AbstractTypeDeclarationRector implements ConfigurableRectorInterface

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
@@ -84,7 +84,7 @@ abstract class AbstractDowngradeReturnTypeDeclarationRector extends AbstractType
 
         // It can either be the type, or the nullable type (eg: ?object)
         $isNullableType = $functionLike->returnType instanceof NullableType;
-        $typeName = $isNullableType ? $functionLike->returnType->type->name : $functionLike->returnType->name;
+        $typeName = $isNullableType ? $this->getName($functionLike->returnType->type) : $this->getName($functionLike->returnType);
 
         // Check it is the type to be removed
         return $typeName !== $this->getReturnTypeName();

--- a/rules/downgrade/src/Rector/FunctionLike/DowngradeParamObjectTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/DowngradeParamObjectTypeDeclarationRector.php
@@ -48,16 +48,16 @@ PHP
         );
     }
 
+    public function getPhpVersionFeature(): string
+    {
+        return PhpVersionFeature::OBJECT_TYPE;
+    }
+
     /**
      * Name of the type to remove
      */
     protected function getParamTypeName(): string
     {
         return 'object';
-    }
-
-    public function getPhpVersionFeature(): string
-    {
-        return PhpVersionFeature::OBJECT_TYPE;
     }
 }

--- a/rules/downgrade/src/Rector/FunctionLike/DowngradeParamObjectTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/DowngradeParamObjectTypeDeclarationRector.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Downgrade\Rector\FunctionLike;
+
+use Rector\Core\RectorDefinition\CodeSample;
+use Rector\Core\RectorDefinition\RectorDefinition;
+use Rector\Downgrade\Rector\FunctionLike\AbstractDowngradeParamTypeDeclarationRector;
+
+/**
+ * @see \Rector\Downgrade\Tests\Rector\FunctionLike\DowngradeParamObjectTypeDeclarationRector\DowngradeParamObjectTypeDeclarationRectorTest
+ */
+final class DowngradeParamObjectTypeDeclarationRector extends AbstractDowngradeParamTypeDeclarationRector
+{
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition(
+            $this->getRectorDefinitionDescription(),
+            [
+                new CodeSample(
+                    <<<'PHP'
+<?php
+
+class SomeClass
+{
+    public function someFunction(object $someObject)
+    {
+    }
+}
+PHP
+                    ,
+                    <<<'PHP'
+<?php
+
+class SomeClass
+{
+    /**
+     * @param object $someObject
+     */
+    public function someFunction($someObject)
+    {
+    }
+}
+PHP
+                ),
+            ]
+        );
+    }
+
+    /**
+     * Name of the type to remove
+     */
+    protected function getParamTypeName(): string
+    {
+        return 'object';
+    }
+}

--- a/rules/downgrade/src/Rector/FunctionLike/DowngradeParamObjectTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/DowngradeParamObjectTypeDeclarationRector.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace Rector\Downgrade\Rector\FunctionLike;
 
 use Rector\Core\RectorDefinition\CodeSample;
-use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\Core\RectorDefinition\RectorDefinition;
-use Rector\Downgrade\Rector\FunctionLike\AbstractDowngradeParamTypeDeclarationRector;
+use Rector\Core\ValueObject\PhpVersionFeature;
 
 /**
  * @see \Rector\Downgrade\Tests\Rector\FunctionLike\DowngradeParamObjectTypeDeclarationRector\DowngradeParamObjectTypeDeclarationRectorTest

--- a/rules/downgrade/src/Rector/FunctionLike/DowngradeParamObjectTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/DowngradeParamObjectTypeDeclarationRector.php
@@ -56,7 +56,7 @@ PHP
         return 'object';
     }
 
-    protected function getPhpVersionFeature(): string
+    public function getPhpVersionFeature(): string
     {
         return PhpVersionFeature::OBJECT_TYPE;
     }

--- a/rules/downgrade/src/Rector/FunctionLike/DowngradeParamObjectTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/DowngradeParamObjectTypeDeclarationRector.php
@@ -53,10 +53,7 @@ PHP
         return PhpVersionFeature::OBJECT_TYPE;
     }
 
-    /**
-     * Name of the type to remove
-     */
-    protected function getParamTypeName(): string
+    public function getTypeNameToRemove(): string
     {
         return 'object';
     }

--- a/rules/downgrade/src/Rector/FunctionLike/DowngradeParamObjectTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/DowngradeParamObjectTypeDeclarationRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Downgrade\Rector\FunctionLike;
 
 use Rector\Core\RectorDefinition\CodeSample;
+use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\Core\RectorDefinition\RectorDefinition;
 use Rector\Downgrade\Rector\FunctionLike\AbstractDowngradeParamTypeDeclarationRector;
 
@@ -54,5 +55,10 @@ PHP
     protected function getParamTypeName(): string
     {
         return 'object';
+    }
+
+    protected function getPhpVersionFeature(): string
+    {
+        return PhpVersionFeature::OBJECT_TYPE;
     }
 }

--- a/rules/downgrade/src/Rector/FunctionLike/DowngradeReturnObjectTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/DowngradeReturnObjectTypeDeclarationRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Downgrade\Rector\FunctionLike;
 
 use Rector\Core\RectorDefinition\CodeSample;
+use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\Core\RectorDefinition\RectorDefinition;
 use Rector\Downgrade\Rector\FunctionLike\AbstractDowngradeReturnTypeDeclarationRector;
 
@@ -56,5 +57,10 @@ PHP
     protected function getReturnTypeName(): string
     {
         return 'object';
+    }
+
+    protected function getPhpVersionFeature(): string
+    {
+        return PhpVersionFeature::OBJECT_TYPE;
     }
 }

--- a/rules/downgrade/src/Rector/FunctionLike/DowngradeReturnObjectTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/DowngradeReturnObjectTypeDeclarationRector.php
@@ -50,16 +50,16 @@ PHP
         );
     }
 
+    public function getPhpVersionFeature(): string
+    {
+        return PhpVersionFeature::OBJECT_TYPE;
+    }
+
     /**
      * Name of the type to remove
      */
     protected function getReturnTypeName(): string
     {
         return 'object';
-    }
-
-    public function getPhpVersionFeature(): string
-    {
-        return PhpVersionFeature::OBJECT_TYPE;
     }
 }

--- a/rules/downgrade/src/Rector/FunctionLike/DowngradeReturnObjectTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/DowngradeReturnObjectTypeDeclarationRector.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace Rector\Downgrade\Rector\FunctionLike;
 
 use Rector\Core\RectorDefinition\CodeSample;
-use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\Core\RectorDefinition\RectorDefinition;
-use Rector\Downgrade\Rector\FunctionLike\AbstractDowngradeReturnTypeDeclarationRector;
+use Rector\Core\ValueObject\PhpVersionFeature;
 
 /**
  * @see \Rector\Downgrade\Tests\Rector\FunctionLike\DowngradeReturnObjectTypeDeclarationRector\DowngradeReturnObjectTypeDeclarationRectorTest

--- a/rules/downgrade/src/Rector/FunctionLike/DowngradeReturnObjectTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/DowngradeReturnObjectTypeDeclarationRector.php
@@ -55,10 +55,7 @@ PHP
         return PhpVersionFeature::OBJECT_TYPE;
     }
 
-    /**
-     * Name of the type to remove
-     */
-    protected function getReturnTypeName(): string
+    public function getTypeNameToRemove(): string
     {
         return 'object';
     }

--- a/rules/downgrade/src/Rector/FunctionLike/DowngradeReturnObjectTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/DowngradeReturnObjectTypeDeclarationRector.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Downgrade\Rector\FunctionLike;
+
+use Rector\Core\RectorDefinition\CodeSample;
+use Rector\Core\RectorDefinition\RectorDefinition;
+use Rector\Downgrade\Rector\FunctionLike\AbstractDowngradeReturnTypeDeclarationRector;
+
+/**
+ * @see \Rector\Downgrade\Tests\Rector\FunctionLike\DowngradeReturnObjectTypeDeclarationRector\DowngradeReturnObjectTypeDeclarationRectorTest
+ */
+final class DowngradeReturnObjectTypeDeclarationRector extends AbstractDowngradeReturnTypeDeclarationRector
+{
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition(
+            $this->getRectorDefinitionDescription(),
+            [
+                new CodeSample(
+                    <<<'PHP'
+<?php
+
+class SomeClass
+{
+    public function getSomeObject(): object
+    {
+        return new SomeObject();
+    }
+}
+PHP
+                    ,
+                    <<<'PHP'
+<?php
+
+class SomeClass
+{
+    /**
+     * @return object
+     */
+    public function getSomeObject()
+    {
+        return new SomeObject();
+    }
+}
+PHP
+                ),
+            ]
+        );
+    }
+
+    /**
+     * Name of the type to remove
+     */
+    protected function getReturnTypeName(): string
+    {
+        return 'object';
+    }
+}

--- a/rules/downgrade/src/Rector/FunctionLike/DowngradeReturnObjectTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/DowngradeReturnObjectTypeDeclarationRector.php
@@ -58,7 +58,7 @@ PHP
         return 'object';
     }
 
-    protected function getPhpVersionFeature(): string
+    public function getPhpVersionFeature(): string
     {
         return PhpVersionFeature::OBJECT_TYPE;
     }

--- a/rules/downgrade/src/Rector/Property/DowngradeTypedPropertyRector.php
+++ b/rules/downgrade/src/Rector/Property/DowngradeTypedPropertyRector.php
@@ -6,14 +6,14 @@ namespace Rector\Downgrade\Rector\Property;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Property;
-use Rector\Core\Rector\AbstractRector;
-use Rector\Core\RectorDefinition\CodeSample;
-use Rector\Core\ValueObject\PhpVersionFeature;
-use Rector\NodeTypeResolver\Node\AttributeKey;
-use Rector\Downgrade\Rector\DowngradeRectorTrait;
-use Rector\Core\RectorDefinition\RectorDefinition;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\RectorDefinition\CodeSample;
+use Rector\Core\RectorDefinition\RectorDefinition;
+use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\Downgrade\Rector\DowngradeRectorTrait;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 
 /**
  * @see \Rector\Downgrade\Tests\Rector\Property\DowngradeTypedPropertyRector\DowngradeTypedPropertyRectorTest

--- a/rules/downgrade/src/Rector/Property/DowngradeTypedPropertyRector.php
+++ b/rules/downgrade/src/Rector/Property/DowngradeTypedPropertyRector.php
@@ -12,17 +12,15 @@ use Rector\Core\Rector\AbstractRector;
 use Rector\Core\RectorDefinition\CodeSample;
 use Rector\Core\RectorDefinition\RectorDefinition;
 use Rector\Core\ValueObject\PhpVersionFeature;
-use Rector\Downgrade\Rector\DowngradeRectorTrait;
+use Rector\Downgrade\Rector\DowngradeRectorInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 
 /**
  * @see \Rector\Downgrade\Tests\Rector\Property\DowngradeTypedPropertyRector\DowngradeTypedPropertyRectorTest
  * @see \Rector\Downgrade\Tests\Rector\Property\NoDocBlockDowngradeTypedPropertyRector\DowngradeTypedPropertyRectorTest
  */
-final class DowngradeTypedPropertyRector extends AbstractRector implements ConfigurableRectorInterface
+final class DowngradeTypedPropertyRector extends AbstractRector implements ConfigurableRectorInterface, DowngradeRectorInterface
 {
-    use DowngradeRectorTrait;
-
     /**
      * @var string
      */
@@ -98,7 +96,7 @@ PHP
         return $node;
     }
 
-    protected function getPhpVersionFeature(): string
+    public function getPhpVersionFeature(): string
     {
         return PhpVersionFeature::TYPED_PROPERTIES;
     }

--- a/rules/downgrade/src/Rector/Property/DowngradeTypedPropertyRector.php
+++ b/rules/downgrade/src/Rector/Property/DowngradeTypedPropertyRector.php
@@ -12,7 +12,7 @@ use Rector\Core\Rector\AbstractRector;
 use Rector\Core\RectorDefinition\CodeSample;
 use Rector\Core\RectorDefinition\RectorDefinition;
 use Rector\Core\ValueObject\PhpVersionFeature;
-use Rector\Downgrade\Rector\DowngradeRectorInterface;
+use Rector\Downgrade\Contract\Rector\DowngradeRectorInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 
 /**

--- a/rules/downgrade/src/Rector/Property/DowngradeTypedPropertyRector.php
+++ b/rules/downgrade/src/Rector/Property/DowngradeTypedPropertyRector.php
@@ -6,12 +6,14 @@ namespace Rector\Downgrade\Rector\Property;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Property;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
-use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\RectorDefinition\CodeSample;
-use Rector\Core\RectorDefinition\RectorDefinition;
+use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\Downgrade\Rector\DowngradeRectorTrait;
+use Rector\Core\RectorDefinition\RectorDefinition;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 
 /**
  * @see \Rector\Downgrade\Tests\Rector\Property\DowngradeTypedPropertyRector\DowngradeTypedPropertyRectorTest
@@ -19,6 +21,8 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
  */
 final class DowngradeTypedPropertyRector extends AbstractRector implements ConfigurableRectorInterface
 {
+    use DowngradeRectorTrait;
+
     /**
      * @var string
      */
@@ -71,6 +75,10 @@ PHP
      */
     public function refactor(Node $node): ?Node
     {
+        if ($this->isAtLeastPhpVersion($this->getPhpVersionFeature())) {
+            return $node;
+        }
+
         if ($node->type === null) {
             return null;
         }
@@ -88,5 +96,10 @@ PHP
         $node->type = null;
 
         return $node;
+    }
+
+    protected function getPhpVersionFeature(): string
+    {
+        return PhpVersionFeature::TYPED_PROPERTIES;
     }
 }

--- a/rules/downgrade/tests/Rector/FunctionLike/DowngradeParamObjectTypeDeclarationRector/DowngradeParamObjectTypeDeclarationRectorTest.php
+++ b/rules/downgrade/tests/Rector/FunctionLike/DowngradeParamObjectTypeDeclarationRector/DowngradeParamObjectTypeDeclarationRectorTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Downgrade\Tests\Rector\FunctionLike\DowngradeParamObjectTypeDeclarationRector;
+
+use Iterator;
+use Symplify\SmartFileSystem\SmartFileInfo;
+use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;
+use Rector\Downgrade\Rector\FunctionLike\DowngradeParamObjectTypeDeclarationRector;
+
+final class DowngradeParamObjectTypeDeclarationRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @requires PHP >= 7.2
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @return array<string, mixed[]>
+     */
+    protected function getRectorsWithConfiguration(): array
+    {
+        return [
+            DowngradeParamObjectTypeDeclarationRector::class => [
+                DowngradeParamObjectTypeDeclarationRector::ADD_DOC_BLOCK => true,
+            ],
+        ];
+    }
+
+    protected function getRectorClass(): string
+    {
+        return DowngradeParamObjectTypeDeclarationRector::class;
+    }
+
+    protected function getPhpVersion(): string
+    {
+        return PhpVersionFeature::BEFORE_OBJECT_TYPE;
+    }
+}

--- a/rules/downgrade/tests/Rector/FunctionLike/DowngradeParamObjectTypeDeclarationRector/DowngradeParamObjectTypeDeclarationRectorTest.php
+++ b/rules/downgrade/tests/Rector/FunctionLike/DowngradeParamObjectTypeDeclarationRector/DowngradeParamObjectTypeDeclarationRectorTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Rector\Downgrade\Tests\Rector\FunctionLike\DowngradeParamObjectTypeDeclarationRector;
 
 use Iterator;
-use Symplify\SmartFileSystem\SmartFileInfo;
-use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;
+use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\Downgrade\Rector\FunctionLike\DowngradeParamObjectTypeDeclarationRector;
+use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class DowngradeParamObjectTypeDeclarationRectorTest extends AbstractRectorTestCase
 {

--- a/rules/downgrade/tests/Rector/FunctionLike/DowngradeParamObjectTypeDeclarationRector/Fixture/docblock_exists.php.inc
+++ b/rules/downgrade/tests/Rector/FunctionLike/DowngradeParamObjectTypeDeclarationRector/Fixture/docblock_exists.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Downgrade\Tests\Rector\FunctionLike\DowngradeParamObjectTypeDeclarationRector\Fixture;
+
+class DocBlockExists {
+    /**
+     * This property is the best one
+     */
+    public function someFunction(object $someObject)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Downgrade\Tests\Rector\FunctionLike\DowngradeParamObjectTypeDeclarationRector\Fixture;
+
+class DocBlockExists {
+    /**
+     * This property is the best one
+     * @param object $someObject
+     */
+    public function someFunction($someObject)
+    {
+    }
+}
+
+?>

--- a/rules/downgrade/tests/Rector/FunctionLike/DowngradeParamObjectTypeDeclarationRector/Fixture/docblock_tag_exists.php.inc
+++ b/rules/downgrade/tests/Rector/FunctionLike/DowngradeParamObjectTypeDeclarationRector/Fixture/docblock_tag_exists.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Downgrade\Tests\Rector\FunctionLike\DowngradeParamObjectTypeDeclarationRector\Fixture;
+
+class DocBlockTagExists {
+    /**
+     * This property is the best one
+     * @param object $someObject
+     */
+    public function someFunction(object $someObject)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Downgrade\Tests\Rector\FunctionLike\DowngradeParamObjectTypeDeclarationRector\Fixture;
+
+class DocBlockTagExists {
+    /**
+     * This property is the best one
+     * @param object $someObject
+     */
+    public function someFunction($someObject)
+    {
+    }
+}
+
+?>

--- a/rules/downgrade/tests/Rector/FunctionLike/DowngradeParamObjectTypeDeclarationRector/Fixture/fixture.php.inc
+++ b/rules/downgrade/tests/Rector/FunctionLike/DowngradeParamObjectTypeDeclarationRector/Fixture/fixture.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\Downgrade\Tests\Rector\FunctionLike\DowngradeParamObjectTypeDeclarationRector\Fixture;
+
+class SomeClass
+{
+    public function someFunction(object $someObject)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Downgrade\Tests\Rector\FunctionLike\DowngradeParamObjectTypeDeclarationRector\Fixture;
+
+class SomeClass
+{
+    /**
+     * @param object $someObject
+     */
+    public function someFunction($someObject)
+    {
+    }
+}
+
+?>

--- a/rules/downgrade/tests/Rector/FunctionLike/DowngradeParamObjectTypeDeclarationRector/Fixture/multiple_matching_params.php.inc
+++ b/rules/downgrade/tests/Rector/FunctionLike/DowngradeParamObjectTypeDeclarationRector/Fixture/multiple_matching_params.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Downgrade\Tests\Rector\FunctionLike\DowngradeParamObjectTypeDeclarationRector\Fixture;
+
+class MultipleMatchingParams
+{
+    public function someFunction(object $someObject, string $someOtherVar, object $someOtherObject, ?object $nullableObject)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Downgrade\Tests\Rector\FunctionLike\DowngradeParamObjectTypeDeclarationRector\Fixture;
+
+class MultipleMatchingParams
+{
+    /**
+     * @param object $someObject
+     * @param object $someOtherObject
+     * @param object|null $nullableObject
+     */
+    public function someFunction($someObject, string $someOtherVar, $someOtherObject, $nullableObject)
+    {
+    }
+}
+
+?>

--- a/rules/downgrade/tests/Rector/FunctionLike/DowngradeParamObjectTypeDeclarationRector/Fixture/multiple_params.php.inc
+++ b/rules/downgrade/tests/Rector/FunctionLike/DowngradeParamObjectTypeDeclarationRector/Fixture/multiple_params.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\Downgrade\Tests\Rector\FunctionLike\DowngradeParamObjectTypeDeclarationRector\Fixture;
+
+class MultipleParams
+{
+    public function someFunction(object $someObject, string $someOtherVar)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Downgrade\Tests\Rector\FunctionLike\DowngradeParamObjectTypeDeclarationRector\Fixture;
+
+class MultipleParams
+{
+    /**
+     * @param object $someObject
+     */
+    public function someFunction($someObject, string $someOtherVar)
+    {
+    }
+}
+
+?>

--- a/rules/downgrade/tests/Rector/FunctionLike/DowngradeParamObjectTypeDeclarationRector/Fixture/nullable_type.php.inc
+++ b/rules/downgrade/tests/Rector/FunctionLike/DowngradeParamObjectTypeDeclarationRector/Fixture/nullable_type.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\Downgrade\Tests\Rector\FunctionLike\DowngradeParamObjectTypeDeclarationRector\Fixture;
+
+class NullableType
+{
+    public function someFunction(?object $someObject)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Downgrade\Tests\Rector\FunctionLike\DowngradeParamObjectTypeDeclarationRector\Fixture;
+
+class NullableType
+{
+    /**
+     * @param object|null $someObject
+     */
+    public function someFunction($someObject)
+    {
+    }
+}
+
+?>

--- a/rules/downgrade/tests/Rector/FunctionLike/DowngradeParamObjectTypeDeclarationRector/Source/AnotherClass.php
+++ b/rules/downgrade/tests/Rector/FunctionLike/DowngradeParamObjectTypeDeclarationRector/Source/AnotherClass.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Rector\Downgrade\Tests\Rector\FunctionLike\DowngradeParamObjectTypeDeclarationRector\Source;
+
+
+class AnotherClass
+{
+
+}

--- a/rules/downgrade/tests/Rector/FunctionLike/DowngradeReturnObjectTypeDeclarationRector/DowngradeReturnObjectTypeDeclarationRectorTest.php
+++ b/rules/downgrade/tests/Rector/FunctionLike/DowngradeReturnObjectTypeDeclarationRector/DowngradeReturnObjectTypeDeclarationRectorTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Downgrade\Tests\Rector\FunctionLike\DowngradeReturnObjectTypeDeclarationRector;
+
+use Iterator;
+use Symplify\SmartFileSystem\SmartFileInfo;
+use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;
+use Rector\Downgrade\Rector\FunctionLike\DowngradeReturnObjectTypeDeclarationRector;
+
+final class DowngradeReturnObjectTypeDeclarationRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @requires PHP >= 7.2
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @return array<string, mixed[]>
+     */
+    protected function getRectorsWithConfiguration(): array
+    {
+        return [
+            DowngradeReturnObjectTypeDeclarationRector::class => [
+                DowngradeReturnObjectTypeDeclarationRector::ADD_DOC_BLOCK => true,
+            ],
+        ];
+    }
+
+    protected function getRectorClass(): string
+    {
+        return DowngradeReturnObjectTypeDeclarationRector::class;
+    }
+
+    protected function getPhpVersion(): string
+    {
+        return PhpVersionFeature::BEFORE_OBJECT_TYPE;
+    }
+}

--- a/rules/downgrade/tests/Rector/FunctionLike/DowngradeReturnObjectTypeDeclarationRector/DowngradeReturnObjectTypeDeclarationRectorTest.php
+++ b/rules/downgrade/tests/Rector/FunctionLike/DowngradeReturnObjectTypeDeclarationRector/DowngradeReturnObjectTypeDeclarationRectorTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Rector\Downgrade\Tests\Rector\FunctionLike\DowngradeReturnObjectTypeDeclarationRector;
 
 use Iterator;
-use Symplify\SmartFileSystem\SmartFileInfo;
-use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;
+use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\Downgrade\Rector\FunctionLike\DowngradeReturnObjectTypeDeclarationRector;
+use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class DowngradeReturnObjectTypeDeclarationRectorTest extends AbstractRectorTestCase
 {

--- a/rules/downgrade/tests/Rector/FunctionLike/DowngradeReturnObjectTypeDeclarationRector/Fixture/docblock_exists.php.inc
+++ b/rules/downgrade/tests/Rector/FunctionLike/DowngradeReturnObjectTypeDeclarationRector/Fixture/docblock_exists.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Downgrade\Tests\Rector\FunctionLike\DowngradeReturnObjectTypeDeclarationRector\Fixture;
+
+class DocBlockExists {
+    /**
+     * This property is the best one
+     */
+    public function getSomeObject(): object
+    {
+        return new SomeObject();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Downgrade\Tests\Rector\FunctionLike\DowngradeReturnObjectTypeDeclarationRector\Fixture;
+
+class DocBlockExists {
+    /**
+     * This property is the best one
+     * @return object
+     */
+    public function getSomeObject()
+    {
+        return new SomeObject();
+    }
+}
+
+?>

--- a/rules/downgrade/tests/Rector/FunctionLike/DowngradeReturnObjectTypeDeclarationRector/Fixture/docblock_tag_exists.php.inc
+++ b/rules/downgrade/tests/Rector/FunctionLike/DowngradeReturnObjectTypeDeclarationRector/Fixture/docblock_tag_exists.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Downgrade\Tests\Rector\FunctionLike\DowngradeReturnObjectTypeDeclarationRector\Fixture;
+
+class DocBlockTagExists {
+    /**
+     * This property is the best one
+     * @return object
+     */
+    public function getSomeObject(): object
+    {
+        return new SomeObject();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Downgrade\Tests\Rector\FunctionLike\DowngradeReturnObjectTypeDeclarationRector\Fixture;
+
+class DocBlockTagExists {
+    /**
+     * This property is the best one
+     * @return object
+     */
+    public function getSomeObject()
+    {
+        return new SomeObject();
+    }
+}
+
+?>

--- a/rules/downgrade/tests/Rector/FunctionLike/DowngradeReturnObjectTypeDeclarationRector/Fixture/fixture.php.inc
+++ b/rules/downgrade/tests/Rector/FunctionLike/DowngradeReturnObjectTypeDeclarationRector/Fixture/fixture.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Downgrade\Tests\Rector\FunctionLike\DowngradeReturnObjectTypeDeclarationRector\Fixture;
+
+class SomeClass
+{
+    public function getSomeObject(): object
+    {
+        return new SomeObject();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Downgrade\Tests\Rector\FunctionLike\DowngradeReturnObjectTypeDeclarationRector\Fixture;
+
+class SomeClass
+{
+    /**
+     * @return object
+     */
+    public function getSomeObject()
+    {
+        return new SomeObject();
+    }
+}
+
+?>

--- a/rules/downgrade/tests/Rector/FunctionLike/DowngradeReturnObjectTypeDeclarationRector/Fixture/nullable_type.php.inc
+++ b/rules/downgrade/tests/Rector/FunctionLike/DowngradeReturnObjectTypeDeclarationRector/Fixture/nullable_type.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Downgrade\Tests\Rector\FunctionLike\DowngradeReturnObjectTypeDeclarationRector\Fixture;
+
+class NullableType
+{
+    public function getSomeObject(): ?object
+    {
+        return new SomeObject();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Downgrade\Tests\Rector\FunctionLike\DowngradeReturnObjectTypeDeclarationRector\Fixture;
+
+class NullableType
+{
+    /**
+     * @return object|null
+     */
+    public function getSomeObject()
+    {
+        return new SomeObject();
+    }
+}
+
+?>

--- a/rules/downgrade/tests/Rector/FunctionLike/DowngradeReturnObjectTypeDeclarationRector/Source/AnotherClass.php
+++ b/rules/downgrade/tests/Rector/FunctionLike/DowngradeReturnObjectTypeDeclarationRector/Source/AnotherClass.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Rector\Downgrade\Tests\Rector\FunctionLike\DowngradeReturnObjectTypeDeclarationRector\Source;
+
+
+class AnotherClass
+{
+
+}

--- a/rules/downgrade/tests/Rector/Property/DowngradeTypedPropertyRector/DowngradeTypedPropertyRectorTest.php
+++ b/rules/downgrade/tests/Rector/Property/DowngradeTypedPropertyRector/DowngradeTypedPropertyRectorTest.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace Rector\Downgrade\Tests\Rector\Property\DowngradeTypedPropertyRector;
 
 use Iterator;
+use Symplify\SmartFileSystem\SmartFileInfo;
+use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;
 use Rector\Downgrade\Rector\Property\DowngradeTypedPropertyRector;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class DowngradeTypedPropertyRectorTest extends AbstractRectorTestCase
 {
@@ -40,5 +41,10 @@ final class DowngradeTypedPropertyRectorTest extends AbstractRectorTestCase
     protected function getRectorClass(): string
     {
         return DowngradeTypedPropertyRector::class;
+    }
+
+    protected function getPhpVersion(): string
+    {
+        return PhpVersionFeature::BEFORE_TYPED_PROPERTIES;
     }
 }

--- a/rules/downgrade/tests/Rector/Property/DowngradeTypedPropertyRector/DowngradeTypedPropertyRectorTest.php
+++ b/rules/downgrade/tests/Rector/Property/DowngradeTypedPropertyRector/DowngradeTypedPropertyRectorTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Rector\Downgrade\Tests\Rector\Property\DowngradeTypedPropertyRector;
 
 use Iterator;
-use Symplify\SmartFileSystem\SmartFileInfo;
-use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;
+use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\Downgrade\Rector\Property\DowngradeTypedPropertyRector;
+use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class DowngradeTypedPropertyRectorTest extends AbstractRectorTestCase
 {

--- a/rules/downgrade/tests/Rector/Property/NoDocBlockDowngradeTypedPropertyRector/DowngradeTypedPropertyRectorTest.php
+++ b/rules/downgrade/tests/Rector/Property/NoDocBlockDowngradeTypedPropertyRector/DowngradeTypedPropertyRectorTest.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace Rector\Downgrade\Tests\Rector\Property\NoDocBlockDowngradeTypedPropertyRector;
 
 use Iterator;
+use Symplify\SmartFileSystem\SmartFileInfo;
+use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;
 use Rector\Downgrade\Rector\Property\DowngradeTypedPropertyRector;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class DowngradeTypedPropertyRectorTest extends AbstractRectorTestCase
 {
@@ -40,5 +41,10 @@ final class DowngradeTypedPropertyRectorTest extends AbstractRectorTestCase
     protected function getRectorClass(): string
     {
         return DowngradeTypedPropertyRector::class;
+    }
+
+    protected function getPhpVersion(): string
+    {
+        return PhpVersionFeature::BEFORE_TYPED_PROPERTIES;
     }
 }

--- a/rules/downgrade/tests/Rector/Property/NoDocBlockDowngradeTypedPropertyRector/DowngradeTypedPropertyRectorTest.php
+++ b/rules/downgrade/tests/Rector/Property/NoDocBlockDowngradeTypedPropertyRector/DowngradeTypedPropertyRectorTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Rector\Downgrade\Tests\Rector\Property\NoDocBlockDowngradeTypedPropertyRector;
 
 use Iterator;
-use Symplify\SmartFileSystem\SmartFileInfo;
-use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;
+use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\Downgrade\Rector\Property\DowngradeTypedPropertyRector;
+use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class DowngradeTypedPropertyRectorTest extends AbstractRectorTestCase
 {

--- a/src/ValueObject/PhpVersionFeature.php
+++ b/src/ValueObject/PhpVersionFeature.php
@@ -139,7 +139,17 @@ final class PhpVersionFeature
     /**
      * @var string
      */
+    public const BEFORE_MIXED_TYPE = '7.4';
+
+    /**
+     * @var string
+     */
     public const BEFORE_TYPED_PROPERTIES = '7.3';
+
+    /**
+     * @var string
+     */
+    public const BEFORE_OBJECT_TYPE = '7.1';
 
     /**
      * @see https://wiki.php.net/rfc/covariant-returns-and-contravariant-parameters


### PR DESCRIPTION
Fixes #4108 (well, 99% of it, read below)

The original proposal is to downgrade the `mixed` type. In this PR, I did something better: 

- I implemented it as an abstract class, so that any type can be downgraded
    - `AbstractDowngradeParamTypeDeclarationRector`
    - `AbstractDowngradeReturnTypeDeclarationRector`
- I implemented it for `object`:
    - `DowngradeParamObjectTypeDeclarationRector`
    - `DowngradeReturnObjectTypeDeclarationRector`

With these downgrade rules, I can already:

- Code using PHP 7.4
- Deploy it to PHP 7.1 (yay!)

I haven't implemented it for the `mixed` type yet, since PHP 8.0 is still a few months away. But it's a copy/paste of the `object` type implementations, so be welcome to do it at any time.

I've also added the 2 new rectors to the downgrade set, and I made all rules in this set be executed only if the feature is not supported by the intended PHP version (eg: `object` is removed if target PHP is 7.1, not for 7.2 upwards).