### PR TITLE
Return also explicitly mixed types in IdentifierTypeMapper

### DIFF
--- a/packages/node-type-resolver/tests/StaticTypeMapper/StaticTypeMapperTest.php
+++ b/packages/node-type-resolver/tests/StaticTypeMapper/StaticTypeMapperTest.php
@@ -54,6 +54,8 @@ final class StaticTypeMapperTest extends AbstractKernelTestCase
         ]);
 
         yield [$genericTypeNode, IterableType::class];
+
+        yield [new IdentifierTypeNode('mixed'), MixedType::class];
     }
 
     public function testMapPHPStanTypeToPHPStanPhpDocTypeNode(): void

--- a/packages/static-type-mapper/src/PhpDocParser/IdentifierTypeMapper.php
+++ b/packages/static-type-mapper/src/PhpDocParser/IdentifierTypeMapper.php
@@ -53,7 +53,7 @@ final class IdentifierTypeMapper implements PhpDocTypeMapperInterface
     public function mapToPHPStanType(TypeNode $typeNode, Node $node, NameScope $nameScope): Type
     {
         $type = $this->scalarStringToTypeMapper->mapScalarStringToType($typeNode->name);
-        if (! $type instanceof MixedType) {
+        if (! $type instanceof MixedType || $type->isExplicitMixed()) {
             return $type;
         }
 


### PR DESCRIPTION
For explicit `MixedType`s it was trying to resolve a type but ultimately fail and return an implicit `MixedType`.