### PR TITLE
[Downgrade PHP 8.0] mixed and static types

### DIFF
--- a/rules/downgrade-php80/src/Rector/FunctionLike/DowngradeParamMixedTypeDeclarationRector.php
+++ b/rules/downgrade-php80/src/Rector/FunctionLike/DowngradeParamMixedTypeDeclarationRector.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Rector\DowngradePhp80\Rector\FunctionLike;
 
 use Rector\Core\RectorDefinition\CodeSample;
-use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\Core\RectorDefinition\RectorDefinition;
+use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\DowngradePhp72\Rector\FunctionLike\AbstractDowngradeParamTypeDeclarationRector;
 
 /**

--- a/rules/downgrade-php80/src/Rector/FunctionLike/DowngradeParamMixedTypeDeclarationRector.php
+++ b/rules/downgrade-php80/src/Rector/FunctionLike/DowngradeParamMixedTypeDeclarationRector.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Rector\DowngradePhp80\Rector\FunctionLike;
 
 use Rector\Core\RectorDefinition\CodeSample;
-use Rector\Core\RectorDefinition\RectorDefinition;
 use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\Core\RectorDefinition\RectorDefinition;
+use Rector\DowngradePhp72\Rector\FunctionLike\AbstractDowngradeParamTypeDeclarationRector;
 
 /**
  * @see \Rector\DowngradePhp80\Tests\Rector\FunctionLike\DowngradeParamMixedTypeDeclarationRector\DowngradeParamMixedTypeDeclarationRectorTest

--- a/rules/downgrade-php80/src/Rector/FunctionLike/DowngradeParamMixedTypeDeclarationRector.php
+++ b/rules/downgrade-php80/src/Rector/FunctionLike/DowngradeParamMixedTypeDeclarationRector.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp80\Rector\FunctionLike;
+
+use Rector\Core\RectorDefinition\CodeSample;
+use Rector\Core\RectorDefinition\RectorDefinition;
+use Rector\Core\ValueObject\PhpVersionFeature;
+
+/**
+ * @see \Rector\DowngradePhp80\Tests\Rector\FunctionLike\DowngradeParamMixedTypeDeclarationRector\DowngradeParamMixedTypeDeclarationRectorTest
+ */
+final class DowngradeParamMixedTypeDeclarationRector extends AbstractDowngradeParamTypeDeclarationRector
+{
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition(
+            $this->getRectorDefinitionDescription(),
+            [
+                new CodeSample(
+                    <<<'PHP'
+<?php
+
+class SomeClass
+{
+    public function someFunction(mixed $anything)
+    {
+    }
+}
+PHP
+                    ,
+                    <<<'PHP'
+<?php
+
+class SomeClass
+{
+    /**
+     * @param mixed $anything
+     */
+    public function someFunction($anything)
+    {
+    }
+}
+PHP
+                ),
+            ]
+        );
+    }
+
+    public function getPhpVersionFeature(): string
+    {
+        return PhpVersionFeature::OBJECT_TYPE;
+    }
+
+    public function getTypeNameToRemove(): string
+    {
+        return 'mixed';
+    }
+}

