### PR TITLE
apply run ecs check-heredoc-nowdoc command to packages and rules directory

### DIFF
--- a/rules/code-quality/src/Rector/Foreach_/ForeachToInArrayRector.php
+++ b/rules/code-quality/src/Rector/Foreach_/ForeachToInArrayRector.php
@@ -53,7 +53,7 @@ final class ForeachToInArrayRector extends AbstractRector
                 new CodeSample(
                     <<<'PHP'
 foreach ($items as $item) {
-    if ($item === "something") {
+    if ($item === 'something') {
         return true;
     }
 }

--- a/rules/dead-code/src/Rector/BinaryOp/RemoveDuplicatedInstanceOfRector.php
+++ b/rules/dead-code/src/Rector/BinaryOp/RemoveDuplicatedInstanceOfRector.php
@@ -41,7 +41,7 @@ PHP
                 <<<'PHP'
 class SomeClass
 {
-    public function run($value)
+    public function run($value): void
     {
         $isIt = $value instanceof A;
         $isIt = $value instanceof A;

--- a/rules/doctrine-code-quality/src/Rector/MethodCall/ChangeQuerySetParametersMethodParameterFromArrayToArrayCollectionRector.php
+++ b/rules/doctrine-code-quality/src/Rector/MethodCall/ChangeQuerySetParametersMethodParameterFromArrayToArrayCollectionRector.php
@@ -64,7 +64,6 @@ final class ChangeQuerySetParametersMethodParameterFromArrayToArrayCollectionRec
         return new RectorDefinition('Change array to ArrayCollection in setParameters method of query builder', [
             new CodeSample(
                 <<<'PHP'
-
 use Doctrine\ORM\EntityRepository;
 
 class SomeRepository extends EntityRepository

--- a/rules/php-spec-to-phpunit/src/Rector/AbstractPhpSpecToPHPUnitRector.php
+++ b/rules/php-spec-to-phpunit/src/Rector/AbstractPhpSpecToPHPUnitRector.php
@@ -21,13 +21,14 @@ abstract class AbstractPhpSpecToPHPUnitRector extends AbstractRector
         return new RectorDefinition('Migrate PhpSpec behavior to PHPUnit test', [
             new CodeSample(
                 <<<'PHP'
+
 namespace spec\SomeNamespaceForThisTest;
 
 use PhpSpec\ObjectBehavior;
 
 class OrderSpec extends ObjectBehavior
 {
-    public function let(OrderFactory $factory, ShippingMethod $shippingMethod)
+    public function let(OrderFactory $factory, ShippingMethod $shippingMethod): void
     {
         $factory->createShippingMethodFor(Argument::any())->shouldBeCalled()->willReturn($shippingMethod);
     }

--- a/rules/php71/src/Rector/TryCatch/MultiExceptionCatchRector.php
+++ b/rules/php71/src/Rector/TryCatch/MultiExceptionCatchRector.php
@@ -27,11 +27,11 @@ final class MultiExceptionCatchRector extends AbstractRector
                 new CodeSample(
 <<<'PHP'
 try {
-   // Some code...
+    // Some code...
 } catch (ExceptionType1 $exception) {
-   $sameCode;
+    $sameCode;
 } catch (ExceptionType2 $exception) {
-   $sameCode;
+    $sameCode;
 }
 PHP
                     ,

--- a/rules/phpunit/src/Rector/Foreach_/SimplifyForeachInstanceOfRector.php
+++ b/rules/phpunit/src/Rector/Foreach_/SimplifyForeachInstanceOfRector.php
@@ -36,7 +36,7 @@ final class SimplifyForeachInstanceOfRector extends AbstractRector
             new CodeSample(
                 <<<'PHP'
 foreach ($foos as $foo) {
-    $this->assertInstanceOf(\SplFileInfo::class, $foo);
+    $this->assertInstanceOf(SplFileInfo::class, $foo);
 }
 PHP
                 ,

--- a/rules/phpunit/src/Rector/MethodCall/DelegateExceptionArgumentsRector.php
+++ b/rules/phpunit/src/Rector/MethodCall/DelegateExceptionArgumentsRector.php
@@ -32,8 +32,8 @@ final class DelegateExceptionArgumentsRector extends AbstractPHPUnitRector
             [
                 new CodeSample(
                     '$this->setExpectedException(Exception::class, "Message", "CODE");',
-                    <<<PHP
-{$this->setExpectedException}(Throwable::class);
+                    <<<'PHP'
+{$this->setExpectedException}(Exception::class);
 {$this->expectExceptionMessage}('Message');
 {$this->expectExceptionCode}('CODE');
 PHP

--- a/rules/phpunit/src/Rector/MethodCall/DelegateExceptionArgumentsRector.php
+++ b/rules/phpunit/src/Rector/MethodCall/DelegateExceptionArgumentsRector.php
@@ -33,9 +33,9 @@ final class DelegateExceptionArgumentsRector extends AbstractPHPUnitRector
                 new CodeSample(
                     '$this->setExpectedException(Exception::class, "Message", "CODE");',
                     <<<PHP
-$this->setExpectedException(Throwable::class);
-$this->expectExceptionMessage('Message');
-$this->expectExceptionCode('CODE');
+{$this->setExpectedException}(Throwable::class);
+{$this->expectExceptionMessage}('Message');
+{$this->expectExceptionCode}('CODE');
 PHP
                 ),
             ]

--- a/rules/phpunit/src/Rector/MethodCall/DelegateExceptionArgumentsRector.php
+++ b/rules/phpunit/src/Rector/MethodCall/DelegateExceptionArgumentsRector.php
@@ -32,7 +32,7 @@ final class DelegateExceptionArgumentsRector extends AbstractPHPUnitRector
             [
                 new CodeSample(
                     '$this->setExpectedException(Exception::class, "Message", "CODE");',
-                    <<<'PHP'
+                    <<<PHP
 $this->setExpectedException(Throwable::class);
 $this->expectExceptionMessage('Message');
 $this->expectExceptionCode('CODE');

--- a/rules/phpunit/src/Rector/MethodCall/DelegateExceptionArgumentsRector.php
+++ b/rules/phpunit/src/Rector/MethodCall/DelegateExceptionArgumentsRector.php
@@ -33,9 +33,9 @@ final class DelegateExceptionArgumentsRector extends AbstractPHPUnitRector
                 new CodeSample(
                     '$this->setExpectedException(Exception::class, "Message", "CODE");',
                     <<<'PHP'
-$this->setExpectedException(Exception::class);
-$this->expectExceptionMessage("Message");
-$this->expectExceptionCode("CODE");
+$this->setExpectedException(Throwable::class);
+$this->expectExceptionMessage('Message');
+$this->expectExceptionCode('CODE');
 PHP
                 ),
             ]

--- a/rules/phpunit/src/Rector/MethodCall/DelegateExceptionArgumentsRector.php
+++ b/rules/phpunit/src/Rector/MethodCall/DelegateExceptionArgumentsRector.php
@@ -33,9 +33,9 @@ final class DelegateExceptionArgumentsRector extends AbstractPHPUnitRector
                 new CodeSample(
                     '$this->setExpectedException(Exception::class, "Message", "CODE");',
                     <<<'PHP'
-{$this->setExpectedException}(Exception::class);
-{$this->expectExceptionMessage}('Message');
-{$this->expectExceptionCode}('CODE');
+$this->setExpectedException(Exception::class);
+$this->expectExceptionMessage('Message');
+$this->expectExceptionCode('CODE');
 PHP
                 ),
             ]


### PR DESCRIPTION
Run `ecs` command for `HeredocNowdocPHPCodeFormatter` to `rules` and `packages` directory:

```
packages/easy-coding-standard/bin/ecs check-heredoc-nowdoc ../rector/packages
packages/easy-coding-standard/bin/ecs check-heredoc-nowdoc ../rector/rules
```

by https://github.com/symplify/symplify/pull/2137