### PR TITLE
Add a fixture for generators with keys

### DIFF
--- a/rules/php74/tests/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector/Fixture/skip_string_keys_from_generator.php.inc
+++ b/rules/php74/tests/Rector/FuncCall/ArraySpreadInsteadOfArrayMergeRector/Fixture/skip_string_keys_from_generator.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Php74\Tests\Rector\FuncCall\ArraySpreadInsteadOfArrayMergeRector\Fixture;
+
+function z(): \Generator
+{
+    yield 'key' => 'value';
+}
+
+class SkipStringKeysFromGenerator
+{
+    public function run()
+    {
+        return \iterator_to_array(z());
+    }
+}


### PR DESCRIPTION
See https://github.com/rectorphp/rector/issues/4333
This adds a fixture that shows what not to be fixed, a `\Generator` that has string keys.