### PR TITLE
Map iterable in ScalarStringToTypeMapper

### DIFF
--- a/packages/node-type-resolver/tests/StaticTypeMapper/StaticTypeMapperTest.php
+++ b/packages/node-type-resolver/tests/StaticTypeMapper/StaticTypeMapperTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Rector\NodeTypeResolver\Tests\StaticTypeMapper;
 
 use Iterator;
+use PhpParser\Node;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
@@ -73,5 +75,19 @@ final class StaticTypeMapperTest extends AbstractKernelTestCase
 
         $phpStanDocTypeNode = $this->staticTypeMapper->mapPHPStanTypeToPHPStanPhpDocTypeNode($mixedType);
         $this->assertInstanceOf(IdentifierTypeNode::class, $phpStanDocTypeNode);
+    }
+
+    /**
+     * @dataProvider provideDataForMapPhpParserNodePHPStanType()
+     */
+    public function testMapPhpParserNodePHPStanType(Node $node, string $expectedType): void
+    {
+        $phpStanType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($node);
+        $this->assertInstanceOf($expectedType, $phpStanType);
+    }
+
+    public function provideDataForMapPhpParserNodePHPStanType(): Iterator
+    {
+        yield [new Identifier('iterable'), IterableType::class];
     }
 }

--- a/packages/static-type-mapper/src/Mapper/ScalarStringToTypeMapper.php
+++ b/packages/static-type-mapper/src/Mapper/ScalarStringToTypeMapper.php
@@ -10,6 +10,7 @@ use PHPStan\Type\BooleanType;
 use PHPStan\Type\CallableType;
 use PHPStan\Type\FloatType;
 use PHPStan\Type\IntegerType;
+use PHPStan\Type\IterableType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectWithoutClassType;
@@ -49,6 +50,10 @@ final class ScalarStringToTypeMapper
 
         if ($loweredScalarName === 'array') {
             return new ArrayType(new MixedType(), new MixedType());
+        }
+
+        if ($loweredScalarName === 'iterable') {
+            return new IterableType(new MixedType(), new MixedType());
         }
 
         if ($loweredScalarName === 'mixed') {


### PR DESCRIPTION
`iterable` return types were mapped to implicit `MixedType`s before. Now they will be handled like `array`, but with the corresponding `IterableType`.