### PR TITLE
Infer var type annotation only if none exists

### DIFF
--- a/rules/downgrade-php74/src/Rector/Property/AbstractDowngradeTypedPropertyRector.php
+++ b/rules/downgrade-php74/src/Rector/Property/AbstractDowngradeTypedPropertyRector.php
@@ -41,8 +41,10 @@ abstract class AbstractDowngradeTypedPropertyRector extends AbstractDowngradeRec
                 $phpDocInfo = $this->phpDocInfoFactory->createEmpty($node);
             }
 
-            $newType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($node->type);
-            $phpDocInfo->changeVarType($newType);
+            if ($phpDocInfo->getVarTagValue() === null) {
+                $newType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($node->type);
+                $phpDocInfo->changeVarType($newType);
+            }
         }
         $node->type = null;
 

--- a/rules/downgrade-php74/src/Rector/Property/AbstractDowngradeTypedPropertyRector.php
+++ b/rules/downgrade-php74/src/Rector/Property/AbstractDowngradeTypedPropertyRector.php
@@ -41,7 +41,7 @@ abstract class AbstractDowngradeTypedPropertyRector extends AbstractDowngradeRec
                 $phpDocInfo = $this->phpDocInfoFactory->createEmpty($node);
             }
 
-            if ($phpDocInfo->getVarTagValue() === null) {
+            if ($phpDocInfo->getVarTagValueNode() === null) {
                 $newType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($node->type);
                 $phpDocInfo->changeVarType($newType);
             }

--- a/rules/downgrade-php74/tests/Rector/Property/DowngradeTypedPropertyRector/Fixture/docblock_exists.php.inc
+++ b/rules/downgrade-php74/tests/Rector/Property/DowngradeTypedPropertyRector/Fixture/docblock_exists.php.inc
@@ -7,30 +7,6 @@ class DocBlockExists {
      * This property is the best one
      */
     private ?string $property;
-
-    /**
-     * This property is also fine
-     * @var string[]
-     */
-    private array $arrayProperty;
-
-    /**
-     * This property is the worst
-     * @var int
-     */
-    private float $wronglyAnnotatedProperty;
-
-    /**
-     * This property allows less than the annotation suggests
-     * @var int|null
-     */
-    private int $widerAnnotatedProperty;
-
-    /**
-     * This property allows more than the annotation suggests
-     * @var int
-     */
-    private ?int $stricterAnnotatedProperty;
 }
 
 ?>
@@ -45,30 +21,6 @@ class DocBlockExists {
      * @var string|null
      */
     private $property;
-
-    /**
-     * This property is also fine
-     * @var string[]
-     */
-    private $arrayProperty;
-
-    /**
-     * This property is the worst
-     * @var int
-     */
-    private $wronglyAnnotatedProperty;
-
-    /**
-     * This property allows less than the annotation suggests
-     * @var int|null
-     */
-    private $widerAnnotatedProperty;
-
-    /**
-     * This property allows more than the annotation suggests
-     * @var int
-     */
-    private $stricterAnnotatedProperty;
 }
 
 ?>

--- a/rules/downgrade-php74/tests/Rector/Property/DowngradeTypedPropertyRector/Fixture/docblock_exists.php.inc
+++ b/rules/downgrade-php74/tests/Rector/Property/DowngradeTypedPropertyRector/Fixture/docblock_exists.php.inc
@@ -7,6 +7,30 @@ class DocBlockExists {
      * This property is the best one
      */
     private ?string $property;
+
+    /**
+     * This property is also fine
+     * @var string[]
+     */
+    private array $arrayProperty;
+
+    /**
+     * This property is the worst
+     * @var int
+     */
+    private float $wronglyAnnotatedProperty;
+
+    /**
+     * This property allows less than the annotation suggests
+     * @var int|null
+     */
+    private int $widerAnnotatedProperty;
+
+    /**
+     * This property allows more than the annotation suggests
+     * @var int
+     */
+    private ?int $stricterAnnotatedProperty;
 }
 
 ?>
@@ -21,6 +45,30 @@ class DocBlockExists {
      * @var string|null
      */
     private $property;
+
+    /**
+     * This property is also fine
+     * @var string[]
+     */
+    private $arrayProperty;
+
+    /**
+     * This property is the worst
+     * @var int
+     */
+    private $wronglyAnnotatedProperty;
+
+    /**
+     * This property allows less than the annotation suggests
+     * @var int|null
+     */
+    private $widerAnnotatedProperty;
+
+    /**
+     * This property allows more than the annotation suggests
+     * @var int
+     */
+    private $stricterAnnotatedProperty;
 }
 
 ?>

--- a/rules/downgrade-php74/tests/Rector/Property/DowngradeTypedPropertyRector/Fixture/docblock_with_var_type.php.inc
+++ b/rules/downgrade-php74/tests/Rector/Property/DowngradeTypedPropertyRector/Fixture/docblock_with_var_type.php.inc
@@ -1,0 +1,87 @@
+<?php
+
+namespace Rector\DowngradePhp74\Tests\Rector\Property\DowngradeTypedPropertyRector\Fixture;
+
+class DocBlockWithVarType {
+    /**
+     * This property is amazing
+     * @var string[]
+     */
+    private array $arrayProperty;
+
+    /**
+     * This property is more than amazing
+     * @var array<string, string>
+     */
+    private array $associativeArrayProperty;
+
+    /**
+     * This property is misleading
+     * @var int
+     */
+    private float $misleadinglyAnnotatedProperty;
+
+    /**
+     * This property is the worst
+     * @var string
+     */
+    private bool $wronglyAnnotatedProperty;
+
+    /**
+     * This property allows less than the annotation suggests
+     * @var int|null
+     */
+    private int $widerAnnotatedProperty;
+
+    /**
+     * This property allows more than the annotation suggests
+     * @var int
+     */
+    private ?int $stricterAnnotatedProperty;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\DowngradePhp74\Tests\Rector\Property\DowngradeTypedPropertyRector\Fixture;
+
+class DocBlockWithVarType {
+    /**
+     * This property is amazing
+     * @var string[]
+     */
+    private $arrayProperty;
+
+    /**
+     * This property is more than amazing
+     * @var array<string, string>
+     */
+    private $associativeArrayProperty;
+
+    /**
+     * This property is misleading
+     * @var int
+     */
+    private $misleadinglyAnnotatedProperty;
+
+    /**
+     * This property is the worst
+     * @var string
+     */
+    private $wronglyAnnotatedProperty;
+
+    /**
+     * This property allows less than the annotation suggests
+     * @var int|null
+     */
+    private $widerAnnotatedProperty;
+
+    /**
+     * This property allows more than the annotation suggests
+     * @var int
+     */
+    private $stricterAnnotatedProperty;
+}
+
+?>


### PR DESCRIPTION
solves #4396 

Caveat: It keeps *all* var type annotations, even if they conflict with the "real" type.