### PR TITLE
Add a Doctrine DBAL 2.11 Rule Set

### DIFF
--- a/config/set/doctrine-dbal-211.php
+++ b/config/set/doctrine-dbal-211.php
@@ -15,85 +15,25 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->call('configure', [[
             RenameMethodRector::METHOD_CALL_RENAMES => inline_value_objects([
                 // https://github.com/doctrine/dbal/blob/master/UPGRADE.md#deprecations-in-the-wrapper-connection-class
-                new MethodCallRename(
-                    'Doctrine\DBAL\Connection',
-                    'executeUpdate',
-                    'executeStatement'
-                ),
-                new MethodCallRename(
-                    'Doctrine\DBAL\Connection',
-                    'exec',
-                    'executeStatement'
-                ),
-                new MethodCallRename(
-                    'Doctrine\DBAL\Connection',
-                    'query',
-                    'executeQuery'
-                ),
+                new MethodCallRename('Doctrine\DBAL\Connection', 'executeUpdate', 'executeStatement'),
+                new MethodCallRename('Doctrine\DBAL\Connection', 'exec', 'executeStatement'),
+                new MethodCallRename('Doctrine\DBAL\Connection', 'query', 'executeQuery'),
                 // https://github.com/doctrine/dbal/blob/master/UPGRADE.md#driverexceptiongeterrorcode-is-deprecated
-                new MethodCallRename(
-                    'Doctrine\DBAL\Driver\DriverException',
-                    'getErrorCode',
-                    'getSQLState'
-                ),
+                new MethodCallRename('Doctrine\DBAL\Driver\DriverException', 'getErrorCode', 'getSQLState'),
                 // https://github.com/doctrine/dbal/blob/master/UPGRADE.md#deprecated-expressionbuilder-methods
-                new MethodCallRename(
-                    'Doctrine\DBAL\Query\Expression\ExpressionBuilder',
-                    'andX',
-                    'and'
-                ),
-                new MethodCallRename(
-                    'Doctrine\DBAL\Query\Expression\ExpressionBuilder',
-                    'orX',
-                    'or'
-                ),
+                new MethodCallRename('Doctrine\DBAL\Query\Expression\ExpressionBuilder', 'andX', 'and'),
+                new MethodCallRename('Doctrine\DBAL\Query\Expression\ExpressionBuilder', 'orX', 'or'),
                 // https://github.com/doctrine/dbal/blob/master/UPGRADE.md#deprecated-compositeexpression-methods
-                new MethodCallRename(
-                    'Doctrine\DBAL\Query\Expression\CompositeExpression',
-                    'add',
-                    'with'
-                ),
-                new MethodCallRename(
-                    'Doctrine\DBAL\Query\Expression\CompositeExpression',
-                    'addMultiple',
-                    'with'
-                ),
+                new MethodCallRename('Doctrine\DBAL\Query\Expression\CompositeExpression', 'add', 'with'),
+                new MethodCallRename('Doctrine\DBAL\Query\Expression\CompositeExpression', 'addMultiple', 'with'),
                 // https://github.com/doctrine/dbal/blob/master/UPGRADE.md#deprecated-fetchmode-and-the-corresponding-methods
-                new MethodCallRename(
-                    'Doctrine\DBAL\Connection',
-                    'fetchAssoc',
-                    'fetchAssociative'
-                ),
-                new MethodCallRename(
-                    'Doctrine\DBAL\Connection',
-                    'fetchArray',
-                    'fetchNumeric'
-                ),
-                new MethodCallRename(
-                    'Doctrine\DBAL\Connection',
-                    'fetchColumn',
-                    'fetchOne'
-                ),
-                new MethodCallRename(
-                    'Doctrine\DBAL\Connection',
-                    'fetchAll',
-                    'fetchAllAssociative'
-                ),
-                new MethodCallRename(
-                    'Doctrine\DBAL\Statement',
-                    'fetchAssoc',
-                    'fetchAssociative'
-                ),
-                new MethodCallRename(
-                    'Doctrine\DBAL\Statement',
-                    'fetchColumn',
-                    'fetchOne'
-                ),
-                new MethodCallRename(
-                    'Doctrine\DBAL\Statement',
-                    'fetchAll',
-                    'fetchAllAssociative'
-                ),
+                new MethodCallRename('Doctrine\DBAL\Connection', 'fetchAssoc', 'fetchAssociative'),
+                new MethodCallRename('Doctrine\DBAL\Connection', 'fetchArray', 'fetchNumeric'),
+                new MethodCallRename('Doctrine\DBAL\Connection', 'fetchColumn', 'fetchOne'),
+                new MethodCallRename('Doctrine\DBAL\Connection', 'fetchAll', 'fetchAllAssociative'),
+                new MethodCallRename('Doctrine\DBAL\Statement', 'fetchAssoc', 'fetchAssociative'),
+                new MethodCallRename('Doctrine\DBAL\Statement', 'fetchColumn', 'fetchOne'),
+                new MethodCallRename('Doctrine\DBAL\Statement', 'fetchAll', 'fetchAllAssociative'),
             ]),
         ]]);
 

