### PR TITLE
Changed docs to be slightly less ambiguous

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@
 
 Rector helps you with 2 areas - major code changes and in daily work.
 
--   Do you have a legacy code base? Do you want to have that latest version of PHP or your favorite framework?
-    → **Rector gets you there with instant upgrade**.
+- Do you have a legacy code base? Do you want to have that latest version of PHP or your favorite framework?
+ → **Rector gets you there with instant upgrade**.
 
  <br>
 
--   Do you have code quality you need, but struggle to keep it with new developers in your team? Do you wish to have code-reviews for each member of your team, but don't have time for it?
-    → **Add Rector to you CI and let it fix your code for you. Get [instant feedback](https://tomasvotruba.com/blog/2020/01/13/why-is-first-instant-feedback-crucial-to-developers/) after each commit.**
+- Do you have code quality you need, but struggle to keep it with new developers in your team? Do you wish to have  code-reviews for each member of your team, but don't have time for it?
+→ **Add Rector to you CI and let it fix your code for you. Get [instant feedback](https://tomasvotruba.com/blog/2020/01/13/why-is-first-instant-feedback-crucial-to-developers/) after each commit.**
 
 <br>
 
@@ -24,7 +24,7 @@ It's a tool that [we develop](https://getrector.org/) and share for free, so you
 
 <br>
 
--   **[Try Rector Online](https://getrector.org/demo)**
+- **[Try Rector Online](https://getrector.org/demo)**
 
 ## Show Case: Complete 2700 `@var` annotations in 2 mins
 
@@ -53,34 +53,34 @@ It supports all versions of PHP from 5.2 and major open-source projects:
 
 ### What Can Rector Do for You?
 
--   [Upgrade 30 000 unit tests from PHPUnit 6 to 9 in 2 weeks](https://twitter.com/LBajsarowicz/status/1272947900016967683)
--   [Complete PHP 7.4 property type declarations](https://tomasvotruba.com/blog/2018/11/15/how-to-get-php-74-typed-properties-to-your-code-in-few-seconds/)
--   [Migrate your project from Nette to Symfony](https://tomasvotruba.com/blog/2019/02/21/how-we-migrated-from-nette-to-symfony-in-3-weeks-part-1/)
--   [Refactor Laravel Facades to Dependency Injection](https://tomasvotruba.com/blog/2019/03/04/how-to-turn-laravel-from-static-to-dependency-injection-in-one-day/)
--   And much more...
+- [Upgrade 30 000 unit tests from PHPUnit 6 to 9 in 2 weeks](https://twitter.com/LBajsarowicz/status/1272947900016967683)
+- [Complete PHP 7.4 property type declarations](https://tomasvotruba.com/blog/2018/11/15/how-to-get-php-74-typed-properties-to-your-code-in-few-seconds/)
+- [Migrate your project from Nette to Symfony](https://tomasvotruba.com/blog/2019/02/21/how-we-migrated-from-nette-to-symfony-in-3-weeks-part-1/)
+- [Refactor Laravel Facades to Dependency Injection](https://tomasvotruba.com/blog/2019/03/04/how-to-turn-laravel-from-static-to-dependency-injection-in-one-day/)
+- And much more...
 
 <br>
 
 ## Documentation
 
--   [Explore 600+ Rector Rules](/docs/rector_rules_overview.md)
--   [How Does Rector Work?](/docs/how_it_works.md)
--   [PHP Parser Nodes Overview](/docs/nodes_overview.md)
+- [Explore 600+ Rector Rules](/docs/rector_rules_overview.md)
+- [How Does Rector Work?](/docs/how_it_works.md)
+- [PHP Parser Nodes Overview](/docs/nodes_overview.md)
 
 ### Advanced
 
--   [How To Run Rector on Changed Files Only](/docs/how_to_run_rector_on_changed_files_only.md)
--   [How Run One Rule From Command Line](/docs/how_to_run_one_rule_from_command_line.md)
--   [How to Ignore Rule or Paths](/docs/how_to_ignore_rule_or_paths.md)
--   [How to Configure Rule](/docs/how_to_configure_rules.md)
--   [How run Rector in Docker](/docs/how_to_run_rector_in_docker.md)
--   [Add Checkstyle with your CI](/docs/checkstyle.md)
+- [How To Run Rector on Changed Files Only](/docs/how_to_run_rector_on_changed_files_only.md)
+- [How Run One Rule From Command Line](/docs/how_to_run_one_rule_from_command_line.md)
+- [How to Ignore Rule or Paths](/docs/how_to_ignore_rule_or_paths.md)
+- [How to Configure Rule](/docs/how_to_configure_rules.md)
+- [How run Rector in Docker](/docs/how_to_run_rector_in_docker.md)
+- [Add Checkstyle with your CI](/docs/checkstyle.md)
 
 ### Contributing
 
--   [How to Add Test for Rector Rule](/docs/how_to_add_test_for_rector_rule.md)
--   [How to Create New Rector Rule](/docs/create_own_rule.md)
--   [How to Generate New Rector Rule with Recipe](/docs/rector_recipe.md)
+- [How to Add Test for Rector Rule](/docs/how_to_add_test_for_rector_rule.md)
+- [How to Create New Rector Rule](/docs/create_own_rule.md)
+- [How to Generate New Rector Rule with Recipe](/docs/rector_recipe.md)
 
 ## Install
 
@@ -88,8 +88,8 @@ It supports all versions of PHP from 5.2 and major open-source projects:
 composer require rector/rector --dev
 ```
 
--   Having conflicts during `composer require`? → Use the [Rector Prefixed](https://github.com/rectorphp/rector-prefixed)
--   Using a different PHP version than Rector supports? → Use the [Docker image](/docs/how_to_run_rector_in_docker.md)
+- Having conflicts during `composer require`? → Use the [Rector Prefixed](https://github.com/rectorphp/rector-prefixed)
+- Using a different PHP version than Rector supports? → Use the [Docker image](/docs/how_to_run_rector_in_docker.md)
 
 <br>
 
@@ -97,10 +97,10 @@ composer require rector/rector --dev
 
 There a 2 main ways to use Rector:
 
--   a _single rule_, to have the change under control - you can choose [from over 600 rules](/docs/rector_rules_overview.md)
--   or group of rules called _sets_ - pick from [sets](/config/set)
+- a *single rule*, to have the change under control - you can choose [from over 600 rules](/docs/rector_rules_overview.md)
+- or group of rules called *sets* - pick from [sets](/config/set)
 
-To use them, create a `rector.php` in the root directory of your project:
+To use them, create a `rector.php` in your root directory:
 
 ```bash
 vendor/bin/rector init
@@ -139,13 +139,13 @@ Then dry run Rector, replacing "{{src}}" with the directory you wish to process:
 vendor/bin/rector process {{src}} --dry-run
 ```
 
-Rector will show you diff of files that it _would_ change. To _make_ the changes, drop `--dry-run`:
+Rector will show you diff of files that it *would* change. To *make* the changes, drop `--dry-run`:
 
 ```bash
 vendor/bin/rector process {{src}}
 ```
 
-_Note: `rector.php` is loaded by default. For different location, use `--config` option._
+*Note: `rector.php` is loaded by default. For different location, use `--config` option.*
 
 <br>
 
@@ -250,13 +250,13 @@ vendor/bin/rector process {{src}}/Controller --dry-run --xdebug
 
 Do you use Rector to upgrade your code? Add it here:
 
--   [palantirnet/drupal-rector](https://github.com/palantirnet/drupal-rector) by [Palantir.net](https://github.com/palantirnet) for [Drupal](https://www.drupal.org/)
--   [sabbelasichon/typo3-rector](https://github.com/sabbelasichon/typo3-rector) for [TYPO3](https://typo3.org/)
+- [palantirnet/drupal-rector](https://github.com/palantirnet/drupal-rector) by [Palantir.net](https://github.com/palantirnet) for [Drupal](https://www.drupal.org/)
+- [sabbelasichon/typo3-rector](https://github.com/sabbelasichon/typo3-rector) for [TYPO3](https://typo3.org/)
 
 ## Known Drawbacks
 
 ### How to Apply Coding Standards?
 
-Rector uses [nikic/php-parser](https://github.com/nikic/PHP-Parser/), that build on technology called _abstract syntax tree_ (AST). AST doesn't care about spaces and produces mall-formatted code in both PHP and docblock annotations. **That's why your project needs to have coding standard tool** and set of rules, so it can make refactored nice and shiny again.
+Rector uses [nikic/php-parser](https://github.com/nikic/PHP-Parser/), that build on technology called *abstract syntax tree* (AST). AST doesn't care about spaces and produces mall-formatted code in both PHP and docblock annotations. **That's why your project needs to have coding standard tool** and set of rules, so it can make refactored nice and shiny again.
 
 Don't have any coding standard tool? Add [ECS](https://github.com/Symplify/EasyCodingStandard) and use prepared [`ecs-after-rector.php`](/ecs-after-rector.php) set.

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@
 
 Rector helps you with 2 areas - major code changes and in daily work.
 
-- Do you have a legacy code base? Do you want to have that latest version of PHP or your favorite framework?
- → **Rector gets you there with instant upgrade**.
+-   Do you have a legacy code base? Do you want to have that latest version of PHP or your favorite framework?
+    → **Rector gets you there with instant upgrade**.
 
  <br>
 
-- Do you have code quality you need, but struggle to keep it with new developers in your team? Do you wish to have  code-reviews for each member of your team, but don't have time for it?
-→ **Add Rector to you CI and let it fix your code for you. Get [instant feedback](https://tomasvotruba.com/blog/2020/01/13/why-is-first-instant-feedback-crucial-to-developers/) after each commit.**
+-   Do you have code quality you need, but struggle to keep it with new developers in your team? Do you wish to have code-reviews for each member of your team, but don't have time for it?
+    → **Add Rector to you CI and let it fix your code for you. Get [instant feedback](https://tomasvotruba.com/blog/2020/01/13/why-is-first-instant-feedback-crucial-to-developers/) after each commit.**
 
 <br>
 
@@ -24,7 +24,7 @@ It's a tool that [we develop](https://getrector.org/) and share for free, so you
 
 <br>
 
-- **[Try Rector Online](https://getrector.org/demo)**
+-   **[Try Rector Online](https://getrector.org/demo)**
 
 ## Show Case: Complete 2700 `@var` annotations in 2 mins
 
@@ -53,34 +53,34 @@ It supports all versions of PHP from 5.2 and major open-source projects:
 
 ### What Can Rector Do for You?
 
-- [Upgrade 30 000 unit tests from PHPUnit 6 to 9 in 2 weeks](https://twitter.com/LBajsarowicz/status/1272947900016967683)
-- [Complete PHP 7.4 property type declarations](https://tomasvotruba.com/blog/2018/11/15/how-to-get-php-74-typed-properties-to-your-code-in-few-seconds/)
-- [Migrate your project from Nette to Symfony](https://tomasvotruba.com/blog/2019/02/21/how-we-migrated-from-nette-to-symfony-in-3-weeks-part-1/)
-- [Refactor Laravel Facades to Dependency Injection](https://tomasvotruba.com/blog/2019/03/04/how-to-turn-laravel-from-static-to-dependency-injection-in-one-day/)
-- And much more...
+-   [Upgrade 30 000 unit tests from PHPUnit 6 to 9 in 2 weeks](https://twitter.com/LBajsarowicz/status/1272947900016967683)
+-   [Complete PHP 7.4 property type declarations](https://tomasvotruba.com/blog/2018/11/15/how-to-get-php-74-typed-properties-to-your-code-in-few-seconds/)
+-   [Migrate your project from Nette to Symfony](https://tomasvotruba.com/blog/2019/02/21/how-we-migrated-from-nette-to-symfony-in-3-weeks-part-1/)
+-   [Refactor Laravel Facades to Dependency Injection](https://tomasvotruba.com/blog/2019/03/04/how-to-turn-laravel-from-static-to-dependency-injection-in-one-day/)
+-   And much more...
 
 <br>
 
 ## Documentation
 
-- [Explore 600+ Rector Rules](/docs/rector_rules_overview.md)
-- [How Does Rector Work?](/docs/how_it_works.md)
-- [PHP Parser Nodes Overview](/docs/nodes_overview.md)
+-   [Explore 600+ Rector Rules](/docs/rector_rules_overview.md)
+-   [How Does Rector Work?](/docs/how_it_works.md)
+-   [PHP Parser Nodes Overview](/docs/nodes_overview.md)
 
 ### Advanced
 
-- [How To Run Rector on Changed Files Only](/docs/how_to_run_rector_on_changed_files_only.md)
-- [How Run One Rule From Command Line](/docs/how_to_run_one_rule_from_command_line.md)
-- [How to Ignore Rule or Paths](/docs/how_to_ignore_rule_or_paths.md)
-- [How to Configure Rule](/docs/how_to_configure_rules.md)
-- [How run Rector in Docker](/docs/how_to_run_rector_in_docker.md)
-- [Add Checkstyle with your CI](/docs/checkstyle.md)
+-   [How To Run Rector on Changed Files Only](/docs/how_to_run_rector_on_changed_files_only.md)
+-   [How Run One Rule From Command Line](/docs/how_to_run_one_rule_from_command_line.md)
+-   [How to Ignore Rule or Paths](/docs/how_to_ignore_rule_or_paths.md)
+-   [How to Configure Rule](/docs/how_to_configure_rules.md)
+-   [How run Rector in Docker](/docs/how_to_run_rector_in_docker.md)
+-   [Add Checkstyle with your CI](/docs/checkstyle.md)
 
 ### Contributing
 
-- [How to Add Test for Rector Rule](/docs/how_to_add_test_for_rector_rule.md)
-- [How to Create New Rector Rule](/docs/create_own_rule.md)
-- [How to Generate New Rector Rule with Recipe](/docs/rector_recipe.md)
+-   [How to Add Test for Rector Rule](/docs/how_to_add_test_for_rector_rule.md)
+-   [How to Create New Rector Rule](/docs/create_own_rule.md)
+-   [How to Generate New Rector Rule with Recipe](/docs/rector_recipe.md)
 
 ## Install
 
@@ -88,8 +88,8 @@ It supports all versions of PHP from 5.2 and major open-source projects:
 composer require rector/rector --dev
 ```
 
-- Having conflicts during `composer require`? → Use the [Rector Prefixed](https://github.com/rectorphp/rector-prefixed)
-- Using a different PHP version than Rector supports? → Use the [Docker image](/docs/how_to_run_rector_in_docker.md)
+-   Having conflicts during `composer require`? → Use the [Rector Prefixed](https://github.com/rectorphp/rector-prefixed)
+-   Using a different PHP version than Rector supports? → Use the [Docker image](/docs/how_to_run_rector_in_docker.md)
 
 <br>
 
@@ -97,10 +97,10 @@ composer require rector/rector --dev
 
 There a 2 main ways to use Rector:
 
-- a *single rule*, to have the change under control - you can choose [from over 600 rules](/docs/rector_rules_overview.md)
-- or group of rules called *sets* - pick from [sets](/config/set)
+-   a _single rule_, to have the change under control - you can choose [from over 600 rules](/docs/rector_rules_overview.md)
+-   or group of rules called _sets_ - pick from [sets](/config/set)
 
-To use them, create a `rector.php` in your root directory:
+To use them, create a `rector.php` in the root directory of your project:
 
 ```bash
 vendor/bin/rector init
@@ -133,23 +133,25 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
 <br>
 
-Then dry run Rector:
+Then dry run Rector, replacing "{{src}}" with the directory you wish to process:
 
 ```bash
-vendor/bin/rector process src --dry-run
+vendor/bin/rector process {{src}} --dry-run
 ```
 
-Rector will show you diff of files that it *would* change. To *make* the changes, drop `--dry-run`:
+Rector will show you diff of files that it _would_ change. To _make_ the changes, drop `--dry-run`:
 
 ```bash
-vendor/bin/rector process src
+vendor/bin/rector process {{src}}
 ```
 
-*Note: `rector.php` is loaded by default. For different location, use `--config` option.*
+_Note: `rector.php` is loaded by default. For different location, use `--config` option._
 
 <br>
 
 ## Full Config Configuration
+
+Modify to fit your environment.
 
 ```php
 <?php
@@ -165,7 +167,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters = $containerConfigurator->parameters();
 
     // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [__DIR__ . '/src', __DIR__ . '/tests']);
+    // change {{/src}} and {{/tests}} to fit your directory structure
+    $parameters->set(Option::PATHS, [__DIR__ . '{{/src}}', __DIR__ . '{{/tests'}}]);
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
@@ -229,7 +232,7 @@ See [the contribution guide](/CONTRIBUTING.md).
 You can use `--debug` option, that will print nested exceptions output:
 
 ```bash
-vendor/bin/rector process src/Controller --dry-run --debug
+vendor/bin/rector process {{src}}/Controller --dry-run --debug
 ```
 
 Or with XDebug:
@@ -238,7 +241,7 @@ Or with XDebug:
 2. Add `--xdebug` option when running Rector
 
 ```bash
-vendor/bin/rector process src/Controller --dry-run --xdebug
+vendor/bin/rector process {{src}}/Controller --dry-run --xdebug
 ```
 
 <br>
@@ -247,13 +250,13 @@ vendor/bin/rector process src/Controller --dry-run --xdebug
 
 Do you use Rector to upgrade your code? Add it here:
 
-- [palantirnet/drupal-rector](https://github.com/palantirnet/drupal-rector) by [Palantir.net](https://github.com/palantirnet) for [Drupal](https://www.drupal.org/)
-- [sabbelasichon/typo3-rector](https://github.com/sabbelasichon/typo3-rector) for [TYPO3](https://typo3.org/)
+-   [palantirnet/drupal-rector](https://github.com/palantirnet/drupal-rector) by [Palantir.net](https://github.com/palantirnet) for [Drupal](https://www.drupal.org/)
+-   [sabbelasichon/typo3-rector](https://github.com/sabbelasichon/typo3-rector) for [TYPO3](https://typo3.org/)
 
 ## Known Drawbacks
 
 ### How to Apply Coding Standards?
 
-Rector uses [nikic/php-parser](https://github.com/nikic/PHP-Parser/), that build on technology called *abstract syntax tree* (AST). AST doesn't care about spaces and produces mall-formatted code in both PHP and docblock annotations. **That's why your project needs to have coding standard tool** and set of rules, so it can make refactored nice and shiny again.
+Rector uses [nikic/php-parser](https://github.com/nikic/PHP-Parser/), that build on technology called _abstract syntax tree_ (AST). AST doesn't care about spaces and produces mall-formatted code in both PHP and docblock annotations. **That's why your project needs to have coding standard tool** and set of rules, so it can make refactored nice and shiny again.
 
 Don't have any coding standard tool? Add [ECS](https://github.com/Symplify/EasyCodingStandard) and use prepared [`ecs-after-rector.php`](/ecs-after-rector.php) set.

--- a/docs/create_own_rule.md
+++ b/docs/create_own_rule.md
@@ -1,5 +1,3 @@
-
-
 # 3 Steps to Create Your Own Rector
 
 First, make sure it's not covered by [any existing Rectors](/docs/rector_rules_overview.md).
@@ -138,10 +136,10 @@ The `rector.php` configuration is loaded by default, so we can skip it.
 
 ```bash
 # see the diff first
-vendor/bin/rector process src --dry-run
+vendor/bin/rector process {{src}} --dry-run
 
 # if it's ok, apply
-vendor/bin/rector process src
+vendor/bin/rector process {{src}}
 ```
 
 That's it!

--- a/docs/how_to_run_one_rule_from_command_line.md
+++ b/docs/how_to_run_one_rule_from_command_line.md
@@ -3,11 +3,11 @@
 Do you have config that includes many sets and Rectors? You might want to run only a single Rector. The `--only` argument allows that, e.g.:
 
 ```bash
-vendor/bin/rector process src --set solid --only Rector\SOLID\Rector\Class_\FinalizeClassesWithoutChildrenRector
+vendor/bin/rector process {{src}} --set solid --only Rector\SOLID\Rector\Class_\FinalizeClassesWithoutChildrenRector
 ```
 
 Too long? Use a short class name:
 
 ```bash
-vendor/bin/rector process src --set solid --only FinalizeClassesWithoutChildrenRector
+vendor/bin/rector process {{src}} --set solid --only FinalizeClassesWithoutChildrenRector
 ```

--- a/docs/how_to_run_rector_in_docker.md
+++ b/docs/how_to_run_rector_in_docker.md
@@ -3,16 +3,16 @@
 You can run Rector on your project using Docker.
 To make sure you are running latest version, use `docker pull rector/rector`.
 
-*Note that Rector inside Docker expects your application in `/project` directory - it is mounted via volume from the current directory (`$pwd`).*
+_Note that Rector inside Docker expects your application in `/project` directory - it is mounted via volume from the current directory (`$pwd`)._
 
 ```bash
-docker run --rm -v $(pwd):/project rector/rector:latest process src --set symfony40 --dry-run
+docker run --rm -v $(pwd):/project rector/rector:latest process {{src}} --set symfony40 --dry-run
 ```
 
 Using `rector.php` config:
 
 ```bash
-docker run --rm -v $(pwd):/project rector/rector:latest process src \
+docker run --rm -v $(pwd):/project rector/rector:latest process {{src}} \
     --config rector.php \
     --dry-run
 ```

--- a/docs/how_to_run_rector_in_docker.md
+++ b/docs/how_to_run_rector_in_docker.md
@@ -3,7 +3,7 @@
 You can run Rector on your project using Docker.
 To make sure you are running latest version, use `docker pull rector/rector`.
 
-_Note that Rector inside Docker expects your application in `/project` directory - it is mounted via volume from the current directory (`$pwd`)._
+*Note that Rector inside Docker expects your application in `/project` directory - it is mounted via volume from the current directory (`$pwd`).*
 
 ```bash
 docker run --rm -v $(pwd):/project rector/rector:latest process {{src}} --set symfony40 --dry-run

--- a/docs/how_to_run_rector_on_changed_files_only.md
+++ b/docs/how_to_run_rector_on_changed_files_only.md
@@ -4,7 +4,7 @@ Execution can be limited to changed files using the `process` option `--match-gi
 This option will filter the files included by the configuration, creating an intersection with the files listed in `git diff`.
 
 ```bash
-vendor/bin/rector process src --match-git-diff
+vendor/bin/rector process {{src}} --match-git-diff
 ```
 
 This option is useful in CI with pull-requests that only change few files.


### PR DESCRIPTION
When learning about this, I was not sure that "src" was a path that needed changing, or if it were a standard command line argument that wasn't a path.  Given that ambiguity, I imagine that other people have that problem too.  I changed several documents to replace "src" with "{{src}}" and gave an explanation in a couple places in README.md about what was to be done with "{{src}}".  Hopefully that is enough to help.  There are places in other documents that I left things as they were, as the code didn't seem too ambiguous to me.