### PR TITLE
[PHP 8.0] Improve NullsafeOperatorRector : Skip no direct usage after if in next statement at last

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,6 +3,10 @@ includes:
     - vendor/phpstan/phpstan/conf/bleedingEdge.neon
     - vendor/symplify/phpstan-extensions/config/config.neon
 
+    # see https://github.com/symplify/coding-standard
+    - vendor/symplify/coding-standard/config/symplify-rules.neon
+    - vendor/symplify/coding-standard/packages/cognitive-complexity/config/cognitive-complexity-services.neon
+
 services:
     -
         class: Symplify\CodingStandard\CognitiveComplexity\Rules\FunctionLikeCognitiveComplexityRule

--- a/rules/php80/src/Rector/If_/NullsafeOperatorRector.php
+++ b/rules/php80/src/Rector/If_/NullsafeOperatorRector.php
@@ -12,7 +12,6 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\NullsafeMethodCall;
 use PhpParser\Node\Expr\NullsafePropertyFetch;
 use PhpParser\Node\Identifier;
-use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Return_;

--- a/rules/php80/src/Rector/If_/NullsafeOperatorRector.php
+++ b/rules/php80/src/Rector/If_/NullsafeOperatorRector.php
@@ -132,14 +132,6 @@ CODE_SAMPLE
 
     private function processAssign(Assign $assign, Node $prevNode, Node $nextNode): ?Node
     {
-        if (property_exists($nextNode, 'expr')) {
-            $prevOfPrevNode = $prevNode->getAttribute(AttributeKey::PREVIOUS_NODE);
-            if (! $prevOfPrevNode instanceof Stmt || $prevOfPrevNode instanceof If_) {
-                $this->removeNode($prevNode);
-                $this->removeNode($nextNode);
-            }
-        }
-
         if ($assign instanceof Assign && property_exists(
             $assign->expr,
             self::NAME
@@ -159,6 +151,8 @@ CODE_SAMPLE
         if ($prevAssign instanceof If_) {
             $nullSafe = $this->getNullSafeOnPrevAssignIsIf($prevAssign, $nextNode, $nullSafe);
         }
+
+        $this->removeNode($nextNode);
 
         if ($nextNode instanceof Return_) {
             $nextNode->expr = $nullSafe;

--- a/rules/php80/tests/Rector/If_/NullsafeOperatorRector/Fixture/skip_no_direct_usage_after_if_in_next.php.inc
+++ b/rules/php80/tests/Rector/If_/NullsafeOperatorRector/Fixture/skip_no_direct_usage_after_if_in_next.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Php80\Tests\Rector\If_\NullsafeOperatorRector\Fixture;
+
+class SkipNoDirectUsafeAfterIfInNext
+{
+    public function f($o)
+    {
+        $o2 = $o->mayFail1();
+        if ($o2 === null) {
+            return null;
+        }
+
+        $mayFail2 = $o2->mayFail2();
+        if ($mayFail2 === null) {
+            return null;
+        }
+
+        $mayFail3 = $mayFail2->mayFail3();
+        if ($mayFail3 === null) {
+            return null;
+        }
+
+        echo 'STATEMENT HERE';
+
+        return $mayFail3->mayFail4();
+    }
+}
+
+?>


### PR DESCRIPTION
It previously cause false positive removal when there is a non-direct usage after if just before last statement. It handle it.