### PR TITLE
rector.php.dist: added missing use for commented rule

### DIFF
--- a/rector.php.dist
+++ b/rector.php.dist
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Core\Configuration\Option;
+use Rector\Php74\Rector\Property\TypedPropertyRector;
 use Rector\Set\ValueObject\SetList;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 


### PR DESCRIPTION
In the example of single rule registration there is a class which is unfortunatelly missing amongst use statements - simply uncommenting the line wouldn't work.