### PR TITLE
Restructure class hierarchy to implement downgrade rules

### DIFF
--- a/rules/downgrade/src/Contract/Rector/DowngradeParamDeclarationRectorInterface.php
+++ b/rules/downgrade/src/Contract/Rector/DowngradeParamDeclarationRectorInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Downgrade\Contract\Rector;
+
+use PhpParser\Node\Param;
+
+interface DowngradeParamDeclarationRectorInterface
+{
+    /**
+     * Indicate if the parameter must be removed
+     */
+    public function shouldRemoveParamDeclaration(Param $param): bool;
+}

--- a/rules/downgrade/src/Contract/Rector/DowngradeReturnDeclarationRectorInterface.php
+++ b/rules/downgrade/src/Contract/Rector/DowngradeReturnDeclarationRectorInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Downgrade\Contract\Rector;
+
+use PhpParser\Node\FunctionLike;
+
+interface DowngradeReturnDeclarationRectorInterface
+{
+    /**
+     * Indicate if the return declaration must be removed
+     */
+    public function shouldRemoveReturnDeclaration(FunctionLike $functionLike): bool;
+}

--- a/rules/downgrade/src/Contract/Rector/DowngradeTypedPropertyRectorInterface.php
+++ b/rules/downgrade/src/Contract/Rector/DowngradeTypedPropertyRectorInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Downgrade\Contract\Rector;
+
+use PhpParser\Node\Stmt\Property;
+
+interface DowngradeTypedPropertyRectorInterface
+{
+    public function shouldSkip(Property $property): bool;
+}

--- a/rules/downgrade/src/Contract/Rector/DowngradeTypedPropertyRectorInterface.php
+++ b/rules/downgrade/src/Contract/Rector/DowngradeTypedPropertyRectorInterface.php
@@ -8,5 +8,5 @@ use PhpParser\Node\Stmt\Property;
 
 interface DowngradeTypedPropertyRectorInterface
 {
-    public function shouldSkip(Property $property): bool;
+    public function shouldRemoveProperty(Property $property): bool;
 }

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamDeclarationRector.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Downgrade\Rector\FunctionLike;
+
+use PhpParser\Node;
+use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\Downgrade\Contract\Rector\DowngradeParamDeclarationRectorInterface;
+use Rector\Downgrade\Rector\Property\AbstractDowngradeRector;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+
+abstract class AbstractDowngradeParamDeclarationRector extends AbstractDowngradeRector implements DowngradeParamDeclarationRectorInterface
+{
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [Function_::class, ClassMethod::class];
+    }
+
+    /**
+     * @param ClassMethod|Function_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($this->isAtLeastPhpVersion($this->getPhpVersionFeature())) {
+            return null;
+        }
+
+        if ($node->params === null || $node->params === []) {
+            return null;
+        }
+
+        foreach ($node->params as $param) {
+            $this->refactorParam($param, $node);
+        }
+
+        return null;
+    }
+
+    protected function getRectorDefinitionDescription(): string
+    {
+        return sprintf("Remove the '%s' param type, add a @param tag instead", $this->getTypeNameToRemove());
+    }
+
+    /**
+     * @param ClassMethod|Function_ $functionLike
+     */
+    private function refactorParam(Param $param, FunctionLike $functionLike): void
+    {
+        if ($this->shouldSkipParam($param)) {
+            return;
+        }
+
+        if ($this->addDocBlock) {
+            $node = $functionLike;
+            /** @var PhpDocInfo|null $phpDocInfo */
+            $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
+            if ($phpDocInfo === null) {
+                $phpDocInfo = $this->phpDocInfoFactory->createEmpty($node);
+            }
+
+            if ($param->type !== null) {
+                $type = $this->staticTypeMapper->mapPhpParserNodePHPStanType($param->type);
+                $paramName = $this->getName($param->var) ?? '';
+                $phpDocInfo->changeParamType($type, $param, $paramName);
+            }
+        }
+
+        $param->type = null;
+    }
+
+    private function shouldSkipParam(Param $param): bool
+    {
+        if ($param->variadic) {
+            return true;
+        }
+
+        if ($param->type === null) {
+            return true;
+        }
+
+        return ! $this->shouldRemoveParamDeclaration($param);
+    }
+}

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamDeclarationRector.php
@@ -44,17 +44,12 @@ abstract class AbstractDowngradeParamDeclarationRector extends AbstractDowngrade
         return null;
     }
 
