### PR TITLE
[PHP 8.0] Add @route to #[Route] attribute in Symfony 5.2

### DIFF
--- a/packages/better-php-doc-parser/config/config.php
+++ b/packages/better-php-doc-parser/config/config.php
@@ -20,11 +20,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->load('Rector\BetterPhpDocParser\\', __DIR__ . '/../src')
         ->exclude([
-            __DIR__ . '/../src/ValueObject/*',
+            __DIR__ . '/../src/ValueObject',
             __DIR__ . '/../src/*/*Info.php',
             __DIR__ . '/../src/*Info.php',
-            __DIR__ . '/../src/Attributes/Ast/PhpDoc/*',
-            __DIR__ . '/../src/PhpDocNode/*',
+            __DIR__ . '/../src/Attributes/Ast/PhpDoc',
+            __DIR__ . '/../src/PhpDocNode',
         ]);
 
     $services->set(Lexer::class);

--- a/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Class_/EntityTagValueNode.php
+++ b/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Class_/EntityTagValueNode.php
@@ -31,4 +31,9 @@ final class EntityTagValueNode extends AbstractDoctrineTagValueNode implements P
     {
         return $this->filterOutMissingItems($this->items);
     }
+
+    public function getAttributeClassName(): string
+    {
+        return 'TBA';
+    }
 }

--- a/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Property_/ColumnTagValueNode.php
+++ b/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Property_/ColumnTagValueNode.php
@@ -44,4 +44,9 @@ final class ColumnTagValueNode extends AbstractDoctrineTagValueNode implements P
     {
         return $this->filterOutMissingItems($this->items);
     }
+
+    public function getAttributeClassName(): string
+    {
+        return 'TBA';
+    }
 }

--- a/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Property_/GeneratedValueTagValueNode.php
+++ b/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Property_/GeneratedValueTagValueNode.php
@@ -30,4 +30,9 @@ final class GeneratedValueTagValueNode extends AbstractDoctrineTagValueNode impl
     {
         return $this->filterOutMissingItems($this->items);
     }
+
+    public function getAttributeClassName(): string
+    {
+        return 'TBA';
+    }
 }

--- a/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Property_/IdTagValueNode.php
+++ b/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Property_/IdTagValueNode.php
@@ -21,4 +21,9 @@ final class IdTagValueNode extends AbstractDoctrineTagValueNode implements PhpAt
     {
         return $this->filterOutMissingItems($this->items);
     }
+
+    public function getAttributeClassName(): string
+    {
+        return 'TBA';
+    }
 }

--- a/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Property_/JoinColumnTagValueNode.php
+++ b/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Property_/JoinColumnTagValueNode.php
@@ -59,4 +59,9 @@ final class JoinColumnTagValueNode extends AbstractDoctrineTagValueNode implemen
     {
         return $this->filterOutMissingItems($this->items);
     }
+
+    public function getAttributeClassName(): string
+    {
+        return 'TBA';
+    }
 }

--- a/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Property_/JoinTableTagValueNode.php
+++ b/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Property_/JoinTableTagValueNode.php
@@ -120,6 +120,11 @@ final class JoinTableTagValueNode extends AbstractDoctrineTagValueNode implement
         return $items;
     }
 
+    public function getAttributeClassName(): string
+    {
+        return 'TBA';
+    }
+
     /**
      * @return string[]
      */

--- a/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Property_/ManyToManyTagValueNode.php
+++ b/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Property_/ManyToManyTagValueNode.php
@@ -79,4 +79,9 @@ final class ManyToManyTagValueNode extends AbstractDoctrineTagValueNode implemen
     {
         return $this->filterOutMissingItems($this->items);
     }
+
+    public function getAttributeClassName(): string
+    {
+        return 'TBA';
+    }
 }

--- a/packages/better-php-doc-parser/src/PhpDocNode/Symfony/SymfonyRouteTagValueNode.php
+++ b/packages/better-php-doc-parser/src/PhpDocNode/Symfony/SymfonyRouteTagValueNode.php
@@ -7,12 +7,13 @@ namespace Rector\BetterPhpDocParser\PhpDocNode\Symfony;
 use Rector\BetterPhpDocParser\Contract\PhpDocNode\ShortNameAwareTagInterface;
 use Rector\BetterPhpDocParser\Contract\PhpDocNode\SilentKeyNodeInterface;
 use Rector\BetterPhpDocParser\PhpDocNode\AbstractTagValueNode;
