### PR TITLE
Add a tag value node for Doctrine Embedded tags

### DIFF
--- a/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Class_/EmbeddedTagValueNode.php
+++ b/packages/better-php-doc-parser/src/PhpDocNode/Doctrine/Class_/EmbeddedTagValueNode.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace Rector\BetterPhpDocParser\PhpDocNode\Doctrine\Class_;
+
+use Rector\BetterPhpDocParser\PhpDocNode\Doctrine\AbstractDoctrineTagValueNode;
+
+final class EmbeddedTagValueNode extends AbstractDoctrineTagValueNode
+{
+    /**
+     * @var string
+     */
+    private $fullyQualifiedClassName;
+
+    public function __construct(array $items, ?string $originalContent, string $fullyQualifiedClassName)
+    {
+        parent::__construct($items, $originalContent);
+
+        $this->fullyQualifiedClassName = $fullyQualifiedClassName;
+    }
+
+    public function getShortName(): string
+    {
+        return '@ORM\Embedded';
+    }
+
+    public function getClass(): string
+    {
+        return $this->items['class'];
+    }
+
+    public function fullyQualifiedClassName(): string
+    {
+        return $this->fullyQualifiedClassName;
+    }
+
+    public function getColumnPrefix(): ?string
+    {
+        return $this->items['columnPrefix'];
+    }
+}

--- a/packages/better-php-doc-parser/src/PhpDocNodeFactory/Doctrine/Property_/DoctrineEmbeddedPhpDocNodeFactory.php
+++ b/packages/better-php-doc-parser/src/PhpDocNodeFactory/Doctrine/Property_/DoctrineEmbeddedPhpDocNodeFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\BetterPhpDocParser\PhpDocNodeFactory\Doctrine\Property_;
+
+use Doctrine\ORM\Mapping\Embedded;
+use PhpParser\Node;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagValueNode;
+use PHPStan\PhpDocParser\Parser\TokenIterator;
+use Rector\BetterPhpDocParser\Contract\GenericPhpDocNodeFactoryInterface;
+use Rector\BetterPhpDocParser\PhpDocNode\Doctrine\Class_\EmbeddedTagValueNode;
+use Rector\BetterPhpDocParser\PhpDocNodeFactory\AbstractPhpDocNodeFactory;
+
+final class DoctrineEmbeddedPhpDocNodeFactory extends AbstractPhpDocNodeFactory implements GenericPhpDocNodeFactoryInterface
+{
+    /**
+     * @return array<string, string>
+     */
+    public function getTagValueNodeClassesToAnnotationClasses(): array
+    {
+        return [
+            EmbeddedTagValueNode::class => 'Doctrine\ORM\Mapping\Embedded',
+        ];
+    }
+
+    public function createFromNodeAndTokens(
+        Node $node,
+        TokenIterator $tokenIterator,
+        string $annotationClass
+    ): ?PhpDocTagValueNode {
+        /** @var Embedded|null $annotation */
+        $annotation = $this->nodeAnnotationReader->readAnnotation($node, $annotationClass);
+        if ($annotation === null) {
+            return null;
+        }
+
+        $content = $this->resolveContentFromTokenIterator($tokenIterator);
+        $items = $this->annotationItemsResolver->resolve($annotation);
+        $fullyQualifiedClassName = $this->resolveFqnTargetEntity($annotation->class, $node);
+
+        return new EmbeddedTagValueNode($items, $content, $fullyQualifiedClassName);
+    }
+}

--- a/packages/better-php-doc-parser/tests/PhpDocParser/Helper/TagValueToPhpParserNodeMap.php
+++ b/packages/better-php-doc-parser/tests/PhpDocParser/Helper/TagValueToPhpParserNodeMap.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Stmt\Property;
 use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\TemplateTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
+use Rector\BetterPhpDocParser\PhpDocNode\Doctrine\Class_\EmbeddedTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocNode\Doctrine\Class_\EntityTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocNode\Doctrine\Class_\TableTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocNode\Doctrine\Property_\ColumnTagValueNode;
@@ -43,6 +44,7 @@ final class TagValueToPhpParserNodeMap
         TableTagValueNode::class => Class_::class,
         CustomIdGeneratorTagValueNode::class => Property::class,
         GeneratedValueTagValueNode::class => Property::class,
+        EmbeddedTagValueNode::class => Property::class,
         // special case for constants
         GenericTagValueNode::class => Property::class,
         SensioTemplateTagValueNode::class => Class_::class,

