### PR TITLE
Fixed invalid method name in code sample.

### DIFF
--- a/rules/symfony/src/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
+++ b/rules/symfony/src/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
@@ -44,7 +44,7 @@ PHP
                 <<<'PHP'
 class SomeCommand extends Command
 {
-    public function index(InputInterface $input, OutputInterface $output): int
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         return 0;
     }


### PR DESCRIPTION
The rule doesn't change the method name from index to execute, it only fixes the return type and the TypeHint.