### PR TITLE
fix: PHP_Parser T_Match issue with php 7

### DIFF
--- a/src/PhpParser/Parser/PhpParserLexerFactory.php
+++ b/src/PhpParser/Parser/PhpParserLexerFactory.php
@@ -17,6 +17,7 @@ final class PhpParserLexerFactory
     {
         return new Emulative([
             'usedAttributes' => ['comments', 'startLine', 'endLine', 'startTokenPos', 'endTokenPos'],
+            'phpVersion' => PHP_VERSION,
         ]);
     }
 }


### PR DESCRIPTION
nikic/PHP-Parser is throwing an "Syntax error, unexpected T_MATCH:699" when we are running  /vendor/bin/rector process .
Because our project uses caxy/php-htmldiff which has a Match class. This class is a reserved keyword in PHP8 but should work in PHP 7.x .
 
This is a known issue: https://github.com/nikic/PHP-Parser/issues/690
This PR configures the Lexer to take into account the current PHP version to prevent this error.

Thank you for taking this fix into consideration.
- David