### PR TITLE
Fix example: exclude directory in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         // single file
         __DIR__ . '/src/ComplicatedFile.php',
         // or directory
-        __DIR__ . '/src/ComplicatedFile.php',
+        __DIR__ . '/src',
         // or fnmatch
         __DIR__ . '/src/*/Tests/*',
     ]);


### PR DESCRIPTION
The line looks wrong. I am not sure if the PR is correct or if a trailing slash is required.