--- a/config/set/doctrine-dbal-211.php
+++ b/config/set/doctrine-dbal-211.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+use Rector\Renaming\ValueObject\MethodCallRename;
+use function Rector\SymfonyPhpConfig\inline_value_objects;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->set(RenameMethodRector::class)
+        ->call('configure', [[
+            RenameMethodRector::METHOD_CALL_RENAMES => inline_value_objects([
+                // https://github.com/doctrine/dbal/blob/master/UPGRADE.md#deprecations-in-the-wrapper-connection-class
+                new MethodCallRename(
+                    'Doctrine\DBAL\Connection',
+                    'executeUpdate',
+                    'executeStatement'
+                ),
+                new MethodCallRename(
+                    'Doctrine\DBAL\Connection',
+                    'exec',
+                    'executeStatement'
+                ),
+                new MethodCallRename(
+                    'Doctrine\DBAL\Connection',
+                    'query',
+                    'executeQuery'
+                ),
+                // https://github.com/doctrine/dbal/blob/master/UPGRADE.md#driverexceptiongeterrorcode-is-deprecated
+                new MethodCallRename(
+                    'Doctrine\DBAL\Driver\DriverException',
+                    'getErrorCode',
+                    'getSQLState'
+                ),
+                // https://github.com/doctrine/dbal/blob/master/UPGRADE.md#deprecated-expressionbuilder-methods
+                new MethodCallRename(
+                    'Doctrine\DBAL\Query\Expression\ExpressionBuilder',
+                    'andX',
+                    'and'
+                ),
+                new MethodCallRename(
+                    'Doctrine\DBAL\Query\Expression\ExpressionBuilder',
+                    'orX',
+                    'or'
+                ),
+                // https://github.com/doctrine/dbal/blob/master/UPGRADE.md#deprecated-compositeexpression-methods
+                new MethodCallRename(
+                    'Doctrine\DBAL\Query\Expression\CompositeExpression',
+                    'add',
+                    'with'
+                ),
+                new MethodCallRename(
+                    'Doctrine\DBAL\Query\Expression\CompositeExpression',
+                    'addMultiple',
+                    'with'
+                ),
+                // https://github.com/doctrine/dbal/blob/master/UPGRADE.md#deprecated-fetchmode-and-the-corresponding-methods
+                new MethodCallRename(
+                    'Doctrine\DBAL\Connection',
+                    'fetchAssoc',
+                    'fetchAssociative'
+                ),
+                new MethodCallRename(
+                    'Doctrine\DBAL\Connection',
+                    'fetchArray',
+                    'fetchNumeric'
+                ),
+                new MethodCallRename(
+                    'Doctrine\DBAL\Connection',
+                    'fetchColumn',
+                    'fetchOne'
+                ),
+                new MethodCallRename(
+                    'Doctrine\DBAL\Connection',
+                    'fetchAll',
+                    'fetchAllAssociative'
+                ),
+                new MethodCallRename(
+                    'Doctrine\DBAL\Statement',
+                    'fetchAssoc',
+                    'fetchAssociative'
+                ),
+                new MethodCallRename(
+                    'Doctrine\DBAL\Statement',
+                    'fetchColumn',
+                    'fetchOne'
+                ),
+                new MethodCallRename(
+                    'Doctrine\DBAL\Statement',
+                    'fetchAll',
+                    'fetchAllAssociative'
+                ),
+            ]),
+        ]]);
+
+    $services->set(RenameClassRector::class)
+        ->call('configure', [[
+            RenameClassRector::OLD_TO_NEW_CLASSES => [
+                // https://github.com/doctrine/dbal/blob/master/UPGRADE.md#pdo-related-classes-outside-of-the-pdo-namespace-are-deprecated
+                'Doctrine\DBAL\Driver\PDOMySql\Driver' => 'Doctrine\DBAL\Driver\PDO\MySQL\Driver',
+                'Doctrine\DBAL\Driver\PDOOracle\Driver' => 'Doctrine\DBAL\Driver\PDO\OCI\Driver',
+                'Doctrine\DBAL\Driver\PDOPgSql\Driver' => 'Doctrine\DBAL\Driver\PDO\PgSQL\Driver',
+                'Doctrine\DBAL\Driver\PDOSqlite\Driver' => 'Doctrine\DBAL\Driver\PDO\SQLite\Driver',
+                'Doctrine\DBAL\Driver\PDOSqlsrv\Driver' => 'Doctrine\DBAL\Driver\PDO\SQLSrv\Driver',
+                'Doctrine\DBAL\Driver\PDOSqlsrv\Connection' => 'Doctrine\DBAL\Driver\PDO\SQLSrv\Connection',
+                'Doctrine\DBAL\Driver\PDOSqlsrv\Statement' => 'Doctrine\DBAL\Driver\PDO\SQLSrv\Statement',
+                // https://github.com/doctrine/dbal/blob/master/UPGRADE.md#deprecated-dbalexception
+                'Doctrine\DBAL\DBALException' => 'Doctrine\DBAL\Exception',
+                // https://github.com/doctrine/dbal/blob/master/UPGRADE.md#inconsistently-and-ambiguously-named-driver-level-classes-are-deprecated
+                'Doctrine\DBAL\Driver\DriverException' => 'Doctrine\DBAL\Driver\Exception',
+                'Doctrine\DBAL\Driver\AbstractDriverException' => 'Doctrine\DBAL\Driver\AbstractException',
+                'Doctrine\DBAL\Driver\IBMDB2\DB2Driver' => 'Doctrine\DBAL\Driver\IBMDB2\Driver',
+                'Doctrine\DBAL\Driver\IBMDB2\DB2Connection' => 'Doctrine\DBAL\Driver\IBMDB2\Connection',
+                'Doctrine\DBAL\Driver\IBMDB2\DB2Statement' => 'Doctrine\DBAL\Driver\IBMDB2\Statement',
+                'Doctrine\DBAL\Driver\Mysqli\MysqliConnection' => 'Doctrine\DBAL\Driver\Mysqli\Connection',
+                'Doctrine\DBAL\Driver\Mysqli\MysqliStatement' => 'Doctrine\DBAL\Driver\Mysqli\Statement',
+                'Doctrine\DBAL\Driver\OCI8\OCI8Connection' => 'Doctrine\DBAL\Driver\OCI8\Connection',
+                'Doctrine\DBAL\Driver\OCI8\OCI8Statement' => 'Doctrine\DBAL\Driver\OCI8\Statement',
+                'Doctrine\DBAL\Driver\SQLSrv\SQLSrvConnection' => 'Doctrine\DBAL\Driver\SQLSrv\Connection',
+                'Doctrine\DBAL\Driver\SQLSrv\SQLSrvStatement' => 'Doctrine\DBAL\Driver\SQLSrv\Statement',
+                'Doctrine\DBAL\Driver\PDOConnection' => 'Doctrine\DBAL\Driver\PDO\Connection',
+                'Doctrine\DBAL\Driver\PDOStatement' => 'Doctrine\DBAL\Driver\PDO\Statement',
+                // https://github.com/doctrine/dbal/blob/master/UPGRADE.md#deprecated-masterslaveconnection-use-primaryreadreplicaconnection
+                'Doctrine\DBAL\Connections\MasterSlaveConnection' => 'Doctrine\DBAL\Connections\PrimaryReadReplicaConnection',
+            ],
+        ]]);
+};