-    protected function getRectorDefinitionDescription(): string
-    {
-        return sprintf("Remove the '%s' param type, add a @param tag instead", $this->getTypeNameToRemove());
-    }
-
     /**
      * @param ClassMethod|Function_ $functionLike
      */
     private function refactorParam(Param $param, FunctionLike $functionLike): void
     {
-        if ($this->shouldSkipParam($param)) {
+        if (! $this->shouldRemoveParamDeclaration($param)) {
             return;
         }
 
@@ -74,18 +69,5 @@ abstract class AbstractDowngradeParamDeclarationRector extends AbstractDowngrade
         }
 
         $param->type = null;
-    }
-
-    private function shouldSkipParam(Param $param): bool
-    {
-        if ($param->variadic) {
-            return true;
-        }
-
-        if ($param->type === null) {
-            return true;
-        }
-
-        return ! $this->shouldRemoveParamDeclaration($param);
     }
 }

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
@@ -12,23 +12,19 @@ use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
-use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
-use Rector\Downgrade\Contract\Rector\DowngradeRectorInterface;
 use Rector\Downgrade\Contract\Rector\DowngradeTypeRectorInterface;
+use Rector\Downgrade\Rector\Property\AbstractDowngradeRector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
-use Rector\TypeDeclaration\Rector\FunctionLike\AbstractTypeDeclarationRector;
 
-abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeDeclarationRector implements ConfigurableRectorInterface, DowngradeRectorInterface, DowngradeTypeRectorInterface
+abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractDowngradeRector implements DowngradeTypeRectorInterface
 {
     /**
-     * @var string
+     * @return string[]
      */
-    public const ADD_DOC_BLOCK = '$addDocBlock';
-
-    /**
-     * @var bool
-     */
-    private $addDocBlock = true;
+    public function getNodeTypes(): array
+    {
+        return [Function_::class, ClassMethod::class];
+    }
 
     /**
      * @param ClassMethod|Function_ $node
@@ -48,11 +44,6 @@ abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractTypeD
         }
 
         return null;
-    }
-
-    public function configure(array $configuration): void
-    {
-        $this->addDocBlock = $configuration[self::ADD_DOC_BLOCK] ?? true;
     }
 
     protected function getRectorDefinitionDescription(): string

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
@@ -13,6 +13,14 @@ abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractDowng
 {
     public function shouldRemoveParamDeclaration(Param $param): bool
     {
+        if ($param->variadic) {
+            return false;
+        }
+
+        if ($param->type === null) {
+            return false;
+        }
+
         // It can either be the type, or the nullable type (eg: ?object)
         $isNullableType = $param->type instanceof NullableType;
         if (! $param->type instanceof Identifier && ! $isNullableType) {
@@ -30,5 +38,10 @@ abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractDowng
 
         // Check it is the type to be removed
         return $typeName === $this->getTypeNameToRemove();
+    }
+
+    protected function getRectorDefinitionDescription(): string
+    {
+        return sprintf("Remove the '%s' param type, add a @param tag instead", $this->getTypeNameToRemove());
     }
 }

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeParamTypeDeclarationRector.php
@@ -4,94 +4,19 @@ declare(strict_types=1);
 
 namespace Rector\Downgrade\Rector\FunctionLike;
 
-use PhpParser\Node;
-use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Param;
-use PhpParser\Node\Stmt\ClassMethod;
-use PhpParser\Node\Stmt\Function_;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Downgrade\Contract\Rector\DowngradeTypeRectorInterface;
-use Rector\Downgrade\Rector\Property\AbstractDowngradeRector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 
-abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractDowngradeRector implements DowngradeTypeRectorInterface
+abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractDowngradeParamDeclarationRector implements DowngradeTypeRectorInterface
 {
-    /**
-     * @return string[]
-     */
-    public function getNodeTypes(): array
+    public function shouldRemoveParamDeclaration(Param $param): bool
     {
-        return [Function_::class, ClassMethod::class];
-    }
-
-    /**
-     * @param ClassMethod|Function_ $node
-     */
-    public function refactor(Node $node): ?Node
-    {
-        if ($this->isAtLeastPhpVersion($this->getPhpVersionFeature())) {
-            return null;
-        }
-
-        if ($node->params === null || $node->params === []) {
-            return null;
-        }
-
-        foreach ($node->params as $param) {
-            $this->refactorParam($param, $node);
-        }
-
-        return null;
-    }
-
-    protected function getRectorDefinitionDescription(): string
-    {
-        return sprintf("Remove the '%s' param type, add a @param tag instead", $this->getTypeNameToRemove());
-    }
-
-    /**
-     * @param ClassMethod|Function_ $functionLike
-     */
-    private function refactorParam(Param $param, FunctionLike $functionLike): void
-    {
-        if ($this->shouldSkipParam($param)) {
-            return;
-        }
-
-        if ($this->addDocBlock) {
-            $node = $functionLike;
-            /** @var PhpDocInfo|null $phpDocInfo */
-            $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
-            if ($phpDocInfo === null) {
-                $phpDocInfo = $this->phpDocInfoFactory->createEmpty($node);
-            }
-
-            if ($param->type !== null) {
-                $type = $this->staticTypeMapper->mapPhpParserNodePHPStanType($param->type);
-                $paramName = $this->getName($param->var) ?? '';
-                $phpDocInfo->changeParamType($type, $param, $paramName);
-            }
-        }
-
-        $param->type = null;
-    }
-
-    private function shouldSkipParam(Param $param): bool
-    {
-        if ($param->variadic) {
-            return true;
-        }
-
-        if ($param->type === null) {
-            return true;
-        }
-
         // It can either be the type, or the nullable type (eg: ?object)
         $isNullableType = $param->type instanceof NullableType;
         if (! $param->type instanceof Identifier && ! $isNullableType) {
-            return true;
+            return false;
         }
 
         // If it is the NullableType, extract the name from its inner type
@@ -104,6 +29,6 @@ abstract class AbstractDowngradeParamTypeDeclarationRector extends AbstractDowng
         }
 
         // Check it is the type to be removed
-        return $typeName !== $this->getTypeNameToRemove();
+        return $typeName === $this->getTypeNameToRemove();
     }
 }

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnDeclarationRector.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\Downgrade\Rector\FunctionLike;
 
 use PhpParser\Node;
-use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
@@ -32,7 +31,7 @@ abstract class AbstractDowngradeReturnDeclarationRector extends AbstractDowngrad
             return null;
         }
 
-        if ($this->shouldSkip($node)) {
+        if (! $this->shouldRemoveReturnDeclaration($node)) {
             return null;
         }
 
@@ -52,17 +51,5 @@ abstract class AbstractDowngradeReturnDeclarationRector extends AbstractDowngrad
         $node->returnType = null;
 
         return $node;
-    }
-
-    /**
-     * @param ClassMethod|Function_ $functionLike
-     */
-    private function shouldSkip(FunctionLike $functionLike): bool
-    {
-        if ($functionLike->returnType === null) {
-            return true;
-        }
-
-        return ! $this->shouldRemoveReturnDeclaration($functionLike);
     }
 }

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnDeclarationRector.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Downgrade\Rector\FunctionLike;
+
+use PhpParser\Node;
+use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\Downgrade\Contract\Rector\DowngradeReturnDeclarationRectorInterface;
+use Rector\Downgrade\Rector\Property\AbstractDowngradeRector;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+
+abstract class AbstractDowngradeReturnDeclarationRector extends AbstractDowngradeRector implements DowngradeReturnDeclarationRectorInterface
+{
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [Function_::class, ClassMethod::class];
+    }
+
+    /**
+     * @param ClassMethod|Function_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($this->isAtLeastPhpVersion($this->getPhpVersionFeature())) {
+            return null;
+        }
+
+        if ($this->shouldSkip($node)) {
+            return null;
+        }
+
+        if ($this->addDocBlock) {
+            /** @var PhpDocInfo|null $phpDocInfo */
+            $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
+            if ($phpDocInfo === null) {
+                $phpDocInfo = $this->phpDocInfoFactory->createEmpty($node);
+            }
+
+            if ($node->returnType !== null) {
+                $type = $this->staticTypeMapper->mapPhpParserNodePHPStanType($node->returnType);
+                $phpDocInfo->changeReturnType($type);
+            }
+        }
+
+        $node->returnType = null;
+
+        return $node;
+    }
+
+    /**
+     * @param ClassMethod|Function_ $functionLike
+     */
+    private function shouldSkip(FunctionLike $functionLike): bool
+    {
+        if ($functionLike->returnType === null) {
+            return true;
+        }
+
+        return ! $this->shouldRemoveReturnDeclaration($functionLike);
+    }
+}

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
@@ -4,71 +4,19 @@ declare(strict_types=1);
 
 namespace Rector\Downgrade\Rector\FunctionLike;
 
