### PR TITLE
Github Actions: add a job which tests the lowest supported versions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,10 @@ jobs:
         strategy:
             matrix:
                 php: ['7.2', '7.3', '7.4']
-                dependencies: [lowest, locked]
+                dependencies: [locked]
+                include:
+                    - php: '7.2'
+                      dependencies: lowest
 
         name: PHP ${{ matrix.php }} tests
         steps:
@@ -29,5 +32,5 @@ jobs:
             -   run: composer update --prefer-lowest --no-progress --ansi
                 if: "matrix.dependencies == 'lowest'"
             -   run: composer install --no-progress --ansi
-                if: "matrix.dependencies == 'locked'"
+                if: "matrix.dependencies != 'lowest'"
             -   run: vendor/bin/phpunit

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,10 +12,10 @@ jobs:
         strategy:
             matrix:
                 php: ['7.2', '7.3', '7.4']
-                dependencies: [locked]
+                dependencies: ['locked']
                 include:
                     - php: '7.2'
-                      dependencies: lowest
+                      dependencies: 'lowest'
 
         name: PHP ${{ matrix.php }} tests
         steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,7 +26,7 @@ jobs:
             -   name: Setup Problem Matchers for PHPUnit
                 run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-            -   run: composer install --prefer-lowest --no-progress --ansi
+            -   run: composer update --prefer-lowest --no-progress --ansi
                 if: "matrix.dependencies == 'lowest'"
             -   run: composer install --no-progress --ansi
                 if: "matrix.dependencies == 'locked'"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,6 +12,7 @@ jobs:
         strategy:
             matrix:
                 php: ['7.2', '7.3', '7.4']
+                dependencies: [lowest, locked]
 
         name: PHP ${{ matrix.php }} tests
         steps:
@@ -25,5 +26,8 @@ jobs:
             -   name: Setup Problem Matchers for PHPUnit
                 run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
+            -   run: composer install --prefer-lowest --no-progress --ansi
+                if: "matrix.dependencies == 'lowest'"
             -   run: composer install --no-progress --ansi
+                if: "matrix.dependencies == 'locked'"
             -   run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "symplify/set-config-resolver": "^8.2.20",
         "symplify/smart-file-system": "^8.2.20",
         "tracy/tracy": "^2.7",
-        "webmozart/assert": "^1.0"
+        "webmozart/assert": "^1.8"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16",


### PR DESCRIPTION
in https://github.com/rectorphp/rector/issues/4218 there was identified, that rector cannot be installed properly with lowest dependency resolution.

this PR adds automated coverage to prevent regressing the lower version boundary