### PR TITLE
Check for property fetch type in DoctrineCollectionDoctype rector

### DIFF
--- a/rules/doctrine-code-quality/src/Rector/Property/ImproveDoctrineCollectionDocTypeInEntityRector.php
+++ b/rules/doctrine-code-quality/src/Rector/Property/ImproveDoctrineCollectionDocTypeInEntityRector.php
@@ -208,6 +208,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if (! $propertyFetches[0] instanceof PropertyFetch) {
+            return null;
+        }
+
         $property = $this->matchPropertyFetchToClassProperty($propertyFetches[0]);
         if ($property === null) {
             return null;

--- a/rules/doctrine-code-quality/tests/Rector/Property/ImproveDoctrineCollectionDocTypeInEntityRector/Fixture/var_static.php.inc
+++ b/rules/doctrine-code-quality/tests/Rector/Property/ImproveDoctrineCollectionDocTypeInEntityRector/Fixture/var_static.php.inc
@@ -1,0 +1,73 @@
+<?php
+
+namespace Rector\DoctrineCodeQuality\Tests\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Fixture;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Rector\DoctrineCodeQuality\Tests\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Source\Training;
+
+/**
+ * @ORM\Entity
+ */
+class VarStatic
+{
+    /**
+     * @ORM\OneToMany(targetEntity=Training::class, mappedBy="trainer")
+     * @var Collection|Training[]
+     */
+    private $trainings = [];
+
+    /**
+     * @var string
+     */
+    private static $value = '';
+
+    public static function getValue()
+    {
+        return self::$value;
+    }
+
+    public static function setValue(string $value)
+    {
+        self::$value = $value;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\DoctrineCodeQuality\Tests\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Fixture;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Rector\DoctrineCodeQuality\Tests\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Source\Training;
+
+/**
+ * @ORM\Entity
+ */
+class VarStatic
+{
+    /**
+     * @ORM\OneToMany(targetEntity=Training::class, mappedBy="trainer")
+     * @var \Rector\DoctrineCodeQuality\Tests\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Source\Training[]|\Doctrine\Common\Collections\Collection<int, \Rector\DoctrineCodeQuality\Tests\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector\Source\Training>
+     */
+    private $trainings = [];
+
+    /**
+     * @var string
+     */
+    private static $value = '';
+
+    public static function getValue()
+    {
+        return self::$value;
+    }
+
+    public static function setValue(string $value)
+    {
+        self::$value = $value;
+    }
+}
+
+?>


### PR DESCRIPTION
If you have any static methods in a Doctrine entity, the `doctrine-code-quality` rector currently fails with the following error:

```
TypeError: Argument 1 passed to Rector\DoctrineCodeQuality\Rector\Property\ImproveDoctrineCollectionDocTypeInEntityRector::matchPropertyFetchToClassProperty() must be an instance of PhpParser\Node\Expr\PropertyFetch, instance of PhpParser\Node\Expr\StaticPropertyFetch given
```

This PR adds a check to skip if a node is not an instance of `PropertyFetch`