### PR TITLE
[Downgrade PHP 7.4] Added downgrade array spread rule to set

### DIFF
--- a/config/set/downgrade-php74.php
+++ b/config/set/downgrade-php74.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Rector\DowngradePhp74\Rector\Array_\DowngradeArraySpreadRector;
 use Rector\DowngradePhp74\Rector\ArrowFunction\ArrowFunctionToAnonymousFunctionRector;
 use Rector\DowngradePhp74\Rector\Coalesce\DowngradeNullCoalescingOperatorRector;
 use Rector\DowngradePhp74\Rector\FuncCall\DowngradeStripTagsCallWithArrayRector;
@@ -16,4 +17,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(DowngradeNullCoalescingOperatorRector::class);
     $services->set(DowngradeNumericLiteralSeparatorRector::class);
     $services->set(DowngradeStripTagsCallWithArrayRector::class);
+    $services->set(DowngradeArraySpreadRector::class);
 };


### PR DESCRIPTION
I forgot to add rector `DowngradeArraySpreadRector` to the set in #4375, fixed now.

Can generate a new tag after merged?