-use PhpParser\Node;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Downgrade\Contract\Rector\DowngradeTypeRectorInterface;
-use Rector\Downgrade\Rector\Property\AbstractDowngradeRector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 
-abstract class AbstractDowngradeReturnTypeDeclarationRector extends AbstractDowngradeRector implements DowngradeTypeRectorInterface
+abstract class AbstractDowngradeReturnTypeDeclarationRector extends AbstractDowngradeReturnDeclarationRector implements DowngradeTypeRectorInterface
 {
-    /**
-     * @return string[]
-     */
-    public function getNodeTypes(): array
-    {
-        return [Function_::class, ClassMethod::class];
-    }
-
-    /**
-     * @param ClassMethod|Function_ $node
-     */
-    public function refactor(Node $node): ?Node
-    {
-        if ($this->isAtLeastPhpVersion($this->getPhpVersionFeature())) {
-            return null;
-        }
-
-        if ($this->shouldSkip($node)) {
-            return null;
-        }
-
-        if ($this->addDocBlock) {
-            /** @var PhpDocInfo|null $phpDocInfo */
-            $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
-            if ($phpDocInfo === null) {
-                $phpDocInfo = $this->phpDocInfoFactory->createEmpty($node);
-            }
-
-            if ($node->returnType !== null) {
-                $type = $this->staticTypeMapper->mapPhpParserNodePHPStanType($node->returnType);
-                $phpDocInfo->changeReturnType($type);
-            }
-        }
-
-        $node->returnType = null;
-
-        return $node;
-    }
-
-    protected function getRectorDefinitionDescription(): string
-    {
-        return sprintf("Remove the '%s' function type, add a @return tag instead", $this->getTypeNameToRemove());
-    }
-
     /**
      * @param ClassMethod|Function_ $functionLike
      */
-    private function shouldSkip(FunctionLike $functionLike): bool
+    public function shouldRemoveReturnDeclaration(FunctionLike $functionLike): bool
     {
-        if ($functionLike->returnType === null) {
-            return true;
-        }
-
         // It can either be the type, or the nullable type (eg: ?object)
         $isNullableType = $functionLike->returnType instanceof NullableType;
         if ($isNullableType) {
@@ -80,6 +28,11 @@ abstract class AbstractDowngradeReturnTypeDeclarationRector extends AbstractDown
         }
 
         // Check it is the type to be removed
-        return $typeName !== $this->getTypeNameToRemove();
+        return $typeName === $this->getTypeNameToRemove();
+    }
+
+    protected function getRectorDefinitionDescription(): string
+    {
+        return sprintf("Remove the '%s' function type, add a @return tag instead", $this->getTypeNameToRemove());
     }
 }

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
@@ -10,23 +10,19 @@ use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
-use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
-use Rector\Downgrade\Contract\Rector\DowngradeRectorInterface;
 use Rector\Downgrade\Contract\Rector\DowngradeTypeRectorInterface;
+use Rector\Downgrade\Rector\Property\AbstractDowngradeRector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
-use Rector\TypeDeclaration\Rector\FunctionLike\AbstractTypeDeclarationRector;
 
