### PR TITLE
[Nette] Add RemoveParentAndNameFromComponentConstructorRector

### DIFF
--- a/config/set/nette-30.php
+++ b/config/set/nette-30.php
@@ -7,7 +7,7 @@ use Rector\Generic\Rector\ClassMethod\ArgumentDefaultValueReplacerRector;
 use Rector\Generic\Rector\MethodCall\FormerNullableArgumentToScalarTypedRector;
 use Rector\Generic\ValueObject\ArgumentDefaultValueReplacer;
 use Rector\Nette\Rector\ClassMethod\RemoveParentAndNameFromComponentConstructorRector;
-use Rector\Nette\Rector\MethodCall\AddDatePickerToDateControlRector;
+use Rector\Nette\Rector\MethodCall\AddNextrasDatePickerToDateControlRector;
 use Rector\Nette\Rector\MethodCall\GetConfigWithDefaultsArgumentToArrayMergeInCompilerExtensionRector;
 use Rector\Nette\Rector\MethodCall\MagicHtmlCallToAppendAttributeRector;
 use Rector\Nette\Rector\MethodCall\RequestGetCookieDefaultArgumentToCoalesceRector;
@@ -27,7 +27,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->import(__DIR__ . '/nette-30-return-types.php');
     $containerConfigurator->import(__DIR__ . '/nette-30-param-types.php');
     $services = $containerConfigurator->services();
-    $services->set(AddDatePickerToDateControlRector::class);
+    $services->set(AddNextrasDatePickerToDateControlRector::class);
     $services->set(ChangeFormArrayAccessToAnnotatedControlVariableRector::class);
     $services->set(GetConfigWithDefaultsArgumentToArrayMergeInCompilerExtensionRector::class);
     // Control class has remove __construct(), e.g. https://github.com/Pixidos/GPWebPay/pull/16/files#diff-fdc8251950f85c5467c63c249df05786

--- a/config/set/nette-30.php
+++ b/config/set/nette-30.php
@@ -6,6 +6,7 @@ use Rector\DeadCode\Rector\StaticCall\RemoveParentCallWithoutParentRector;
 use Rector\Generic\Rector\ClassMethod\ArgumentDefaultValueReplacerRector;
 use Rector\Generic\Rector\MethodCall\FormerNullableArgumentToScalarTypedRector;
 use Rector\Generic\ValueObject\ArgumentDefaultValueReplacer;
+use Rector\Nette\Rector\ClassMethod\RemoveParentAndNameFromComponentConstructorRector;
 use Rector\Nette\Rector\MethodCall\AddDatePickerToDateControlRector;
 use Rector\Nette\Rector\MethodCall\GetConfigWithDefaultsArgumentToArrayMergeInCompilerExtensionRector;
 use Rector\Nette\Rector\MethodCall\MagicHtmlCallToAppendAttributeRector;
@@ -25,84 +26,78 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->import(__DIR__ . '/nette-30-dependency-injection.php');
     $containerConfigurator->import(__DIR__ . '/nette-30-return-types.php');
     $containerConfigurator->import(__DIR__ . '/nette-30-param-types.php');
-
     $services = $containerConfigurator->services();
     $services->set(AddDatePickerToDateControlRector::class);
     $services->set(ChangeFormArrayAccessToAnnotatedControlVariableRector::class);
     $services->set(GetConfigWithDefaultsArgumentToArrayMergeInCompilerExtensionRector::class);
-
     // Control class has remove __construct(), e.g. https://github.com/Pixidos/GPWebPay/pull/16/files#diff-fdc8251950f85c5467c63c249df05786
     $services->set(RemoveParentCallWithoutParentRector::class);
     // https://github.com/nette/utils/commit/d0041ba59f5d8bf1f5b3795fd76d43fb13ea2e15
-
     $services->set(FormerNullableArgumentToScalarTypedRector::class);