--- a/config/set/doctrine-dbal-30.php
+++ b/config/set/doctrine-dbal-30.php
@@ -18,7 +18,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->call('configure', [[
             RenameMethodRector::METHOD_CALL_RENAMES => inline_value_objects([
                 new MethodCallRename(
-                    'DBAL\Platforms\AbstractPlatform',
+                    'Doctrine\DBAL\Platforms\AbstractPlatform',
                     'getVarcharTypeDeclarationSQL',
                     'getStringTypeDeclarationSQL'
                 ),

--- a/config/set/doctrine-dbal-30.php
+++ b/config/set/doctrine-dbal-30.php
@@ -6,6 +6,7 @@ use PHPStan\Type\VoidType;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
 use function Rector\SymfonyPhpConfig\inline_value_objects;
+use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector;
 use Rector\TypeDeclaration\ValueObject\AddReturnTypeDeclaration;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -31,5 +32,13 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             AddReturnTypeDeclarationRector::METHOD_RETURN_TYPES => inline_value_objects([
                 new AddReturnTypeDeclaration('Doctrine\DBAL\Connection', 'ping', new VoidType()),
             ]),
+        ]]);
+
+    # https://github.com/doctrine/dbal/blob/master/UPGRADE.md#deprecated-abstractionresult
+    $services->set(RenameClassRector::class)
+        ->call('configure', [[
+            RenameClassRector::OLD_TO_NEW_CLASSES => [
+                'Doctrine\DBAL\Abstraction\Result' => 'Doctrine\DBAL\Result',
+            ],
         ]]);
 };

--- a/config/set/doctrine-dbal-30.php
+++ b/config/set/doctrine-dbal-30.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 use PHPStan\Type\VoidType;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
+use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
 use function Rector\SymfonyPhpConfig\inline_value_objects;
-use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector;
 use Rector\TypeDeclaration\ValueObject\AddReturnTypeDeclaration;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;

--- a/packages/set/src/ValueObject/SetList.php
+++ b/packages/set/src/ValueObject/SetList.php
@@ -134,6 +134,11 @@ final class SetList
     /**
      * @var string
      */
+    public const DOCTRINE_DBAL_211 = __DIR__ . '/../../../../config/set/doctrine-dbal-211.php';
+
+    /**
+     * @var string
+     */
     public const DOCTRINE_DBAL_30 = __DIR__ . '/../../../../config/set/doctrine-dbal-30.php';
 
     /**


### PR DESCRIPTION
See https://github.com/doctrine/dbal/blob/master/UPGRADE.md#upgrade-to-211

Lots of changes in DBAL 2.11, but I don't think all of them can be handled by rector. I also fixed a few things in the 3.0 rule set.

Questions:

- the [MasterSlaveConnection -> PrimaryReadReplicaConnection](https://github.com/doctrine/dbal/blob/master/UPGRADE.md#deprecated-masterslaveconnection-use-primaryreadreplicaconnection) includes renaming some arguments in `DriverManager::getConnection`'s array. Are there pre-existing rectors that can handle something like that?
- Unsure on the order which these are executed in practice (in order defined?). Some classes are renamed and have methods that changed (`DriverException` for instance)
- Really questioning the wisdom of including the `fetchAll` -> `fetchAllAssociative` rename -- [upgrade guide](https://github.com/doctrine/dbal/blob/master/UPGRADE.md#deprecated-fetchmode-and-the-corresponding-methods) mentions that quite a few `fetchAll*` methods were added, but the conneciton docblocks say `fetchAll` returns associative arrays. Statement docblocks are not clear, but PDO itself defaults to fetch both associative and numeric. Hard to say if this should be included.