### PR TITLE
Downgrade PHP7.4 array_merge without arguments (#4377)

### DIFF
--- a/config/set/downgrade-php74.php
+++ b/config/set/downgrade-php74.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Rector\DowngradePhp74\Rector\Array_\DowngradeArraySpreadRector;
 use Rector\DowngradePhp74\Rector\ArrowFunction\ArrowFunctionToAnonymousFunctionRector;
 use Rector\DowngradePhp74\Rector\Coalesce\DowngradeNullCoalescingOperatorRector;
+use Rector\DowngradePhp74\Rector\FuncCall\DowngradeArrayMergeCallWithoutArgumentsRector;
 use Rector\DowngradePhp74\Rector\FuncCall\DowngradeStripTagsCallWithArrayRector;
 use Rector\DowngradePhp74\Rector\LNumber\DowngradeNumericLiteralSeparatorRector;
 use Rector\DowngradePhp74\Rector\Property\DowngradeTypedPropertyRector;
@@ -18,4 +19,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(DowngradeNumericLiteralSeparatorRector::class);
     $services->set(DowngradeStripTagsCallWithArrayRector::class);
     $services->set(DowngradeArraySpreadRector::class);
+    $services->set(DowngradeArrayMergeCallWithoutArgumentsRector::class);
 };

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# All 592 Rectors Overview
+# All 593 Rectors Overview
 
 - [Projects](#projects)
 ---
@@ -19,7 +19,7 @@
 - [DowngradePhp71](#downgradephp71) (3)
 - [DowngradePhp72](#downgradephp72) (2)
 - [DowngradePhp73](#downgradephp73) (1)
-- [DowngradePhp74](#downgradephp74) (6)
+- [DowngradePhp74](#downgradephp74) (7)
 - [DowngradePhp80](#downgradephp80) (6)
 - [DynamicTypeAnalysis](#dynamictypeanalysis) (3)
 - [FileSystemRector](#filesystemrector) (1)
@@ -5066,6 +5066,29 @@ Replace arrow functions with anonymous functions
 +        $callable = function ($matches) use ($delimiter) {
 +            return $delimiter . strtolower($matches[1]);
 +        };
+     }
+ }
+```
+
+<br><br>
+
+### `DowngradeArrayMergeCallWithoutArgumentsRector`
+
+- class: [`Rector\DowngradePhp74\Rector\FuncCall\DowngradeArrayMergeCallWithoutArgumentsRector`](/rules/downgrade-php74/src/Rector/FuncCall/DowngradeArrayMergeCallWithoutArgumentsRector.php)
+- [test fixtures](/rules/downgrade-php74/tests/Rector/FuncCall/DowngradeArrayMergeCallWithoutArgumentsRector/Fixture)
+
+Add missing param to `array_merge` and `array_merge_recursive`
+
+```diff
+ class SomeClass
+ {
+-    public function run()
++    public function run()
+     {
+-        array_merge();
+-        array_merge_recursive();
++        array_merge([]);
++        array_merge_recursive([]);
      }
  }
 ```

--- a/rules/downgrade-php74/src/Rector/FuncCall/DowngradeArrayMergeCallWithoutArgumentsRector.php
+++ b/rules/downgrade-php74/src/Rector/FuncCall/DowngradeArrayMergeCallWithoutArgumentsRector.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp74\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\FuncCall;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\RectorDefinition\CodeSample;
+use Rector\Core\RectorDefinition\RectorDefinition;
+
+/**
+ * @see \Rector\DowngradePhp74\Tests\Rector\FuncCall\DowngradeArrayMergeCallWithoutArgumentsRector\DowngradeArrayMergeCallWithoutArgumentsRectorTest
+ */
+final class DowngradeArrayMergeCallWithoutArgumentsRector extends AbstractRector
+{
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Add missing param to `array_merge` and `array_merge_recursive`', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run()
+    {
+        array_merge();
+        array_merge_recursive();
+    }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run()
+    {
+        array_merge([]);
+        array_merge_recursive([]);
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    /**
+     * @param FuncCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (! $this->shouldRefactor($node)) {
+            return null;
+        }
+
+        $node->args = [new Arg(new Array_())];
+
+        return $node;
+    }
+
+    /**
+     * @param FuncCall $node
+     */
+    private function shouldRefactor(Node $node): bool
+    {
+        if (! $this->isFuncCallName($node, 'array_merge') && ! $this->isFuncCallName($node, 'array_merge_recursive')) {
+            return false;
+        }
+
+        // If param is provided, do nothing
+        if ($node->args !== []) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/rules/downgrade-php74/src/Rector/FuncCall/DowngradeArrayMergeCallWithoutArgumentsRector.php
+++ b/rules/downgrade-php74/src/Rector/FuncCall/DowngradeArrayMergeCallWithoutArgumentsRector.php
@@ -68,17 +68,14 @@ CODE_SAMPLE
         return $node;
     }
 
-    /**
-     * @param FuncCall $node
-     */
-    private function shouldRefactor(Node $node): bool
+    private function shouldRefactor(FuncCall $funcCall): bool
     {
-        if (! $this->isFuncCallName($node, 'array_merge') && ! $this->isFuncCallName($node, 'array_merge_recursive')) {
+        if (! $this->isNames($funcCall, ['array_merge', 'array_merge_recursive'])) {
             return false;
         }
 
         // If param is provided, do nothing
-        if ($node->args !== []) {
+        if ($funcCall->args !== []) {
             return false;
         }
 

--- a/rules/downgrade-php74/tests/Rector/FuncCall/DowngradeArrayMergeCallWithoutArgumentsRector/DowngradeArrayMergeCallWithoutArgumentsRectorTest.php
+++ b/rules/downgrade-php74/tests/Rector/FuncCall/DowngradeArrayMergeCallWithoutArgumentsRector/DowngradeArrayMergeCallWithoutArgumentsRectorTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp74\Tests\Rector\FuncCall\DowngradeArrayMergeCallWithoutArgumentsRector;
+
+use Iterator;
+use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;
+use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\DowngradePhp74\Rector\FuncCall\DowngradeArrayMergeCallWithoutArgumentsRector;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class DowngradeArrayMergeCallWithoutArgumentsRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @requires PHP 7.4
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    protected function getRectorClass(): string
+    {
+        return DowngradeArrayMergeCallWithoutArgumentsRector::class;
+    }
+
+    protected function getPhpVersion(): string
+    {
+        return PhpVersionFeature::BEFORE_STRIP_TAGS_WITH_ARRAY;
+    }
+}

--- a/rules/downgrade-php74/tests/Rector/FuncCall/DowngradeArrayMergeCallWithoutArgumentsRector/Fixture/array_merge.php.inc
+++ b/rules/downgrade-php74/tests/Rector/FuncCall/DowngradeArrayMergeCallWithoutArgumentsRector/Fixture/array_merge.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\DowngradePhp74\Tests\Rector\FuncCall\DowngradeArrayMergeCallWithoutArgumentsRector\Fixture;
+
+class ArrayMergeClass
+{
+    public function run()
+    {
+        array_merge();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\DowngradePhp74\Tests\Rector\FuncCall\DowngradeArrayMergeCallWithoutArgumentsRector\Fixture;
+
+class ArrayMergeClass
+{
+    public function run()
+    {
+        array_merge([]);
+    }
+}
+
+?>

--- a/rules/downgrade-php74/tests/Rector/FuncCall/DowngradeArrayMergeCallWithoutArgumentsRector/Fixture/array_merge_recursive.php.inc
+++ b/rules/downgrade-php74/tests/Rector/FuncCall/DowngradeArrayMergeCallWithoutArgumentsRector/Fixture/array_merge_recursive.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\DowngradePhp74\Tests\Rector\FuncCall\DowngradeArrayMergeCallWithoutArgumentsRector\Fixture;
+
+class ArrayMergeRecursiveClass
+{
+    public function run()
+    {
+        array_merge_recursive();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\DowngradePhp74\Tests\Rector\FuncCall\DowngradeArrayMergeCallWithoutArgumentsRector\Fixture;
+
+class ArrayMergeRecursiveClass
+{
+    public function run()
+    {
+        array_merge_recursive([]);
+    }
+}
+
+?>

--- a/rules/downgrade-php74/tests/Rector/FuncCall/DowngradeArrayMergeCallWithoutArgumentsRector/Fixture/skip_array.php.inc
+++ b/rules/downgrade-php74/tests/Rector/FuncCall/DowngradeArrayMergeCallWithoutArgumentsRector/Fixture/skip_array.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\DowngradePhp74\Tests\Rector\FuncCall\DowngradeArrayMergeCallWithoutArgumentsRector\Fixture;
+
+class SkipArrayClass
+{
+    public function run()
+    {
+        // Array: do no change
+        array_merge([]);
+        array_merge_recursive([]);
+    }
+}
+
+?>

--- a/rules/downgrade-php74/tests/Rector/FuncCall/DowngradeArrayMergeCallWithoutArgumentsRector/Fixture/skip_multiple_arguments.php.inc
+++ b/rules/downgrade-php74/tests/Rector/FuncCall/DowngradeArrayMergeCallWithoutArgumentsRector/Fixture/skip_multiple_arguments.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rector\DowngradePhp74\Tests\Rector\FuncCall\DowngradeArrayMergeCallWithoutArgumentsRector\Fixture;
+
+class SkipMultipleArgumentsClass
+{
+    public function run()
+    {
+        $array = [];
+        // Multiple Arguments: do no change
+        array_merge([], []);
+        array_merge($array, []);
+        array_merge([], $array);
+        array_merge($array, $array);
+        array_merge_recursive([], []);
+        array_merge_recursive($array, []);
+        array_merge_recursive([], $array);
+        array_merge_recursive($array, $array);
+    }
+}
+
+?>

--- a/rules/downgrade-php74/tests/Rector/FuncCall/DowngradeArrayMergeCallWithoutArgumentsRector/Fixture/skip_variable.php.inc
+++ b/rules/downgrade-php74/tests/Rector/FuncCall/DowngradeArrayMergeCallWithoutArgumentsRector/Fixture/skip_variable.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\DowngradePhp74\Tests\Rector\FuncCall\DowngradeArrayMergeCallWithoutArgumentsRector\Fixture;
+
+class SkipVariableClass
+{
+    public function run()
+    {
+        $array = [];
+        // Variable: do no change
+        array_merge($array);
+        array_merge_recursive($array);
+    }
+}
+
+?>

--- a/src/ValueObject/PhpVersionFeature.php
+++ b/src/ValueObject/PhpVersionFeature.php
@@ -226,4 +226,9 @@ final class PhpVersionFeature
      * @var string
      */
     public const IS_ITERABLE = '7.1';
+
+    /**
+     * @var string
+     */
+    public const BEFORE_ARRAY_MERGE_WITHOUT_ARGUMENTS = '7.3';
 }


### PR DESCRIPTION
Although most use cases will be covered by the array spread Rector, this will cover the rare cases where there might be an `array_merge()` or `array_merge_recursive()` without any arguments.

Solves #4377