+    $services->set(StaticCallToMethodCallRector::class)->call('configure', [[
+        StaticCallToMethodCallRector::STATIC_CALLS_TO_METHOD_CALLS => inline_value_objects([
 
-    $services->set(StaticCallToMethodCallRector::class)
-        ->call('configure', [[
-            StaticCallToMethodCallRector::STATIC_CALLS_TO_METHOD_CALLS => inline_value_objects([
-                new StaticCallToMethodCall('Nette\Security\Passwords', 'hash', 'Nette\Security\Passwords', 'hash'),
-                new StaticCallToMethodCall('Nette\Security\Passwords', 'verify', 'Nette\Security\Passwords', 'verify'),
-                new StaticCallToMethodCall(
+            new StaticCallToMethodCall('Nette\Security\Passwords', 'hash', 'Nette\Security\Passwords', 'hash'),
+            new StaticCallToMethodCall('Nette\Security\Passwords', 'verify', 'Nette\Security\Passwords', 'verify'),
+            new StaticCallToMethodCall(
                 'Nette\Security\Passwords',
                 'needsRehash',
                 'Nette\Security\Passwords',
                 'needsRehash'
-                ), ]
             ),
-        ]]);
+
+        ]),
+    ]]);
     // https://github.com/contributte/event-dispatcher-extra/tree/v0.4.3 and higher
-    $services->set(RenameClassConstantRector::class)
-        ->call('configure', [[
-            RenameClassConstantRector::CLASS_CONSTANT_RENAME => inline_value_objects([
-                new RenameClassConstant('Contributte\Events\Extra\Event\Security\LoggedInEvent', 'NAME', 'class'),
-                new RenameClassConstant('Contributte\Events\Extra\Event\Security\LoggedOutEvent', 'NAME', 'class'),
-                new RenameClassConstant('Contributte\Events\Extra\Event\Application\ShutdownEvent', 'NAME', 'class'), ]
+    $services->set(RenameClassConstantRector::class)->call('configure', [[
+        RenameClassConstantRector::CLASS_CONSTANT_RENAME => inline_value_objects([
+
+            new RenameClassConstant('Contributte\Events\Extra\Event\Security\LoggedInEvent', 'NAME', 'class'),
+            new RenameClassConstant('Contributte\Events\Extra\Event\Security\LoggedOutEvent', 'NAME', 'class'),
+            new RenameClassConstant('Contributte\Events\Extra\Event\Application\ShutdownEvent', 'NAME', 'class'),
+
+        ]),
+    ]]);
+    $services->set(RenameClassRector::class)->call('configure', [[
+        RenameClassRector::OLD_TO_NEW_CLASSES => [
+            # nextras/forms was split into 2 packages
+            'Nextras\FormComponents\Controls\DatePicker' => 'Nextras\FormComponents\Controls\DateControl',
+            # @see https://github.com/nette/di/commit/a0d361192f8ac35f1d9f82aab7eb351e4be395ea
+            'Nette\DI\ServiceDefinition' => 'Nette\DI\Definitions\ServiceDefinition',
+            'Nette\DI\Statement' => 'Nette\DI\Definitions\Statement',
+        ],
+    ]]);
+    $services->set(ArgumentDefaultValueReplacerRector::class)->call('configure', [[
+        ArgumentDefaultValueReplacerRector::REPLACED_ARGUMENTS => inline_value_objects([
+            // json 2nd argument is now `int` typed
+            new ArgumentDefaultValueReplacer(
+                'Nette\Utils\Json',
+                'decode',
+                1,
+                true,
+                'Nette\Utils\Json::FORCE_ARRAY'
             ),
-        ]]);
-    $services->set(RenameClassRector::class)
-        ->call('configure', [[
-            RenameClassRector::OLD_TO_NEW_CLASSES => [
-                # nextras/forms was split into 2 packages
-                'Nextras\FormComponents\Controls\DatePicker' => 'Nextras\FormComponents\Controls\DateControl',
-                # @see https://github.com/nette/di/commit/a0d361192f8ac35f1d9f82aab7eb351e4be395ea
-                'Nette\DI\ServiceDefinition' => 'Nette\DI\Definitions\ServiceDefinition',
-                'Nette\DI\Statement' => 'Nette\DI\Definitions\Statement',
-            ],
-        ]]);
-    $services->set(ArgumentDefaultValueReplacerRector::class)
-        ->call('configure', [[
-            ArgumentDefaultValueReplacerRector::REPLACED_ARGUMENTS => inline_value_objects([
-                // json 2nd argument is now `int` typed
-                new ArgumentDefaultValueReplacer(
-                    'Nette\Utils\Json',
-                    'decode',
-                    1,
-                    true,
-                    'Nette\Utils\Json::FORCE_ARRAY'
-                ),
-
-                // @see https://github.com/nette/forms/commit/574b97f9d5e7a902a224e57d7d584e7afc9fefec
-                new ArgumentDefaultValueReplacer('Nette\Forms\Form', 'decode', 0, true, 'array'),
-            ]),
-        ]]);
-
-    $services->set(RenameMethodRector::class)
-        ->call('configure', [[
-            RenameMethodRector::METHOD_CALL_RENAMES => inline_value_objects([
-                new MethodCallRename('Nette\Forms\Controls\BaseControl', 'setAttribute', 'setHtmlAttribute'),
-                // see https://github.com/nette/forms/commit/b99385aa9d24d729a18f6397a414ea88eab6895a
-                new MethodCallRename('Nette\Forms\Controls\BaseControl', 'setType', 'setHtmlType'),
-                new MethodCallRename('Nette\Forms\Controls\BaseControl', 'setAttribute', 'setHtmlAttribute'),
-                new MethodCallRename(
-                    'Nette\DI\Definitions\ServiceDefinition',
-                    # see https://github.com/nette/di/commit/1705a5db431423fc610a6f339f88dead1b5dc4fb
-                    'setClass',
-                    'setType'
-                ),
-                new MethodCallRename('Nette\DI\Definitions\ServiceDefinition', 'getClass', 'getType'),
-                new MethodCallRename('Nette\DI\Definitions\Definition', 'isAutowired', 'getAutowired'), ]),
-        ]]);
-
+            // @see https://github.com/nette/forms/commit/574b97f9d5e7a902a224e57d7d584e7afc9fefec
+            new ArgumentDefaultValueReplacer('Nette\Forms\Form', 'decode', 0, true, 'array'),
+        ]),
+    ]]);
+    $services->set(RenameMethodRector::class)->call('configure', [[
+        RenameMethodRector::METHOD_CALL_RENAMES => inline_value_objects([
+            new MethodCallRename('Nette\Forms\Controls\BaseControl', 'setAttribute', 'setHtmlAttribute'),
+            // see https://github.com/nette/forms/commit/b99385aa9d24d729a18f6397a414ea88eab6895a
+            new MethodCallRename('Nette\Forms\Controls\BaseControl', 'setType', 'setHtmlType'),
+            new MethodCallRename('Nette\Forms\Controls\BaseControl', 'setAttribute', 'setHtmlAttribute'),
+            new MethodCallRename(
+                'Nette\DI\Definitions\ServiceDefinition',
+                # see https://github.com/nette/di/commit/1705a5db431423fc610a6f339f88dead1b5dc4fb
+                'setClass',
+                'setType'
+            ),
+            new MethodCallRename('Nette\DI\Definitions\ServiceDefinition', 'getClass', 'getType'),
+            new MethodCallRename('Nette\DI\Definitions\Definition', 'isAutowired', 'getAutowired'),
+        ]),
+    ]]);
     $services->set(MagicHtmlCallToAppendAttributeRector::class);
     $services->set(RequestGetCookieDefaultArgumentToCoalesceRector::class);
+    $services->set(RemoveParentAndNameFromComponentConstructorRector::class);
 };

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,4 @@
-# All 598 Rectors Overview
+# All 599 Rectors Overview
 
 - [Projects](#projects)
 ---
@@ -31,7 +31,7 @@
 - [MockistaToMockery](#mockistatomockery) (2)
 - [MysqlToMysqli](#mysqltomysqli) (4)
 - [Naming](#naming) (11)
-- [Nette](#nette) (17)
+- [Nette](#nette) (18)
 - [NetteCodeQuality](#nettecodequality) (6)
 - [NetteKdyby](#nettekdyby) (4)
 - [NetteTesterToPHPUnit](#nettetestertophpunit) (3)
@@ -8085,6 +8085,29 @@ Use `Nette\Utils\Strings` over bare `preg_match()` and `preg_match_all()` functi
          $content = 'Hi my name is Tom';
 -        preg_match('#Hi#', $content, $matches);
 +        $matches = Strings::match($content, '#Hi#');
+     }
+ }
+```
+
+<br><br>
+
+### `RemoveParentAndNameFromComponentConstructorRector`
+
+- class: [`Rector\Nette\Rector\ClassMethod\RemoveParentAndNameFromComponentConstructorRector`](/rules/nette/src/Rector/ClassMethod/RemoveParentAndNameFromComponentConstructorRector.php)
+- [test fixtures](/rules/nette/tests/Rector/ClassMethod/RemoveParentAndNameFromComponentConstructorRector/Fixture)
+
+Remove `$parent` and `$name` in control constructor
+
+```diff
+ use Nette\Application\UI\Control;
+
+ class SomeControl extends Control
+ {
+-    public function __construct(IContainer $parent = null, $name = null, int $value)
++    public function __construct(int $value)
+     {
+-        parent::__construct($parent, $name);
+         $this->value = $value;
      }
  }
 ```

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -7838,10 +7838,10 @@ Change under_score names to camelCase
 
 ## Nette
 
-### `AddDatePickerToDateControlRector`
+### `AddNextrasDatePickerToDateControlRector`
 
-- class: [`Rector\Nette\Rector\MethodCall\AddDatePickerToDateControlRector`](/rules/nette/src/Rector/MethodCall/AddDatePickerToDateControlRector.php)
-- [test fixtures](/rules/nette/tests/Rector/MethodCall/AddDatePickerToDateControlRector/Fixture)
+- class: [`Rector\Nette\Rector\MethodCall\AddNextrasDatePickerToDateControlRector`](/rules/nette/src/Rector/MethodCall/AddNextrasDatePickerToDateControlRector.php)
+- [test fixtures](/rules/nette/tests/Rector/MethodCall/AddNextrasDatePickerToDateControlRector/Fixture)
 
 Nextras/Form upgrade of addDatePicker method call to DateControl assign
 

--- a/rules/doctrine/src/Rector/ClassMethod/ServiceEntityRepositoryConstructorToDependencyInjectionWithRepositoryPropertyRector.php
+++ b/rules/doctrine/src/Rector/ClassMethod/ServiceEntityRepositoryConstructorToDependencyInjectionWithRepositoryPropertyRector.php
@@ -114,7 +114,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        if ($this->shouldSkip($node)) {
+        if ($this->shouldSkipClassMethod($node)) {
             return null;
         }
 
@@ -142,7 +142,7 @@ CODE_SAMPLE
         return $node;
     }
 
-    private function shouldSkip(ClassMethod $classMethod): bool
+    private function shouldSkipClassMethod(ClassMethod $classMethod): bool
     {
         /** @var string|null $parentClassName */
         $parentClassName = $classMethod->getAttribute(AttributeKey::PARENT_CLASS_NAME);

--- a/rules/nette/src/NodeAnalyzer/StaticCallAnalyzer.php
+++ b/rules/nette/src/NodeAnalyzer/StaticCallAnalyzer.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace Rector\Nette\NodeAnalyzer;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\StaticCall;
+use Rector\NodeNameResolver\NodeNameResolver;
+
+final class StaticCallAnalyzer
+{
+    /**
+     * @var NodeNameResolver
+     */
+    private $nodeNameResolver;
+
+    public function __construct(NodeNameResolver $nodeNameResolver)
+    {
+        $this->nodeNameResolver = $nodeNameResolver;
+    }
+
+    public function isParentCallNamed(StaticCall $staticCall, string $desiredMethodName): bool
+    {
+        if ($staticCall->class instanceof Expr) {
+            return false;
+        }
+
+        if (! $this->nodeNameResolver->isName($staticCall->class, 'parent')) {
+            return false;
+        }
+
+        if ($staticCall->name instanceof Expr) {
+            return false;
+        }
+
+        return $this->nodeNameResolver->isName($staticCall->name, $desiredMethodName);
+    }
+}

--- a/rules/nette/src/Rector/ClassMethod/RemoveParentAndNameFromComponentConstructorRector.php
+++ b/rules/nette/src/Rector/ClassMethod/RemoveParentAndNameFromComponentConstructorRector.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Nette\Rector\ClassMethod;
+
+use Nette\Application\UI\Control;
+use PhpParser\Node;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Stmt\ClassMethod;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\RectorDefinition\CodeSample;
+use Rector\Core\RectorDefinition\RectorDefinition;
+use Rector\Core\ValueObject\MethodName;
+
+/**
+ * @see https://github.com/nette/component-model/commit/1fb769f4602cf82694941530bac1111b3c5cd11b
+ *
+ * @see \Rector\Nette\Tests\Rector\ClassMethod\RemoveParentAndNameFromComponentConstructorRector\RemoveParentAndNameFromComponentConstructorRectorTest
+ */
+final class RemoveParentAndNameFromComponentConstructorRector extends AbstractRector
+{
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Remove $parent and $name in control constructor', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+use Nette\Application\UI\Control;
+
+class SomeControl extends Control
+{
+    public function __construct(IContainer $parent = null, $name = null, int $value)
+    {
+        parent::__construct($parent, $name);
+        $this->value = $value;
+    }
+}
+CODE_SAMPLE
+
+                ,
+                <<<'CODE_SAMPLE'
+use Nette\Application\UI\Control;
+
+class SomeControl extends Control
+{
+    public function __construct(int $value)
+    {
+        $this->value = $value;
+    }
+}
+CODE_SAMPLE
+
+            ),
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class, StaticCall::class, New_::class];
+    }
+
+    /**
+     * @param ClassMethod|StaticCall|New_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($node instanceof ClassMethod) {
+            if (! $this->isInObjectType($node, Control::class)) {
+                return null;
+            }
+
+            if (! $this->isName($node, MethodName::CONSTRUCT)) {
+                return null;
+            }
+
+//            if ((array) $node->params === []) {
+//                return null;
+//            }
+
+            foreach ((array) $node->params as $param) {
+                if ($this->isObjectType($param, 'Nette\ComponentModel\IContainer')) {
+                    $this->removeNode($param);
+                }
+            }
+        }
+        // change the node
+
+        return $node;
+    }
+}

--- a/rules/nette/src/Rector/MethodCall/AddNextrasDatePickerToDateControlRector.php
+++ b/rules/nette/src/Rector/MethodCall/AddNextrasDatePickerToDateControlRector.php
@@ -21,9 +21,9 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
 /**
  * @sponsor Thanks https://amateri.com for sponsoring this rule - visit them on https://www.startupjobs.cz/startup/scrumworks-s-r-o
  *
- * @see \Rector\Nette\Tests\Rector\MethodCall\AddDatePickerToDateControlRector\AddDatePickerToDateControlRectorTest
+ * @see \Rector\Nette\Tests\Rector\MethodCall\AddNextrasDatePickerToDateControlRector\AddNextrasDatePickerToDateControlRectorTest
  */
-final class AddDatePickerToDateControlRector extends AbstractRector
+final class AddNextrasDatePickerToDateControlRector extends AbstractRector
 {
     public function getDefinition(): RectorDefinition
     {

--- a/rules/nette/tests/Rector/ClassMethod/RemoveParentAndNameFromComponentConstructorRector/Fixture/back_order.php.inc
+++ b/rules/nette/tests/Rector/ClassMethod/RemoveParentAndNameFromComponentConstructorRector/Fixture/back_order.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Nette\Tests\Rector\ClassMethod\RemoveParentAndNameFromComponentConstructorRector\Fixture;
+
+use Nette\Application\UI\Control;
+use Nette\ComponentModel\IContainer;
+
+class BackOrderControl extends Control
+{
+    public function __construct($name = null, int $value, IContainer $parent = null)
+    {
+        parent::__construct($parent, $name, $value);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Nette\Tests\Rector\ClassMethod\RemoveParentAndNameFromComponentConstructorRector\Fixture;
+
+use Nette\Application\UI\Control;
+use Nette\ComponentModel\IContainer;
+
+class BackOrderControl extends Control
+{
+    public function __construct(int $value)
+    {
+        parent::__construct($value);
+    }
+}
+
+?>

--- a/rules/nette/tests/Rector/ClassMethod/RemoveParentAndNameFromComponentConstructorRector/Fixture/fixture.php.inc
+++ b/rules/nette/tests/Rector/ClassMethod/RemoveParentAndNameFromComponentConstructorRector/Fixture/fixture.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Nette\Tests\Rector\ClassMethod\RemoveParentAndNameFromComponentConstructorRector\Fixture;
+
+use Nette\Application\UI\Control;
+
+class SomeControl extends Control
+{
+    public function __construct(IContainer $parent = null, $name = null, int $value)
+    {
+        parent::__construct($parent, $name);
+        $this->value = $value;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Nette\Tests\Rector\ClassMethod\RemoveParentAndNameFromComponentConstructorRector\Fixture;
+
+use Nette\Application\UI\Control;
+
+class SomeControl extends Control
+{
+    public function __construct(int $value)
+    {
+        $this->value = $value;
+    }
+}
+
+?>

--- a/rules/nette/tests/Rector/ClassMethod/RemoveParentAndNameFromComponentConstructorRector/Fixture/fixture.php.inc
+++ b/rules/nette/tests/Rector/ClassMethod/RemoveParentAndNameFromComponentConstructorRector/Fixture/fixture.php.inc
@@ -3,6 +3,7 @@
 namespace Rector\Nette\Tests\Rector\ClassMethod\RemoveParentAndNameFromComponentConstructorRector\Fixture;
 
 use Nette\Application\UI\Control;
+use Nette\ComponentModel\IContainer;
 
 class SomeControl extends Control
 {
@@ -20,6 +21,7 @@ class SomeControl extends Control
 namespace Rector\Nette\Tests\Rector\ClassMethod\RemoveParentAndNameFromComponentConstructorRector\Fixture;
 
 use Nette\Application\UI\Control;
+use Nette\ComponentModel\IContainer;
 
 class SomeControl extends Control
 {

--- a/rules/nette/tests/Rector/ClassMethod/RemoveParentAndNameFromComponentConstructorRector/Fixture/new_instance.php.inc
+++ b/rules/nette/tests/Rector/ClassMethod/RemoveParentAndNameFromComponentConstructorRector/Fixture/new_instance.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Nette\Tests\Rector\ClassMethod\RemoveParentAndNameFromComponentConstructorRector\Fixture;
+
+use Rector\Nette\Tests\Rector\ClassMethod\RemoveParentAndNameFromComponentConstructorRector\Source\SomeControlWithConstructorParentAndName;
+
+final class NewInstance
+{
+    public function run()
+    {
+        $someControlWithConstructorParentAndName = new SomeControlWithConstructorParentAndName(null, 'hey');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Nette\Tests\Rector\ClassMethod\RemoveParentAndNameFromComponentConstructorRector\Fixture;
+
+use Rector\Nette\Tests\Rector\ClassMethod\RemoveParentAndNameFromComponentConstructorRector\Source\SomeControlWithConstructorParentAndName;
+
+final class NewInstance
+{
+    public function run()
+    {
+        $someControlWithConstructorParentAndName = new SomeControlWithConstructorParentAndName();
+    }
+}
+
+?>

--- a/rules/nette/tests/Rector/ClassMethod/RemoveParentAndNameFromComponentConstructorRector/Fixture/skip_another_params_in_new_instance.php.inc
+++ b/rules/nette/tests/Rector/ClassMethod/RemoveParentAndNameFromComponentConstructorRector/Fixture/skip_another_params_in_new_instance.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Nette\Tests\Rector\ClassMethod\RemoveParentAndNameFromComponentConstructorRector\Fixture;
+
+use Rector\Nette\Tests\Rector\ClassMethod\RemoveParentAndNameFromComponentConstructorRector\Source\SomeControlWithoutConstructorParentAndName;
+
+final class SkipAnotherParamInNewInstance
+{
+    public function run()
+    {
+        $someControlWithConstructorParentAndName = new SomeControlWithoutConstructorParentAndName('key', 'value');
+    }
+}

--- a/rules/nette/tests/Rector/ClassMethod/RemoveParentAndNameFromComponentConstructorRector/RemoveParentAndNameFromComponentConstructorRectorTest.php
+++ b/rules/nette/tests/Rector/ClassMethod/RemoveParentAndNameFromComponentConstructorRector/RemoveParentAndNameFromComponentConstructorRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Nette\Tests\Rector\ClassMethod\RemoveParentAndNameFromComponentConstructorRector;
+
+use Iterator;
+use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;
+use Rector\Nette\Rector\ClassMethod\RemoveParentAndNameFromComponentConstructorRector;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class RemoveParentAndNameFromComponentConstructorRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    protected function getRectorClass(): string
+    {
+        return RemoveParentAndNameFromComponentConstructorRector::class;
+    }
+}

--- a/rules/nette/tests/Rector/ClassMethod/RemoveParentAndNameFromComponentConstructorRector/Source/SomeControlWithConstructorParentAndName.php
+++ b/rules/nette/tests/Rector/ClassMethod/RemoveParentAndNameFromComponentConstructorRector/Source/SomeControlWithConstructorParentAndName.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace Rector\Nette\Tests\Rector\ClassMethod\RemoveParentAndNameFromComponentConstructorRector\Source;
+
+use Nette\Application\UI\Control;
+
+final class SomeControlWithConstructorParentAndName extends Control
+{
+    public function __construct($parent = null, $name = '')
+    {
+        $this->parent = $parent;
+        $this->name = $name;
+    }
+}

--- a/rules/nette/tests/Rector/ClassMethod/RemoveParentAndNameFromComponentConstructorRector/Source/SomeControlWithoutConstructorParentAndName.php
+++ b/rules/nette/tests/Rector/ClassMethod/RemoveParentAndNameFromComponentConstructorRector/Source/SomeControlWithoutConstructorParentAndName.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace Rector\Nette\Tests\Rector\ClassMethod\RemoveParentAndNameFromComponentConstructorRector\Source;
+
+use Nette\Application\UI\Control;
+
+final class SomeControlWithoutConstructorParentAndName extends Control
+{
+    private $key;
+    private $value;
+
+    public function __construct($key, $value)
+    {
+        $this->key = $key;
+        $this->value = $value;
+    }
+}

--- a/rules/nette/tests/Rector/MethodCall/AddNextrasDatePickerToDateControlRector/AddNextrasDatePickerToDateControlRectorTest.php
+++ b/rules/nette/tests/Rector/MethodCall/AddNextrasDatePickerToDateControlRector/AddNextrasDatePickerToDateControlRectorTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Rector\Nette\Tests\Rector\MethodCall\AddDatePickerToDateControlRector;
+namespace Rector\Nette\Tests\Rector\MethodCall\AddNextrasDatePickerToDateControlRector;
 
 use Iterator;
 use Rector\Core\Testing\PHPUnit\AbstractRectorTestCase;
-use Rector\Nette\Rector\MethodCall\AddDatePickerToDateControlRector;
+use Rector\Nette\Rector\MethodCall\AddNextrasDatePickerToDateControlRector;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
-final class AddDatePickerToDateControlRectorTest extends AbstractRectorTestCase
+final class AddNextrasDatePickerToDateControlRectorTest extends AbstractRectorTestCase
 {
     /**
      * @dataProvider provideData()
@@ -26,6 +26,6 @@ final class AddDatePickerToDateControlRectorTest extends AbstractRectorTestCase
 
     protected function getRectorClass(): string
     {
-        return AddDatePickerToDateControlRector::class;
+        return AddNextrasDatePickerToDateControlRector::class;
     }
 }

--- a/rules/nette/tests/Rector/MethodCall/AddNextrasDatePickerToDateControlRector/Fixture/add_rule.php.inc
+++ b/rules/nette/tests/Rector/MethodCall/AddNextrasDatePickerToDateControlRector/Fixture/add_rule.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Nette\Tests\Rector\MethodCall\AddDatePickerToDateControlRector\Fixture;
+namespace Rector\Nette\Tests\Rector\MethodCall\AddNextrasDatePickerToDateControlRector\Fixture;
 
 use Nette\Application\UI\Form;
 
@@ -18,7 +18,7 @@ class AddRule
 -----
 <?php
 
-namespace Rector\Nette\Tests\Rector\MethodCall\AddDatePickerToDateControlRector\Fixture;
+namespace Rector\Nette\Tests\Rector\MethodCall\AddNextrasDatePickerToDateControlRector\Fixture;
 
 use Nette\Application\UI\Form;
 

--- a/rules/nette/tests/Rector/MethodCall/AddNextrasDatePickerToDateControlRector/Fixture/add_rule_chaing_calls.php.inc
+++ b/rules/nette/tests/Rector/MethodCall/AddNextrasDatePickerToDateControlRector/Fixture/add_rule_chaing_calls.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Nette\Tests\Rector\MethodCall\AddDatePickerToDateControlRector\Fixture;
+namespace Rector\Nette\Tests\Rector\MethodCall\AddNextrasDatePickerToDateControlRector\Fixture;
 
 use Nette\Application\UI\Form;
 
@@ -19,7 +19,7 @@ class AddRuleChainCalls
 -----
 <?php
 
-namespace Rector\Nette\Tests\Rector\MethodCall\AddDatePickerToDateControlRector\Fixture;
+namespace Rector\Nette\Tests\Rector\MethodCall\AddNextrasDatePickerToDateControlRector\Fixture;
 
 use Nette\Application\UI\Form;
 

--- a/rules/nette/tests/Rector/MethodCall/AddNextrasDatePickerToDateControlRector/Fixture/assigned_value.php.inc
+++ b/rules/nette/tests/Rector/MethodCall/AddNextrasDatePickerToDateControlRector/Fixture/assigned_value.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Nette\Tests\Rector\MethodCall\AddDatePickerToDateControlRector\Fixture;
+namespace Rector\Nette\Tests\Rector\MethodCall\AddNextrasDatePickerToDateControlRector\Fixture;
 
 use Nette\Application\UI\Form;
 
@@ -17,7 +17,7 @@ class AssignedValue
 -----
 <?php
 
-namespace Rector\Nette\Tests\Rector\MethodCall\AddDatePickerToDateControlRector\Fixture;
+namespace Rector\Nette\Tests\Rector\MethodCall\AddNextrasDatePickerToDateControlRector\Fixture;
 
 use Nette\Application\UI\Form;
 

--- a/rules/nette/tests/Rector/MethodCall/AddNextrasDatePickerToDateControlRector/Fixture/fixture.php.inc
+++ b/rules/nette/tests/Rector/MethodCall/AddNextrasDatePickerToDateControlRector/Fixture/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Nette\Tests\Rector\MethodCall\AddDatePickerToDateControlRector\Fixture;
+namespace Rector\Nette\Tests\Rector\MethodCall\AddNextrasDatePickerToDateControlRector\Fixture;
 
 use Nette\Application\UI\Form;
 
@@ -17,7 +17,7 @@ class SomeClass
 -----
 <?php
 
-namespace Rector\Nette\Tests\Rector\MethodCall\AddDatePickerToDateControlRector\Fixture;
+namespace Rector\Nette\Tests\Rector\MethodCall\AddNextrasDatePickerToDateControlRector\Fixture;
 
 use Nette\Application\UI\Form;
 


### PR DESCRIPTION
Covers https://github.com/nette/component-model/commit/1fb769f4602cf82694941530bac1111b3c5cd11b

Resolves https://github.com/TomasVotruba/ttime-rector/pull/3/files#diff-c6024e968462aa9eb1c22095f2c0d8fcb30799b131ac279588f08cb3790a8ceb

<br>

@xpavp03 Hi Petr, here I'll be making rule to remove [the parent + name](https://github.com/TomasVotruba/ttime-rector/pull/3/files#diff-c6024e968462aa9eb1c22095f2c0d8fcb30799b131ac279588f08cb3790a8ceb) in components.

You might find some inspiration here :) 