--- a/packages/better-php-doc-parser/tests/PhpDocParser/TagValueNodeReprint/Fixture/DoctrineEmbedded/AnEntityWithAnEmbedded.php
+++ b/packages/better-php-doc-parser/tests/PhpDocParser/TagValueNodeReprint/Fixture/DoctrineEmbedded/AnEntityWithAnEmbedded.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace Rector\BetterPhpDocParser\Tests\PhpDocParser\TagValueNodeReprint\Fixture\DoctrineEmbedded;
+
+use Doctrine\ORM\Mapping as ORM;
+use Rector\BetterPhpDocParser\Tests\PhpDocParser\TagValueNodeReprint\Source\Embeddable;
+
+final class AnEntityWithAnEmbedded
+{
+    /**
+     * @ORM\Embedded(class="Embeddable")
+     */
+    private $embedded;
+}

--- a/packages/better-php-doc-parser/tests/PhpDocParser/TagValueNodeReprint/Fixture/DoctrineEmbedded/AnEntityWithAnEmbeddedAndAColumnPrefix.php
+++ b/packages/better-php-doc-parser/tests/PhpDocParser/TagValueNodeReprint/Fixture/DoctrineEmbedded/AnEntityWithAnEmbeddedAndAColumnPrefix.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace Rector\BetterPhpDocParser\Tests\PhpDocParser\TagValueNodeReprint\Fixture\DoctrineEmbedded;
+
+use Doctrine\ORM\Mapping as ORM;
+use Rector\BetterPhpDocParser\Tests\PhpDocParser\TagValueNodeReprint\Source\Embeddable;
+
+final class AnEntityWithAnEmbeddedAndAColumnPrefix
+{
+    /**
+     * @ORM\Embedded(class="Embeddable", columnPrefix="prefix_")
+     */
+    private $embedded;
+}

--- a/packages/better-php-doc-parser/tests/PhpDocParser/TagValueNodeReprint/Source/Embeddable.php
+++ b/packages/better-php-doc-parser/tests/PhpDocParser/TagValueNodeReprint/Source/Embeddable.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Rector\BetterPhpDocParser\Tests\PhpDocParser\TagValueNodeReprint\Source;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Embeddable
+ */
+final class Embeddable
+{
+}

--- a/packages/better-php-doc-parser/tests/PhpDocParser/TagValueNodeReprint/TagValueNodeReprintTest.php
+++ b/packages/better-php-doc-parser/tests/PhpDocParser/TagValueNodeReprint/TagValueNodeReprintTest.php
@@ -8,6 +8,7 @@ use Iterator;
 use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\TemplateTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
+use Rector\BetterPhpDocParser\PhpDocNode\Doctrine\Class_\EmbeddedTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocNode\Doctrine\Class_\EntityTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocNode\Doctrine\Class_\TableTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocNode\Doctrine\Property_\ColumnTagValueNode;
@@ -64,6 +65,7 @@ final class TagValueNodeReprintTest extends AbstractPhpDocInfoTest
             TableTagValueNode::class => __DIR__ . '/Fixture/DoctrineTable',
             CustomIdGeneratorTagValueNode::class => __DIR__ . '/Fixture/DoctrineCustomIdGenerator',
             GeneratedValueTagValueNode::class => __DIR__ . '/Fixture/DoctrineGeneratedValue',
+            EmbeddedTagValueNode::class => __DIR__ . '/Fixture/DoctrineEmbedded',
             // special case
             GenericTagValueNode::class => __DIR__ . '/Fixture/ConstantReference',
             SensioTemplateTagValueNode::class => __DIR__ . '/Fixture/SensioTemplate',

--- a/stubs/Doctrine/ORM/Mapping/Embedded.php
+++ b/stubs/Doctrine/ORM/Mapping/Embedded.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Doctrine\ORM\Mapping;
+
+// mimics @see https://github.com/doctrine/orm/blob/master/lib/Doctrine/ORM/Annotation/Embedded.php
+
+if (class_exists('Doctrine\ORM\Mapping\Embedded')) {
+    return;
+}
+
+/**
+ * @Annotation
+ * @Target("PROPERTY")
+ */
+final class Embedded implements Annotation
+{
+    /**
+     * @Required
+     * @var string
+     */
+    public $class;
+
+    /**
+     * @var mixed
+     */
+    public $columnPrefix;
+}


### PR DESCRIPTION
Although I'm not submitting an actual rule that uses this, at least it makes the list of supported Doctrine annotations more complete. I also needed this one for a project I'm working on now.

When running the tests on my machine PHPStan produces 89 errors but I guess they have to do with the PHP runtime I'm using locally.