+use Rector\PhpAttribute\Contract\PhpAttributableTagNodeInterface;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * @see \Rector\BetterPhpDocParser\Tests\PhpDocParser\TagValueNodeReprint\TagValueNodeReprintTest
  */
-final class SymfonyRouteTagValueNode extends AbstractTagValueNode implements ShortNameAwareTagInterface, SilentKeyNodeInterface
+final class SymfonyRouteTagValueNode extends AbstractTagValueNode implements ShortNameAwareTagInterface, SilentKeyNodeInterface, PhpAttributableTagNodeInterface
 {
     /**
      * @var string
@@ -42,7 +43,7 @@ final class SymfonyRouteTagValueNode extends AbstractTagValueNode implements Sho
 
     public function getShortName(): string
     {
-        return '@Route';
+        return 'Route';
     }
 
     public function getSilentKey(): string
@@ -53,5 +54,10 @@ final class SymfonyRouteTagValueNode extends AbstractTagValueNode implements Sho
     public function mimicTagValueNodeConfiguration(AbstractTagValueNode $abstractTagValueNode): void
     {
         $this->tagValueNodeConfiguration->mimic($abstractTagValueNode->tagValueNodeConfiguration);
+    }
+
+    public function getAttributableItems(): array
+    {
+        return $this->filterOutMissingItems($this->items);
     }
 }

--- a/packages/better-php-doc-parser/src/PhpDocNode/Symfony/SymfonyRouteTagValueNode.php
+++ b/packages/better-php-doc-parser/src/PhpDocNode/Symfony/SymfonyRouteTagValueNode.php
@@ -41,14 +41,14 @@ final class SymfonyRouteTagValueNode extends AbstractTagValueNode implements Sho
         $this->items['methods'] = $methods;
     }
 
-    public function getShortName(): string
-    {
-        return 'Route';
-    }
-
     public function getSilentKey(): string
     {
         return self::PATH;
+    }
+
+    public function getShortName(): string
+    {
+        return '@Route';
     }
 
     public function mimicTagValueNodeConfiguration(AbstractTagValueNode $abstractTagValueNode): void
@@ -56,8 +56,16 @@ final class SymfonyRouteTagValueNode extends AbstractTagValueNode implements Sho
         $this->tagValueNodeConfiguration->mimic($abstractTagValueNode->tagValueNodeConfiguration);
     }
 
+    /**
+     * @return mixed[]
+     */
     public function getAttributableItems(): array
     {
         return $this->filterOutMissingItems($this->items);
+    }
+
+    public function getAttributeClassName(): string
+    {
+        return 'Symfony\Component\Routing\Attribute\Route';
     }
 }

--- a/packages/better-php-doc-parser/src/PhpDocNode/Symfony/Validator/Constraints/AssertEmailTagValueNode.php
+++ b/packages/better-php-doc-parser/src/PhpDocNode/Symfony/Validator/Constraints/AssertEmailTagValueNode.php
@@ -32,4 +32,9 @@ final class AssertEmailTagValueNode extends AbstractTagValueNode implements Type
     {
         return $this->filterOutMissingItems($this->items);
     }
+
+    public function getAttributeClassName(): string
+    {
+        return 'TBA';
+    }
 }

--- a/packages/better-php-doc-parser/src/PhpDocNode/Symfony/Validator/Constraints/AssertRangeTagValueNode.php
+++ b/packages/better-php-doc-parser/src/PhpDocNode/Symfony/Validator/Constraints/AssertRangeTagValueNode.php
@@ -23,4 +23,9 @@ final class AssertRangeTagValueNode extends AbstractTagValueNode implements Type
     {
         return $this->filterOutMissingItems($this->items);
     }
+
+    public function getAttributeClassName(): string
+    {
+        return 'TBA';
+    }
 }