-abstract class AbstractDowngradeReturnTypeDeclarationRector extends AbstractTypeDeclarationRector implements ConfigurableRectorInterface, DowngradeRectorInterface, DowngradeTypeRectorInterface
+abstract class AbstractDowngradeReturnTypeDeclarationRector extends AbstractDowngradeRector implements DowngradeTypeRectorInterface
 {
     /**
-     * @var string
+     * @return string[]
      */
-    public const ADD_DOC_BLOCK = '$addDocBlock';
-
-    /**
-     * @var bool
-     */
-    private $addDocBlock = true;
+    public function getNodeTypes(): array
+    {
+        return [Function_::class, ClassMethod::class];
+    }
 
     /**
      * @param ClassMethod|Function_ $node
@@ -57,11 +53,6 @@ abstract class AbstractDowngradeReturnTypeDeclarationRector extends AbstractType
         $node->returnType = null;
 
         return $node;
-    }
-
-    public function configure(array $configuration): void
-    {
-        $this->addDocBlock = $configuration[self::ADD_DOC_BLOCK] ?? true;
     }
 
     protected function getRectorDefinitionDescription(): string

--- a/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
+++ b/rules/downgrade/src/Rector/FunctionLike/AbstractDowngradeReturnTypeDeclarationRector.php
@@ -17,6 +17,10 @@ abstract class AbstractDowngradeReturnTypeDeclarationRector extends AbstractDown
      */
     public function shouldRemoveReturnDeclaration(FunctionLike $functionLike): bool
     {
+        if ($functionLike->returnType === null) {
+            return false;
+        }
+
         // It can either be the type, or the nullable type (eg: ?object)
         $isNullableType = $functionLike->returnType instanceof NullableType;
         if ($isNullableType) {

--- a/rules/downgrade/src/Rector/Property/AbstractDowngradeRector.php
+++ b/rules/downgrade/src/Rector/Property/AbstractDowngradeRector.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Downgrade\Rector\Property;
+
+use Rector\Downgrade\Contract\Rector\DowngradeRectorInterface;
+
+abstract class AbstractDowngradeRector extends AbstractMaybeAddDocBlockRector implements DowngradeRectorInterface
+{
+}

--- a/rules/downgrade/src/Rector/Property/AbstractDowngradeTypedPropertyRector.php
+++ b/rules/downgrade/src/Rector/Property/AbstractDowngradeTypedPropertyRector.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Downgrade\Rector\Property;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Property;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\Downgrade\Contract\Rector\DowngradeTypedPropertyRectorInterface;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+
+abstract class AbstractDowngradeTypedPropertyRector extends AbstractDowngradeRector implements DowngradeTypedPropertyRectorInterface
+{
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [Property::class];
+    }
+
+    /**
+     * @param Property $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($this->isAtLeastPhpVersion($this->getPhpVersionFeature())) {
+            return null;
+        }
+
+        if ($node->type === null) {
+            return null;
+        }
+
+        if ($this->shouldSkip($node)) {
+            return null;
+        }
+
+        if ($this->addDocBlock) {
+            /** @var PhpDocInfo|null $phpDocInfo */
+            $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
+            if ($phpDocInfo === null) {
+                $phpDocInfo = $this->phpDocInfoFactory->createEmpty($node);
+            }
+
+            $newType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($node->type);
+            $phpDocInfo->changeVarType($newType);
+        }
+        $node->type = null;
+
+        return $node;
+    }
+}

--- a/rules/downgrade/src/Rector/Property/AbstractDowngradeTypedPropertyRector.php
+++ b/rules/downgrade/src/Rector/Property/AbstractDowngradeTypedPropertyRector.php
@@ -33,7 +33,7 @@ abstract class AbstractDowngradeTypedPropertyRector extends AbstractDowngradeRec
             return null;
         }
 
