### PR TITLE
[PHP74] Do not transform callable|null into typed property

### DIFF
--- a/rules/php74/src/Rector/Property/TypedPropertyRector.php
+++ b/rules/php74/src/Rector/Property/TypedPropertyRector.php
@@ -177,10 +177,6 @@ CODE_SAMPLE
      */
     private function shouldSkipNonClassLikeType(Node $node): bool
     {
-        if (! $this->classLikeTypeOnly) {
-            return false;
-        }
-
         // unwrap nullable type
         if ($node instanceof NullableType) {
             $node = $node->type;
@@ -188,6 +184,13 @@ CODE_SAMPLE
 
         $typeName = $this->getName($node);
         if ($typeName === null) {
+            return false;
+        }
+        if ($typeName === 'callable') {
+            return true;
+        }
+
+        if (! $this->classLikeTypeOnly) {
             return false;
         }
 

--- a/rules/php74/tests/Rector/Property/TypedPropertyRector/Fixture/property.php.inc
+++ b/rules/php74/tests/Rector/Property/TypedPropertyRector/Fixture/property.php.inc
@@ -23,6 +23,11 @@ final class ClassWithProperty
      * @var callable
      */
     private $shouldBeSkippedToo;
+
+    /**
+     * @var callable|null
+     */
+    private $shouldBeSkippedAlso;
 }
 
 ?>
@@ -49,6 +54,11 @@ final class ClassWithProperty
      * @var callable
      */
     private $shouldBeSkippedToo;
+
+    /**
+     * @var callable|null
+     */
+    private $shouldBeSkippedAlso;
 }
 
 ?>


### PR DESCRIPTION
Before
```php
 final class ClassWithProperty
 {
    /**
     * @var callable|null
     */
    private $shouldBeSkippedAlso;
 }
```

would have been transformed to 
```php
 final class ClassWithProperty
 {
    private ?callable $shouldBeSkippedAlso = null;
 }
```

Which result in invalid PHP as explained in the  [RFC](https://wiki.php.net/rfc/typed_properties_v2)

I'm not familiar with the project, this is my first contribution so you might know a less dirty way to fix this.
Thanks by advance for your consideration