--- a/rules/downgrade-php80/src/Rector/FunctionLike/DowngradeReturnMixedTypeDeclarationRector.php
+++ b/rules/downgrade-php80/src/Rector/FunctionLike/DowngradeReturnMixedTypeDeclarationRector.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp80\Rector\FunctionLike;
+
+use Rector\Core\RectorDefinition\CodeSample;
+use Rector\Core\RectorDefinition\RectorDefinition;
+use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\DowngradePhp72\Rector\FunctionLike\AbstractDowngradeReturnTypeDeclarationRector;
+
+/**
+ * @see \Rector\DowngradePhp80\Tests\Rector\FunctionLike\DowngradeReturnMixedTypeDeclarationRector\DowngradeReturnMixedTypeDeclarationRectorTest
+ */
+final class DowngradeReturnMixedTypeDeclarationRector extends AbstractDowngradeReturnTypeDeclarationRector
+{
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition(
+            $this->getRectorDefinitionDescription(),
+            [
+                new CodeSample(
+                    <<<'PHP'
+<?php
+
+class SomeClass
+{
+    public function getAnything(bool $flag): mixed
+    {
+        if ($flag) {
+            return 1;
+        }
+        return 'Hello world'
+    }
+}
+PHP
+                    ,
+                    <<<'PHP'
+<?php
+
+class SomeClass
+{
+    /**
+     * @return mixed
+     */
+    public function getAnything(bool $flag)
+    {
+        if ($flag) {
+            return 1;
+        }
+        return 'Hello world'
+    }
+}
+PHP
+                ),
+            ]
+        );
+    }
+
+    public function getPhpVersionFeature(): string
+    {
+        return PhpVersionFeature::MIXED_TYPE;
+    }
+
+    public function getTypeNameToRemove(): string
+    {
+        return 'mixed';
+    }
+}

--- a/rules/downgrade-php80/src/Rector/FunctionLike/DowngradeReturnStaticTypeDeclarationRector.php
+++ b/rules/downgrade-php80/src/Rector/FunctionLike/DowngradeReturnStaticTypeDeclarationRector.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp80\Rector\FunctionLike;
+
+use Rector\Core\RectorDefinition\CodeSample;
+use Rector\Core\RectorDefinition\RectorDefinition;
+use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\DowngradePhp72\Rector\FunctionLike\AbstractDowngradeReturnTypeDeclarationRector;
+
+/**
+ * @see \Rector\DowngradePhp80\Tests\Rector\FunctionLike\DowngradeReturnStaticTypeDeclarationRector\DowngradeReturnStaticTypeDeclarationRectorTest
+ */
+final class DowngradeReturnStaticTypeDeclarationRector extends AbstractDowngradeReturnTypeDeclarationRector
+{
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition(
+            $this->getRectorDefinitionDescription(),
+            [
+                new CodeSample(
+                    <<<'PHP'
+<?php
+
+class SomeClass
+{
+    public function getStatic(): static
+    {
+        return new static();
+    }
+}
+PHP
+                    ,
+                    <<<'PHP'
+<?php
+
+class SomeClass
+{
+    /**
+     * @return static
+     */
+    public function getStatic()
+    {
+        return new static();
+    }
+}
+PHP
+                ),
+            ]
+        );
+    }
+
+    public function getPhpVersionFeature(): string
+    {
+        return PhpVersionFeature::STATIC_RETURN_TYPE;
+    }
+
+    public function getTypeNameToRemove(): string
+    {
+        return 'static';
+    }
+}

--- a/rules/downgrade-php80/tests/Rector/FunctionLike/DowngradeParamMixedTypeDeclarationRector/DowngradeParamMixedTypeDeclarationRectorTest.php
+++ b/rules/downgrade-php80/tests/Rector/FunctionLike/DowngradeParamMixedTypeDeclarationRector/DowngradeParamMixedTypeDeclarationRectorTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp80\Tests\Rector\FunctionLike\DowngradeParamMixedTypeDeclarationRector;
+
+use Iterator;
+use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;
+use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\DowngradePhp80\Rector\FunctionLike\DowngradeParamMixedTypeDeclarationRector;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class DowngradeParamMixedTypeDeclarationRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @requires PHP >= 8.0
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @return array<string, mixed[]>
+     */
+    protected function getRectorsWithConfiguration(): array
+    {
+        return [
+            DowngradeParamMixedTypeDeclarationRector::class => [
+                DowngradeParamMixedTypeDeclarationRector::ADD_DOC_BLOCK => true,
+            ],
+        ];
+    }
+
+    protected function getRectorClass(): string
+    {
+        return DowngradeParamMixedTypeDeclarationRector::class;
+    }
+
+    protected function getPhpVersion(): string
+    {
+        return PhpVersionFeature::BEFORE_MIXED_TYPE;
+    }
+}

