### PR TITLE
Commented out vendor locking

### DIFF
--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
@@ -87,7 +87,7 @@ abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeD
         $param->type = null;
     }
 
-    private function shouldSkipParam(Param $param, FunctionLike $functionLike, int $position): bool
+    private function shouldSkipParam(Param $param): bool
     {
         if ($param->variadic) {
             return true;

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
@@ -43,8 +43,8 @@ abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeD
             return null;
         }
 
-        foreach ($node->params as $position => $param) {
-            $this->refactorParam($param, $node, (int) $position);
+        foreach ($node->params as $param) {
+            $this->refactorParam($param, $node);
         }
 
         return null;
@@ -63,7 +63,7 @@ abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeD
     /**
      * @param ClassMethod|Function_ $functionLike
      */
-    private function refactorParam(Param $param, FunctionLike $functionLike, int $position): void
+    private function refactorParam(Param $param, FunctionLike $functionLike): void
     {
         if ($this->shouldSkipParam($param)) {
             return;

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
@@ -89,26 +89,6 @@ abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeD
 
     private function shouldSkipParam(Param $param, FunctionLike $functionLike, int $position): bool
     {
-        /**
-         * The code commented below creates a bug:
-         * the param is removed from the interface, but not from a class
-         * implementing the interface, since it is locked.
-         *
-         * If downgrading only one file, locking makes sense.
-         * If downgrading the whole project (as I am doing), it does not.
-         *
-         * What is the best solution?
-         * - Remove this code?
-         * - Read configuration "ENABLE_LOCKING" in the several `isVendorLocked` functions,
-         *   and set it to `false` in rector.php?
-         *
-         * @todo Find best solution and fix
-         * @todo Implement similar solution for `AbstractDowngradeReturnTypeDeclarationRector`
-         */
-        // if ($this->vendorLockResolver->isClassMethodParamLockedIn($functionLike, $position)) {
-        //     return true;
-        // }
-
         if ($param->variadic) {
             return true;
         }

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
@@ -65,7 +65,7 @@ abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeD
      */
     private function refactorParam(Param $param, FunctionLike $functionLike, int $position): void
     {
-        if ($this->shouldSkipParam($param, $functionLike, $position)) {
+        if ($this->shouldSkipParam($param)) {
             return;
         }
 

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
@@ -89,9 +89,25 @@ abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeD
 
     private function shouldSkipParam(Param $param, FunctionLike $functionLike, int $position): bool
     {
-        if ($this->vendorLockResolver->isClassMethodParamLockedIn($functionLike, $position)) {
-            return true;
-        }
+        /**
+         * The code commented below creates a bug:
+         * the param is removed from the interface, but not from a class
+         * implementing the interface, since it is locked.
+         *
+         * If downgrading only one file, locking makes sense.
+         * If downgrading the whole project (as I am doing), it does not.
+         *
+         * What is the best solution?
+         * - Remove this code?
+         * - Read configuration "ENABLE_LOCKING" in the several `isVendorLocked` functions,
+         *   and set it to `false` in rector.php?
+         *
+         * @todo Find best solution and fix
+         * @todo Implement similar solution for `AbstractDowngradeReturnTypeDeclarationRector`
+         */
+        // if ($this->vendorLockResolver->isClassMethodParamLockedIn($functionLike, $position)) {
+        //     return true;
+        // }
 
         if ($param->variadic) {
             return true;


### PR DESCRIPTION
Fixes #4131 

Possible solution: It removes the code calling `isVendorLock`.