--- a/packages/php-attribute/src/Contract/PhpAttributableTagNodeInterface.php
+++ b/packages/php-attribute/src/Contract/PhpAttributableTagNodeInterface.php
@@ -8,6 +8,8 @@ interface PhpAttributableTagNodeInterface
 {
     public function getShortName(): string;
 
+    public function getAttributeClassName(): string;
+
     /**
      * @return mixed[]
      */

--- a/packages/php-attribute/src/Printer/PhpAttributteGroupFactory.php
+++ b/packages/php-attribute/src/Printer/PhpAttributteGroupFactory.php
@@ -103,6 +103,7 @@ final class PhpAttributteGroupFactory
 
         return $args;
     }
+
     private function resolveAttributeClassName(PhpAttributableTagNodeInterface $phpAttributableTagNode): Name
     {
         if ($phpAttributableTagNode->getAttributeClassName() !== self::TBA) {

--- a/packages/php-attribute/src/Printer/PhpAttributteGroupFactory.php
+++ b/packages/php-attribute/src/Printer/PhpAttributteGroupFactory.php
@@ -17,6 +17,9 @@ use Rector\PhpAttribute\Contract\PhpAttributableTagNodeInterface;
 
 final class PhpAttributteGroupFactory
 {
+    /**
+     * @var string
+     */
     public const TBA = 'TBA';
 
     /**
@@ -100,6 +103,14 @@ final class PhpAttributteGroupFactory
 
         return $args;
     }
+    private function resolveAttributeClassName(PhpAttributableTagNodeInterface $phpAttributableTagNode): Name
+    {
+        if ($phpAttributableTagNode->getAttributeClassName() !== self::TBA) {
+            return new FullyQualified($phpAttributableTagNode->getAttributeClassName());
+        }
+
+        return new Name($phpAttributableTagNode->getShortName());
+    }
 
     /**
      * @param Arg[] $args
@@ -119,14 +130,5 @@ final class PhpAttributteGroupFactory
         }
 
         return false;
-    }
-
-    private function resolveAttributeClassName(PhpAttributableTagNodeInterface $phpAttributableTagNode): Name
-    {
-        if ($phpAttributableTagNode->getAttributeClassName() !== self::TBA) {
-            return new FullyQualified($phpAttributableTagNode->getAttributeClassName());
-        }
-
-        return new Name($phpAttributableTagNode->getShortName());
     }
 }

--- a/packages/rector-generator/config/config.php
+++ b/packages/rector-generator/config/config.php
@@ -17,11 +17,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->bind(AddNewServiceToSymfonyPhpConfigRector::class, ref(AddNewServiceToSymfonyPhpConfigRector::class));
 
     $services->load('Rector\RectorGenerator\\', __DIR__ . '/../src')
-        ->exclude([
-            __DIR__ . '/../src/Exception/*',
-            __DIR__ . '/../src/ValueObject/*',
-            __DIR__ . '/../src/Rector',
-        ]);
+        ->exclude([__DIR__ . '/../src/Exception', __DIR__ . '/../src/ValueObject', __DIR__ . '/../src/Rector']);
 
     $services->set(AddNewServiceToSymfonyPhpConfigRector::class)
         ->autowire(false);

--- a/packages/rector-generator/src/Composer/ComposerPackageAutoloadUpdater.php
+++ b/packages/rector-generator/src/Composer/ComposerPackageAutoloadUpdater.php
@@ -20,6 +20,11 @@ final class ComposerPackageAutoloadUpdater
     /**
      * @var string
      */
+    private const AUTOLOAD = 'autoload';
+
+    /**
+     * @var string
+     */
     private const AUTOLOAD_DEV = 'autoload-dev';
 
     /**
@@ -60,7 +65,7 @@ final class ComposerPackageAutoloadUpdater
             return;
         }
 
-        $srcAutoload = $rectorRecipe->isRectorRepository() ? 'autoload' : self::AUTOLOAD_DEV;
+        $srcAutoload = $rectorRecipe->isRectorRepository() ? self::AUTOLOAD : self::AUTOLOAD_DEV;
         $composerJson[$srcAutoload][self::PSR_4][$package->getSrcNamespace()] = $package->getSrcDirectory();
 
         $composerJson[self::AUTOLOAD_DEV][self::PSR_4][$package->getTestsNamespace()] = $package->getTestsDirectory();

--- a/rules/php80/tests/Rector/Class_/AnnotationToAttributeRector/Fixture/RFC/assert_range.php.inc
+++ b/rules/php80/tests/Rector/Class_/AnnotationToAttributeRector/Fixture/RFC/assert_range.php.inc
@@ -27,7 +27,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class AssertRange
 {
-    #[@Assert\Range(['min' => 120, 'max' => 180, 'minMessage' => 'You must be at least {{ limit }}cm tall to enter', 'maxMessage' => 'You cannot be taller than {{ limit }}cm to enter'])]
+    #[@Assert\Range(min: 120, max: 180, minMessage: 'You must be at least {{ limit }}cm tall to enter', maxMessage: 'You cannot be taller than {{ limit }}cm to enter')]
     protected $height;
 }
 

--- a/rules/php80/tests/Rector/Class_/AnnotationToAttributeRector/Fixture/RFC/entity_column_and_assert_email.php.inc
+++ b/rules/php80/tests/Rector/Class_/AnnotationToAttributeRector/Fixture/RFC/entity_column_and_assert_email.php.inc
@@ -25,8 +25,8 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class EntityColumnAndAssertEmail
 {
-    #[@ORM\Column(['type' => 'string', 'unique' => true])]
-    #[@Assert\Email(['message' => 'This value is not a valid email address.'])]
+    #[@ORM\Column(type: 'string', unique: true)]
+    #[@Assert\Email(message: 'This value is not a valid email address.')]
     public $name;
 }
 

--- a/rules/php80/tests/Rector/Class_/AnnotationToAttributeRector/Fixture/RFC/id_column_generated_value.php.inc
+++ b/rules/php80/tests/Rector/Class_/AnnotationToAttributeRector/Fixture/RFC/id_column_generated_value.php.inc
@@ -23,7 +23,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 class IdColumnGeneratedvalue
 {
-    #[@ORM\Column(['type' => 'integer'])]
+    #[@ORM\Column(type: 'integer')]
     #[@ORM\GeneratedValue]
     public $name;
 }

--- a/rules/php80/tests/Rector/Class_/AnnotationToAttributeRector/Fixture/RFC/join_table.php.inc
+++ b/rules/php80/tests/Rector/Class_/AnnotationToAttributeRector/Fixture/RFC/join_table.php.inc
@@ -25,9 +25,9 @@ use Doctrine\ORM\Mapping as ORM;
 
 class JoinTable
 {
-    #[@ORM\JoinTable(['name' => 'users_phonenumbers'])]
-    #[@ORM\JoinColumn(['name' => 'user_id', 'referencedColumnName' => 'id'])]
-    #[@ORM\InverseJoinColumn(['name' => 'phonenumber_id', 'referencedColumnName' => 'id', 'unique' => true])]
+    #[@ORM\JoinTable(name: 'users_phonenumbers')]
+    #[@ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id')]
+    #[@ORM\InverseJoinColumn(name: 'phonenumber_id', referencedColumnName: 'id', unique: true)]
     public $name;
 }
 

--- a/rules/php80/tests/Rector/Class_/AnnotationToAttributeRector/Fixture/RFC/many_to_many.php.inc
+++ b/rules/php80/tests/Rector/Class_/AnnotationToAttributeRector/Fixture/RFC/many_to_many.php.inc
@@ -22,7 +22,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 class ManyToMany
 {
-    #[@ORM\ManyToMany(['targetEntity' => 'Phonenumber'])]
+    #[@ORM\ManyToMany(targetEntity: 'Phonenumber')]
     public $name;
 }
 

--- a/rules/php80/tests/Rector/Class_/AnnotationToAttributeRector/Fixture/entity_with_repository.php.inc
+++ b/rules/php80/tests/Rector/Class_/AnnotationToAttributeRector/Fixture/entity_with_repository.php.inc
@@ -19,7 +19,7 @@ namespace Rector\Php80\Tests\Rector\Class_\AnnotationToAttributeRector\Fixture;
 
 use Doctrine\ORM\Mapping as ORM;
 
-#[@ORM\Entity(['repositoryClass' => 'MyProject\UserRepository', 'readOnly' => true])]
+#[@ORM\Entity(repositoryClass: 'MyProject\UserRepository', readOnly: true)]
 class EntityWithRepository
 {
 }

--- a/rules/php80/tests/Rector/Class_/AnnotationToAttributeRector/Fixture/symfony_route.php.inc
+++ b/rules/php80/tests/Rector/Class_/AnnotationToAttributeRector/Fixture/symfony_route.php.inc
@@ -7,7 +7,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class SymfonyRoute
 {
     /**
-     * @Route("/path", name: "action")
+     * @Route("/path", name="action")
      */
     public function action()
     {
@@ -20,11 +20,11 @@ class SymfonyRoute
 
 namespace Rector\Php80\Tests\Rector\Class_\AnnotationToAttributeRector\Fixture;
 
-use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Routing\Annotation\Route;
 
 class SymfonyRoute
 {
-    #[Route('/path', name: 'action')]
+    #[\Symfony\Component\Routing\Attribute\Route('/path', name: 'action')]
     public function action()
     {
     }

--- a/rules/php80/tests/Rector/Class_/AnnotationToAttributeRector/Fixture/symfony_route.php.inc
+++ b/rules/php80/tests/Rector/Class_/AnnotationToAttributeRector/Fixture/symfony_route.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Php80\Tests\Rector\Class_\AnnotationToAttributeRector\Fixture;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+class SymfonyRoute
+{
+    /**
+     * @Route("/path", name: "action")
+     */
+    public function action()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Php80\Tests\Rector\Class_\AnnotationToAttributeRector\Fixture;
+
+use Symfony\Component\Routing\Attribute\Route;
+
+class SymfonyRoute
+{
+    #[Route('/path', name: 'action')]
+    public function action()
+    {
+    }
+}
+
+?>

--- a/rules/symfony/config/config.php
+++ b/rules/symfony/config/config.php
@@ -16,12 +16,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->autowire();
 
     $services->load('Rector\Symfony\\', __DIR__ . '/../src')
-        ->exclude(
-            [
-                __DIR__ . '/../src/Rector/*',
-                __DIR__ . '/../src/Exception/*',
-                __DIR__ . '/../src/ValueObject/*',
-                __DIR__ . '/../src/PhpDocParser/Ast/PhpDoc/*',
-            ]
-        );
+        ->exclude([__DIR__ . '/../src/Rector', __DIR__ . '/../src/Exception', __DIR__ . '/../src/ValueObject']);
 };

--- a/rules/type-declaration/config/config.php
+++ b/rules/type-declaration/config/config.php
@@ -13,9 +13,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->autoconfigure();
 
     $services->load('Rector\TypeDeclaration\\', __DIR__ . '/../src')
-        ->exclude([
-            __DIR__ . '/../src/Rector/*',
-            __DIR__ . '/../src/Exception/*',
-            __DIR__ . '/../src/ValueObject/*',
-        ]);
+        ->exclude([__DIR__ . '/../src/Rector', __DIR__ . '/../src/Exception', __DIR__ . '/../src/ValueObject']);
 };

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -68,6 +68,8 @@ final class BetterStandardPrinter extends Standard
     private const QUOTED_SLASH_REGEX = "#'|\\\\(?=[\\\\']|$)#";
 
     /**
+     * Remove extra spaces before new Nop_ nodes
+     * @see https://regex101.com/r/iSvroO/1
      * @var string
      */
     private const EXTRA_SPACE_BEFORE_NOP_REGEX = '#^[ \t]+$#m';
@@ -255,7 +257,6 @@ final class BetterStandardPrinter extends Standard
             return $content;
         }
 
-        // remove extra spaces before new Nop_ nodes, @see https://regex101.com/r/iSvroO/1
         return Strings::replace($content, self::EXTRA_SPACE_BEFORE_NOP_REGEX);
     }
 


### PR DESCRIPTION
Closes https://github.com/rectorphp/rector/issues/4310

Ref https://github.com/symfony/symfony/pull/37474

## Example

```diff
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;

 class SymfonyRoute
 {
-    /**
-     * @Route("/path", name="action")
-     */
+    #[Route('/path', name: 'action')]
     public function action()
     {
     }
 }
```