### PR TITLE
Fixes config/set link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,19 +53,19 @@ It supports all versions of PHP from 5.2 and many open-source projects:
 <br>
 
 <p align="center">
-    <a href="/config/set/php"><img src="/docs/images/php.png"></a>
+    <a href="/config/set/"><img src="/docs/images/php.png"></a>
     <img src="/docs/images/space.png" width=40>
-    <a href="/config/set/symfony"><img src="/docs/images/symfony.png"></a>
+    <a href="/config/set/"><img src="/docs/images/symfony.png"></a>
     <img src="/docs/images/space.png" width=40>
-    <a href="/config/set/laravel"><img src="/docs/images/laravel.png"></a>
+    <a href="/config/set/"><img src="/docs/images/laravel.png"></a>
     <img src="/docs/images/space.png" width=40>
-    <a href="/config/set/twig"><img src="/docs/images/twig.png"></a>
+    <a href="/config/set/"><img src="/docs/images/twig.png"></a>
     <br>
     <a href="https://github.com/palantirnet/drupal-rector/tree/master/config/drupal-8"><img src="/docs/images/drupal.png" alt="Drupal Rector rules"></a>
     <img src="/docs/images/space.png" width=40>
-    <a href="/config/set/cakephp"><img src="/docs/images/cakephp.png"></a>
+    <a href="/config/set/"><img src="/docs/images/cakephp.png"></a>
     <img src="/docs/images/space.png" width=40>
-    <a href="/config/set/phpunit"><img src="/docs/images/phpunit.png"></a>
+    <a href="/config/set/"><img src="/docs/images/phpunit.png"></a>
 </p>
 
 <br>


### PR DESCRIPTION
The link previously got 404 page. I think root `/config/set` link is enough since there are multiple set in per-each category, eg: symfony (symfony-autowire.php, symfony-codequality.php, etc).