### PR TITLE
RemoveDoubleUnderscoreInMethodNameRector: Only match names starting with double underscores.

### DIFF
--- a/rules/coding-style/src/Rector/ClassMethod/RemoveDoubleUnderscoreInMethodNameRector.php
+++ b/rules/coding-style/src/Rector/ClassMethod/RemoveDoubleUnderscoreInMethodNameRector.php
@@ -25,7 +25,7 @@ final class RemoveDoubleUnderscoreInMethodNameRector extends AbstractRector
     /**
      * @var string
      */
-    private const DOUBLE_UNDERSCORE_START_REGEX = '#__(.*?)#';
+    private const DOUBLE_UNDERSCORE_START_REGEX = '#^__(.*?)#';
 
     public function getDefinition(): RectorDefinition
     {


### PR DESCRIPTION
The current implementation wrongly matches `mybadlynamed__method()` and cuts off 2 chars in the front `badlynamed__method()`.

This PR fixes that.

Actually even `'#^__#'` should do it. The captured group is never read as it seems.