-        if ($this->shouldSkip($node)) {
+        if (! $this->shouldRemoveProperty($node)) {
             return null;
         }
 

--- a/rules/downgrade/src/Rector/Property/AbstractMaybeAddDocBlockRector.php
+++ b/rules/downgrade/src/Rector/Property/AbstractMaybeAddDocBlockRector.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Downgrade\Rector\Property;
+
+use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Core\Rector\AbstractRector;
+
+abstract class AbstractMaybeAddDocBlockRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    /**
+     * @var string
+     */
+    public const ADD_DOC_BLOCK = '$addDocBlock';
+
+    /**
+     * @var bool
+     */
+    protected $addDocBlock = true;
+
+    public function configure(array $configuration): void
+    {
+        $this->addDocBlock = $configuration[self::ADD_DOC_BLOCK] ?? true;
+    }
+}

--- a/rules/downgrade/src/Rector/Property/DowngradeTypedPropertyRector.php
+++ b/rules/downgrade/src/Rector/Property/DowngradeTypedPropertyRector.php
@@ -4,33 +4,17 @@ declare(strict_types=1);
 
 namespace Rector\Downgrade\Rector\Property;
 
-use PhpParser\Node;
 use PhpParser\Node\Stmt\Property;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
-use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
-use Rector\Core\Rector\AbstractRector;
 use Rector\Core\RectorDefinition\CodeSample;
 use Rector\Core\RectorDefinition\RectorDefinition;
 use Rector\Core\ValueObject\PhpVersionFeature;
-use Rector\Downgrade\Contract\Rector\DowngradeRectorInterface;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 
 /**
  * @see \Rector\Downgrade\Tests\Rector\Property\DowngradeTypedPropertyRector\DowngradeTypedPropertyRectorTest
  * @see \Rector\Downgrade\Tests\Rector\Property\NoDocBlockDowngradeTypedPropertyRector\DowngradeTypedPropertyRectorTest
  */
-final class DowngradeTypedPropertyRector extends AbstractRector implements ConfigurableRectorInterface, DowngradeRectorInterface
+final class DowngradeTypedPropertyRector extends AbstractDowngradeTypedPropertyRector
 {
-    /**
-     * @var string
-     */
-    public const ADD_DOC_BLOCK = '$addDocBlock';
-
-    /**
-     * @var bool
-     */
-    private $addDocBlock = true;
-
     public function getDefinition(): RectorDefinition
     {
         return new RectorDefinition('Changes property type definition from type definitions to `@var` annotations.', [
@@ -55,11 +39,6 @@ PHP
         ]);
     }
 
-    public function configure(array $configuration): void
-    {
-        $this->addDocBlock = $configuration[self::ADD_DOC_BLOCK] ?? true;
-    }
-
     /**
      * @return string[]
      */
@@ -68,36 +47,13 @@ PHP
         return [Property::class];
     }
 
-    /**
-     * @param Property $node
-     */
-    public function refactor(Node $node): ?Node
-    {
-        if ($this->isAtLeastPhpVersion($this->getPhpVersionFeature())) {
-            return null;
-        }
-
-        if ($node->type === null) {
-            return null;
-        }
-
-        if ($this->addDocBlock) {
-            /** @var PhpDocInfo|null $phpDocInfo */
-            $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
-            if ($phpDocInfo === null) {
-                $phpDocInfo = $this->phpDocInfoFactory->createEmpty($node);
-            }
-
-            $newType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($node->type);
-            $phpDocInfo->changeVarType($newType);
-        }
-        $node->type = null;
-
-        return $node;
-    }
-
     public function getPhpVersionFeature(): string
     {
         return PhpVersionFeature::TYPED_PROPERTIES;
+    }
+
+    public function shouldSkip(Property $property): bool
+    {
+        return false;
     }
 }

--- a/rules/downgrade/src/Rector/Property/DowngradeTypedPropertyRector.php
+++ b/rules/downgrade/src/Rector/Property/DowngradeTypedPropertyRector.php
@@ -52,8 +52,8 @@ PHP
         return PhpVersionFeature::TYPED_PROPERTIES;
     }
 
-    public function shouldSkip(Property $property): bool
+    public function shouldRemoveProperty(Property $property): bool
     {
-        return false;
+        return true;
     }
 }


### PR DESCRIPTION
This PR adds no new functionality, but has restructured the different downgrade classes, so that they are more SOLID.

In particular, it enables to easily implement the rules for downgrading the PHP 8.0 type union (type property, param and return declarations).