--- a/rules/downgrade-php80/tests/Rector/FunctionLike/DowngradeParamMixedTypeDeclarationRector/Fixture/docblock_exists.php.inc
+++ b/rules/downgrade-php80/tests/Rector/FunctionLike/DowngradeParamMixedTypeDeclarationRector/Fixture/docblock_exists.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\DowngradePhp80\Tests\Rector\FunctionLike\DowngradeParamMixedTypeDeclarationRector\Fixture;
+
+class DocBlockExists {
+    /**
+     * This property is the best one
+     */
+    public function someFunction(mixed $anything)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\DowngradePhp80\Tests\Rector\FunctionLike\DowngradeParamMixedTypeDeclarationRector\Fixture;
+
+class DocBlockExists {
+    /**
+     * This property is the best one
+     * @param mixed $anything
+     */
+    public function someFunction($anything)
+    {
+    }
+}
+
+?>

--- a/rules/downgrade-php80/tests/Rector/FunctionLike/DowngradeParamMixedTypeDeclarationRector/Fixture/docblock_tag_exists.php.inc
+++ b/rules/downgrade-php80/tests/Rector/FunctionLike/DowngradeParamMixedTypeDeclarationRector/Fixture/docblock_tag_exists.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\DowngradePhp80\Tests\Rector\FunctionLike\DowngradeParamMixedTypeDeclarationRector\Fixture;
+
+class DocBlockTagExists {
+    /**
+     * This property is the best one
+     * @param mixed $anything
+     */
+    public function someFunction(mixed $anything)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\DowngradePhp80\Tests\Rector\FunctionLike\DowngradeParamMixedTypeDeclarationRector\Fixture;
+
+class DocBlockTagExists {
+    /**
+     * This property is the best one
+     * @param mixed $anything
+     */
+    public function someFunction($anything)
+    {
+    }
+}
+
+?>

--- a/rules/downgrade-php80/tests/Rector/FunctionLike/DowngradeParamMixedTypeDeclarationRector/Fixture/fixture.php.inc
+++ b/rules/downgrade-php80/tests/Rector/FunctionLike/DowngradeParamMixedTypeDeclarationRector/Fixture/fixture.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\DowngradePhp80\Tests\Rector\FunctionLike\DowngradeParamMixedTypeDeclarationRector\Fixture;
+
+class SomeClass
+{
+    public function someFunction(mixed $anything)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\DowngradePhp80\Tests\Rector\FunctionLike\DowngradeParamMixedTypeDeclarationRector\Fixture;
+
+class SomeClass
+{
+    /**
+     * @param mixed $anything
+     */
+    public function someFunction($anything)
+    {
+    }
+}
+
+?>

--- a/rules/downgrade-php80/tests/Rector/FunctionLike/DowngradeParamMixedTypeDeclarationRector/Fixture/multiple_matching_params.php.inc
+++ b/rules/downgrade-php80/tests/Rector/FunctionLike/DowngradeParamMixedTypeDeclarationRector/Fixture/multiple_matching_params.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\DowngradePhp80\Tests\Rector\FunctionLike\DowngradeParamMixedTypeDeclarationRector\Fixture;
+
+class MultipleMatchingParams
+{
+    public function someFunction(mixed $anything, string $someOtherVar, mixed $someOtherObject)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\DowngradePhp80\Tests\Rector\FunctionLike\DowngradeParamMixedTypeDeclarationRector\Fixture;
+
+class MultipleMatchingParams
+{
+    /**
+     * @param mixed $anything
+     * @param mixed $someOtherObject
+     */
+    public function someFunction($anything, string $someOtherVar, $someOtherObject)
+    {
+    }
+}
+
+?>

--- a/rules/downgrade-php80/tests/Rector/FunctionLike/DowngradeParamMixedTypeDeclarationRector/Fixture/multiple_params.php.inc
+++ b/rules/downgrade-php80/tests/Rector/FunctionLike/DowngradeParamMixedTypeDeclarationRector/Fixture/multiple_params.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\DowngradePhp80\Tests\Rector\FunctionLike\DowngradeParamMixedTypeDeclarationRector\Fixture;
+
+class MultipleParams
+{
+    public function someFunction(mixed $anything, string $someOtherVar)
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\DowngradePhp80\Tests\Rector\FunctionLike\DowngradeParamMixedTypeDeclarationRector\Fixture;
+
+class MultipleParams
+{
+    /**
+     * @param mixed $anything
+     */
+    public function someFunction($anything, string $someOtherVar)
+    {
+    }
+}
+
+?>

--- a/rules/downgrade-php80/tests/Rector/FunctionLike/DowngradeParamMixedTypeDeclarationRector/Source/AnotherClass.php
+++ b/rules/downgrade-php80/tests/Rector/FunctionLike/DowngradeParamMixedTypeDeclarationRector/Source/AnotherClass.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Rector\DowngradePhp80\Tests\Rector\FunctionLike\DowngradeParamMixedTypeDeclarationRector\Source;
+
+
+class AnotherClass
+{
+
+}

--- a/rules/downgrade-php80/tests/Rector/FunctionLike/DowngradeReturnMixedTypeDeclarationRector/DowngradeReturnMixedTypeDeclarationRectorTest.php
+++ b/rules/downgrade-php80/tests/Rector/FunctionLike/DowngradeReturnMixedTypeDeclarationRector/DowngradeReturnMixedTypeDeclarationRectorTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp80\Tests\Rector\FunctionLike\DowngradeReturnMixedTypeDeclarationRector;
+
+use Iterator;
+use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;
+use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\DowngradePhp80\Rector\FunctionLike\DowngradeReturnMixedTypeDeclarationRector;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class DowngradeReturnMixedTypeDeclarationRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @requires PHP >= 8.0
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @return array<string, mixed[]>
+     */
+    protected function getRectorsWithConfiguration(): array
+    {
+        return [
+            DowngradeReturnMixedTypeDeclarationRector::class => [
+                DowngradeReturnMixedTypeDeclarationRector::ADD_DOC_BLOCK => true,
+            ],
+        ];
+    }
+
+    protected function getRectorClass(): string
+    {
+        return DowngradeReturnMixedTypeDeclarationRector::class;
+    }
+
+    protected function getPhpVersion(): string
+    {
+        return PhpVersionFeature::BEFORE_MIXED_TYPE;
+    }
+}

--- a/rules/downgrade-php80/tests/Rector/FunctionLike/DowngradeReturnMixedTypeDeclarationRector/Fixture/docblock_exists.php.inc
+++ b/rules/downgrade-php80/tests/Rector/FunctionLike/DowngradeReturnMixedTypeDeclarationRector/Fixture/docblock_exists.php.inc
@@ -1,0 +1,40 @@
+<?php
+
+namespace Rector\DowngradePhp80\Tests\Rector\FunctionLike\DowngradeReturnMixedTypeDeclarationRector\Fixture;
+
+class DocBlockExists {
+    /**
+     * This property is the best one
+     */
+    public function getAnything(): mixed
+    {
+        if (mt_rand()) {
+            return 1;
+        }
+
+        return 'value';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\DowngradePhp80\Tests\Rector\FunctionLike\DowngradeReturnMixedTypeDeclarationRector\Fixture;
+
+class DocBlockExists {
+    /**
+     * This property is the best one
+     * @return mixed
+     */
+    public function getAnything()
+    {
+        if (mt_rand()) {
+            return 1;
+        }
+
+        return 'value';
+    }
+}
+
+?>

--- a/rules/downgrade-php80/tests/Rector/FunctionLike/DowngradeReturnMixedTypeDeclarationRector/Fixture/docblock_tag_exists.php.inc
+++ b/rules/downgrade-php80/tests/Rector/FunctionLike/DowngradeReturnMixedTypeDeclarationRector/Fixture/docblock_tag_exists.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\DowngradePhp80\Tests\Rector\FunctionLike\DowngradeReturnMixedTypeDeclarationRector\Fixture;
+
+class DocBlockTagExists {
+    /**
+     * This property is the best one
+     * @return mixed
+     */
+    public function getAnything(): mixed
+    {
+        if (mt_rand()) {
+            return 1;
+        }
+
+        return 'value';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\DowngradePhp80\Tests\Rector\FunctionLike\DowngradeReturnMixedTypeDeclarationRector\Fixture;
+
+class DocBlockTagExists {
+    /**
+     * This property is the best one
+     * @return mixed
+     */
+    public function getAnything()
+    {
+        if (mt_rand()) {
+            return 1;
+        }
+
+        return 'value';
+    }
+}
+
+?>

--- a/rules/downgrade-php80/tests/Rector/FunctionLike/DowngradeReturnMixedTypeDeclarationRector/Fixture/fixture.php.inc
+++ b/rules/downgrade-php80/tests/Rector/FunctionLike/DowngradeReturnMixedTypeDeclarationRector/Fixture/fixture.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rector\DowngradePhp80\Tests\Rector\FunctionLike\DowngradeReturnMixedTypeDeclarationRector\Fixture;
+
+class SomeClass
+{
+    public function getAnything(): mixed
+    {
+        if (mt_rand()) {
+            return 1;
+        }
+
+        return 'value';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\DowngradePhp80\Tests\Rector\FunctionLike\DowngradeReturnMixedTypeDeclarationRector\Fixture;
+
+class SomeClass
+{
+    /**
+     * @return mixed
+     */
+    public function getAnything()
+    {
+        if (mt_rand()) {
+            return 1;
+        }
+
+        return 'value';
+    }
+}
+
+?>

--- a/rules/downgrade-php80/tests/Rector/FunctionLike/DowngradeReturnMixedTypeDeclarationRector/Source/AnotherClass.php
+++ b/rules/downgrade-php80/tests/Rector/FunctionLike/DowngradeReturnMixedTypeDeclarationRector/Source/AnotherClass.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Rector\DowngradePhp80\Tests\Rector\FunctionLike\DowngradeReturnMixedTypeDeclarationRector\Source;
+
+
+class AnotherClass
+{
+
+}

--- a/rules/downgrade-php80/tests/Rector/FunctionLike/DowngradeReturnStaticTypeDeclarationRector/DowngradeReturnStaticTypeDeclarationRectorTest.php
+++ b/rules/downgrade-php80/tests/Rector/FunctionLike/DowngradeReturnStaticTypeDeclarationRector/DowngradeReturnStaticTypeDeclarationRectorTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp80\Tests\Rector\FunctionLike\DowngradeReturnStaticTypeDeclarationRector;
+
+use Iterator;
+use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;
+use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\DowngradePhp80\Rector\FunctionLike\DowngradeReturnStaticTypeDeclarationRector;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class DowngradeReturnStaticTypeDeclarationRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @requires PHP >= 8.0
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    /**
+     * @return array<string, mixed[]>
+     */
+    protected function getRectorsWithConfiguration(): array
+    {
+        return [
+            DowngradeReturnStaticTypeDeclarationRector::class => [
+                DowngradeReturnStaticTypeDeclarationRector::ADD_DOC_BLOCK => true,
+            ],
+        ];
+    }
+
+    protected function getRectorClass(): string
+    {
+        return DowngradeReturnStaticTypeDeclarationRector::class;
+    }
+
+    protected function getPhpVersion(): string
+    {
+        return PhpVersionFeature::BEFORE_MIXED_TYPE;
+    }
+}

--- a/rules/downgrade-php80/tests/Rector/FunctionLike/DowngradeReturnStaticTypeDeclarationRector/Fixture/docblock_exists.php.inc
+++ b/rules/downgrade-php80/tests/Rector/FunctionLike/DowngradeReturnStaticTypeDeclarationRector/Fixture/docblock_exists.php.inc
@@ -1,0 +1,40 @@
+<?php
+
+namespace Rector\DowngradePhp80\Tests\Rector\FunctionLike\DowngradeReturnStaticTypeDeclarationRector\Fixture;
+
+class DocBlockExists {
+    /**
+     * This property is the best one
+     */
+    public function getAnything(): static
+    {
+        if (mt_rand()) {
+            return 1;
+        }
+
+        return 'value';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\DowngradePhp80\Tests\Rector\FunctionLike\DowngradeReturnStaticTypeDeclarationRector\Fixture;
+
+class DocBlockExists {
+    /**
+     * This property is the best one
+     * @return static
+     */
+    public function getAnything()
+    {
+        if (mt_rand()) {
+            return 1;
+        }
+
+        return 'value';
+    }
+}
+
+?>

--- a/rules/downgrade-php80/tests/Rector/FunctionLike/DowngradeReturnStaticTypeDeclarationRector/Fixture/docblock_tag_exists.php.inc
+++ b/rules/downgrade-php80/tests/Rector/FunctionLike/DowngradeReturnStaticTypeDeclarationRector/Fixture/docblock_tag_exists.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Rector\DowngradePhp80\Tests\Rector\FunctionLike\DowngradeReturnStaticTypeDeclarationRector\Fixture;
+
+class DocBlockTagExists {
+    /**
+     * This property is the best one
+     * @return static
+     */
+    public function getAnything(): static
+    {
+        if (mt_rand()) {
+            return 1;
+        }
+
+        return 'value';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\DowngradePhp80\Tests\Rector\FunctionLike\DowngradeReturnStaticTypeDeclarationRector\Fixture;
+
+class DocBlockTagExists {
+    /**
+     * This property is the best one
+     * @return static
+     */
+    public function getAnything()
+    {
+        if (mt_rand()) {
+            return 1;
+        }
+
+        return 'value';
+    }
+}
+
+?>

--- a/rules/downgrade-php80/tests/Rector/FunctionLike/DowngradeReturnStaticTypeDeclarationRector/Fixture/fixture.php.inc
+++ b/rules/downgrade-php80/tests/Rector/FunctionLike/DowngradeReturnStaticTypeDeclarationRector/Fixture/fixture.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rector\DowngradePhp80\Tests\Rector\FunctionLike\DowngradeReturnStaticTypeDeclarationRector\Fixture;
+
+class SomeClass
+{
+    public function getAnything(): static
+    {
+        if (mt_rand()) {
+            return 1;
+        }
+
+        return 'value';
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\DowngradePhp80\Tests\Rector\FunctionLike\DowngradeReturnStaticTypeDeclarationRector\Fixture;
+
+class SomeClass
+{
+    /**
+     * @return static
+     */
+    public function getAnything()
+    {
+        if (mt_rand()) {
+            return 1;
+        }
+
+        return 'value';
+    }
+}
+
+?>

--- a/rules/downgrade-php80/tests/Rector/FunctionLike/DowngradeReturnStaticTypeDeclarationRector/Source/AnotherClass.php
+++ b/rules/downgrade-php80/tests/Rector/FunctionLike/DowngradeReturnStaticTypeDeclarationRector/Source/AnotherClass.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Rector\DowngradePhp80\Tests\Rector\FunctionLike\DowngradeReturnStaticTypeDeclarationRector\Source;
+
+
+class AnotherClass
+{
+
+}

--- a/src/ValueObject/PhpVersionFeature.php
+++ b/src/ValueObject/PhpVersionFeature.php
@@ -185,6 +185,11 @@ final class PhpVersionFeature
     /**
      * @var string
      */
+    public const MIXED_TYPE = '8.0';
+
+    /**
+     * @var string
+     */
     public const STATIC_RETURN_TYPE = '8.0';
 
     /**


### PR DESCRIPTION
Remove `mixed` and `static` types:

```php
public function foo(mixed $anything): mixed
{
}

public function bar(): static
{
}
```