### PR TITLE
[PHP 8.0] Improve NullsafeOperatorRector : Check against !== null

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -692,7 +692,7 @@ parameters:
         - '#Class with base "Application" name is already used in "(.*?)\\Symfony\\Component\\Console\\Application", "Symfony\\Component\\Console\\Application", "Rector\\Core\\Console\\Application"\. Use unique name to make classes easy to recognize#'
         - '#Class with base "FileNode" name is already used in "PHPStan\\Node\\FileNode", "Rector\\Core\\PhpParser\\Node\\CustomNode\\FileNode"\. Use unique name to make classes easy to recognize#'
         - '#Class cognitive complexity for "BetterStandardPrinter" is 52, keep it under 50#'
-        - '#Class cognitive complexity for "NullsafeOperatorRector" is 53, keep it under 50#'
+        - '#Class cognitive complexity for "NullsafeOperatorRector" is \d+, keep it under 50#'
 
         -
             message: '#Node "errorsuppress" is fobidden to use#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -692,7 +692,6 @@ parameters:
         - '#Class with base "Application" name is already used in "(.*?)\\Symfony\\Component\\Console\\Application", "Symfony\\Component\\Console\\Application", "Rector\\Core\\Console\\Application"\. Use unique name to make classes easy to recognize#'
         - '#Class with base "FileNode" name is already used in "PHPStan\\Node\\FileNode", "Rector\\Core\\PhpParser\\Node\\CustomNode\\FileNode"\. Use unique name to make classes easy to recognize#'
         - '#Class cognitive complexity for "BetterStandardPrinter" is 52, keep it under 50#'
-        - '#Class cognitive complexity for "NullsafeOperatorRector" is \d+, keep it under 50#'
 
         -
             message: '#Node "errorsuppress" is fobidden to use#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -692,6 +692,7 @@ parameters:
         - '#Class with base "Application" name is already used in "(.*?)\\Symfony\\Component\\Console\\Application", "Symfony\\Component\\Console\\Application", "Rector\\Core\\Console\\Application"\. Use unique name to make classes easy to recognize#'
         - '#Class with base "FileNode" name is already used in "PHPStan\\Node\\FileNode", "Rector\\Core\\PhpParser\\Node\\CustomNode\\FileNode"\. Use unique name to make classes easy to recognize#'
         - '#Class cognitive complexity for "BetterStandardPrinter" is 52, keep it under 50#'
+        - '#Class cognitive complexity for "NullsafeOperatorRector" is 53, keep it under 50#'
 
         -
             message: '#Node "errorsuppress" is fobidden to use#'

--- a/rules/php80/src/Rector/If_/NullsafeOperatorRector.php
+++ b/rules/php80/src/Rector/If_/NullsafeOperatorRector.php
@@ -155,13 +155,18 @@ CODE_SAMPLE
             $nullSafe = $this->processNullSafeExprResult($expr, $nullSafeIdentifier);
         }
 
-        $nextOfNextNode = null;
         if ($nextNode !== null) {
             $nextOfNextNode = $nextNode->getAttribute(AttributeKey::NEXT_NODE);
             while ($nextOfNextNode) {
                 if ($nextOfNextNode instanceof If_) {
-                    $if->stmts[2] = $this->processNullSafeOperatorNotIdentical($nextOfNextNode);
-                    return $if;
+                    $beforeIf = $nextOfNextNode->getAttribute(AttributeKey::PARENT_NODE);
+                    $nullSafe = $this->processNullSafeOperatorNotIdentical($nextOfNextNode);
+                    if (! $nullSafe instanceof NullsafeMethodCall && ! $nullSafe instanceof PropertyFetch) {
+                        return $beforeIf;
+                    }
+
+                    $beforeIf->stmts[count($beforeIf->stmts) - 1] = new Expression($nullSafe);
+                    return $beforeIf;
                 }
 
                 $nextOfNextNode = $nextOfNextNode->getAttribute(AttributeKey::NEXT_NODE);

--- a/rules/php80/src/Rector/If_/NullsafeOperatorRector.php
+++ b/rules/php80/src/Rector/If_/NullsafeOperatorRector.php
@@ -7,7 +7,6 @@ namespace Rector\Php80\Rector\If_;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Assign;
-use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\NullsafeMethodCall;
 use PhpParser\Node\Expr\NullsafePropertyFetch;
 use PhpParser\Node\Expr\PropertyFetch;
@@ -16,11 +15,11 @@ use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Return_;
 use Rector\Core\PhpParser\Node\Manipulator\IfManipulator;
+use Rector\Core\PhpParser\Node\Manipulator\NullsafeManipulator;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\RectorDefinition\CodeSample;
 use Rector\Core\RectorDefinition\RectorDefinition;
 use Rector\NodeTypeResolver\Node\AttributeKey;
-use Rector\Core\PhpParser\Node\Manipulator\NullsafeManipulator;
 
 /**
  * @see https://wiki.php.net/rfc/nullsafe_operator

--- a/rules/php80/src/Rector/If_/NullsafeOperatorRector.php
+++ b/rules/php80/src/Rector/If_/NullsafeOperatorRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\BinaryOp\Identical;
+use PhpParser\Node\Expr\BinaryOp\NotIdentical;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\NullsafeMethodCall;
 use PhpParser\Node\Expr\NullsafePropertyFetch;
@@ -135,7 +136,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if (! $this->areNodesEqual($if->cond->left, $assignExpr->var)) {
+        if ($if->cond instanceof NotIdentical && ! $this->areNodesEqual($if->cond->left, $assignExpr->var)) {
             return null;
         }
 
@@ -145,10 +146,13 @@ CODE_SAMPLE
         /** @var Node|null $nextNode */
         $nextNode = $expression->getAttribute(AttributeKey::NEXT_NODE);
 
-        /** @var Expr $nullSafe */
+        /** @var NullsafeMethodCall|NullsafePropertyFetch $nullSafe */
         $nullSafe = $this->processNullSafeExpr($assignExpr);
         if ($expr !== null) {
-            $nullSafe = $this->processNullSafeExprResult($expr, $nullSafe->name);
+            /** @var Identifier $nullSafeIdentifier */
+            $nullSafeIdentifier = $nullSafe->name;
+            /** @var NullsafeMethodCall|NullsafePropertyFetch $nullSafe */
+            $nullSafe = $this->processNullSafeExprResult($expr, $nullSafeIdentifier);
         }
 
         if (! $nextNode instanceof If_) {

--- a/rules/php80/src/Rector/If_/NullsafeOperatorRector.php
+++ b/rules/php80/src/Rector/If_/NullsafeOperatorRector.php
@@ -7,8 +7,6 @@ namespace Rector\Php80\Rector\If_;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Assign;
-use PhpParser\Node\Expr\BinaryOp\Identical;
-use PhpParser\Node\Expr\BinaryOp\NotIdentical;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\NullsafeMethodCall;
 use PhpParser\Node\Expr\NullsafePropertyFetch;
@@ -115,7 +113,10 @@ CODE_SAMPLE
             return null;
         }
 
-        if (! $prevNode instanceof Expression || ! $this->ifManipulator->isIfCondUsingAssignIdenticalVariable($if, $prevNode->expr)) {
+        if (! $prevNode instanceof Expression || ! $this->ifManipulator->isIfCondUsingAssignIdenticalVariable(
+            $if,
+            $prevNode->expr
+        )) {
             return null;
         }
 
@@ -275,7 +276,10 @@ CODE_SAMPLE
     private function getNullSafeOnPrevAssignIsIf(If_ $if, Node $nextNode, ?Expr $expr): ?Expr
     {
         $prevIf = $if->getAttribute(AttributeKey::PREVIOUS_NODE);
-        if ($prevIf instanceof Expression && $this->ifManipulator->isIfCondUsingAssignIdenticalVariable($if, $prevIf->expr)) {
+        if ($prevIf instanceof Expression && $this->ifManipulator->isIfCondUsingAssignIdenticalVariable(
+            $if,
+            $prevIf->expr
+        )) {
             $start = $prevIf;
             while ($prevIf instanceof Expression) {
                 $expr = $this->processNullSafeExpr($prevIf->expr->expr);
@@ -325,7 +329,10 @@ CODE_SAMPLE
             while ($node) {
                 /** @var If_ $if */
                 $if = $node->getAttribute(AttributeKey::NEXT_NODE);
-                if ($node instanceof Expression && $this->ifManipulator->isIfCondUsingAssignIdenticalVariable($if, $node->expr)) {
+                if ($node instanceof Expression && $this->ifManipulator->isIfCondUsingAssignIdenticalVariable(
+                    $if,
+                    $node->expr
+                )) {
                     break;
                 }
 

--- a/rules/php80/src/Rector/If_/NullsafeOperatorRector.php
+++ b/rules/php80/src/Rector/If_/NullsafeOperatorRector.php
@@ -169,7 +169,11 @@ CODE_SAMPLE
             return false;
         }
 
-        return $if->cond instanceof Identical && $this->areNodesEqual($if->cond->left, $assign->var);
+        $ifVar = $this->isNull($if->cond->left)
+            ? $if->cond->right
+            : $if->cond->left;
+
+        return $if->cond instanceof Identical && $this->areNodesEqual($ifVar, $assign->var);
     }
 
     private function processAssign(Assign $assign, Node $prevNode, Node $nextNode, bool $isStartIf): ?Node
@@ -190,7 +194,11 @@ CODE_SAMPLE
             return false;
         }
 
-        return $if->cond instanceof NotIdentical && ! $this->areNodesEqual($if->cond->left, $expr->var);
+        $ifVar = $this->isNull($if->cond->left)
+            ? $if->cond->right
+            : $if->cond->left;
+
+        return $if->cond instanceof NotIdentical && ! $this->areNodesEqual($ifVar, $expr->var);
     }
 
     private function processNullSafeExpr(Expr $expr): ?Expr

--- a/rules/php80/src/Rector/If_/NullsafeOperatorRector.php
+++ b/rules/php80/src/Rector/If_/NullsafeOperatorRector.php
@@ -9,9 +9,9 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\BinaryOp\Identical;
 use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\NullsafeMethodCall;
 use PhpParser\Node\Expr\NullsafePropertyFetch;
+use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\If_;
@@ -97,8 +97,7 @@ CODE_SAMPLE
             return $processNullSafeOperator;
         }
 
-        $processNullSafeOperator = $this->processNullSafeOperatorNotIdentical($node);
-        return $processNullSafeOperator;
+        return $this->processNullSafeOperatorNotIdentical($node);
     }
 
     private function processNullSafeOperatorNotIdentical(If_ $if, ?Expr $expr = null): ?Node

--- a/rules/php80/src/Rector/If_/NullsafeOperatorRector.php
+++ b/rules/php80/src/Rector/If_/NullsafeOperatorRector.php
@@ -176,7 +176,7 @@ CODE_SAMPLE
             return false;
         }
 
-        return  $if->cond instanceof Identical && $this->areNodesEqual($this->getIfVar($if), $assign->var);
+        return $if->cond instanceof Identical && $this->areNodesEqual($this->getIfVar($if), $assign->var);
     }
 
     private function processAssign(Assign $assign, Node $prevNode, Node $nextNode, bool $isStartIf): ?Node

--- a/rules/php80/src/Rector/If_/NullsafeOperatorRector.php
+++ b/rules/php80/src/Rector/If_/NullsafeOperatorRector.php
@@ -46,7 +46,7 @@ final class NullsafeOperatorRector extends AbstractRector
     public function __construct(IfManipulator $ifManipulator, NullsafeManipulator $nullsafeManipulator)
     {
         $this->ifManipulator = $ifManipulator;
-        $this->nullSafeManipulator = $nullsafeManipulator;
+        $this->nullsafeManipulator = $nullsafeManipulator;
     }
 
     public function getDefinition(): RectorDefinition
@@ -151,12 +151,12 @@ CODE_SAMPLE
         $nextNode = $expression->getAttribute(AttributeKey::NEXT_NODE);
 
         /** @var NullsafeMethodCall|NullsafePropertyFetch $nullSafe */
-        $nullSafe = $this->nullSafeManipulator->processNullSafeExpr($assignExpr);
+        $nullSafe = $this->nullsafeManipulator->processNullSafeExpr($assignExpr);
         if ($expr !== null) {
             /** @var Identifier $nullSafeIdentifier */
             $nullSafeIdentifier = $nullSafe->name;
             /** @var NullsafeMethodCall|NullsafePropertyFetch $nullSafe */
-            $nullSafe = $this->nullSafeManipulator->processNullSafeExprResult($expr, $nullSafeIdentifier);
+            $nullSafe = $this->nullsafeManipulator->processNullSafeExprResult($expr, $nullSafeIdentifier);
         }
 
         $nextOfNextNode = $this->processIfMayInNextNode($nextNode);
@@ -216,9 +216,9 @@ CODE_SAMPLE
         bool $isStartIf
     ): ?Node {
         $assignNullSafe = ! $isStartIf
-            ? $this->nullSafeManipulator->processNullSafeExpr($assign->expr)
+            ? $this->nullsafeManipulator->processNullSafeExpr($assign->expr)
             : $assign->expr;
-        $nullSafe = $this->nullSafeManipulator->processNullSafeExprResult($assignNullSafe, $nextNode->expr->name);
+        $nullSafe = $this->nullsafeManipulator->processNullSafeExprResult($assignNullSafe, $nextNode->expr->name);
 
         $prevAssign = $prevNode->getAttribute(AttributeKey::PREVIOUS_NODE);
         if ($prevAssign instanceof If_) {
@@ -262,7 +262,7 @@ CODE_SAMPLE
         )) {
             $start = $prevIf;
             while ($prevIf instanceof Expression) {
-                $expr = $this->nullSafeManipulator->processNullSafeExpr($prevIf->expr->expr);
+                $expr = $this->nullsafeManipulator->processNullSafeExpr($prevIf->expr->expr);
                 /** @var If_ $prevIf */
                 $prevIf = $prevIf->getAttribute(AttributeKey::PREVIOUS_NODE);
                 /** @var Expression|Identifier $prevIf */
@@ -281,7 +281,7 @@ CODE_SAMPLE
             /** @var Expr $expr */
             $expr = $expr->var->getAttribute(AttributeKey::PARENT_NODE);
             $expr = $this->getNullSafeAfterStartUntilBeforeEnd($start, $expr);
-            $expr = $this->nullSafeManipulator->processNullSafeExprResult($expr, $nextNode->expr->name);
+            $expr = $this->nullsafeManipulator->processNullSafeExprResult($expr, $nextNode->expr->name);
         }
 
         return $expr;
@@ -303,7 +303,7 @@ CODE_SAMPLE
     private function getNullSafeAfterStartUntilBeforeEnd(?Node $node, ?Expr $expr): ?Expr
     {
         while ($node) {
-            $expr = $this->nullSafeManipulator->processNullSafeExprResult($expr, $node->expr->expr->name);
+            $expr = $this->nullsafeManipulator->processNullSafeExprResult($expr, $node->expr->expr->name);
 
             $node = $node->getAttribute(AttributeKey::NEXT_NODE);
             while ($node) {

--- a/rules/php80/src/Rector/If_/NullsafeOperatorRector.php
+++ b/rules/php80/src/Rector/If_/NullsafeOperatorRector.php
@@ -115,7 +115,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if (! $prevNode instanceof Expression || ! $this->isIfCondUsingAssignIdenticalVariable($if, $prevNode->expr)) {
+        if (! $prevNode instanceof Expression || ! $this->ifManipulator->isIfCondUsingAssignIdenticalVariable($if, $prevNode->expr)) {
             return null;
         }
 
@@ -132,7 +132,7 @@ CODE_SAMPLE
         }
 
         $assignExpr = $assign->expr;
-        if ($this->isIfCondUsingAssignNotIdenticalVariable($if, $assignExpr)) {
+        if ($this->ifManipulator->isIfCondUsingAssignNotIdenticalVariable($if, $assignExpr)) {
             return null;
         }
 
@@ -163,22 +163,6 @@ CODE_SAMPLE
         return $this->processNullSafeOperatorNotIdentical($nextNode, $nullSafe);
     }
 
-    private function getIfVar(If_ $if): Node
-    {
-        /** @var Identical|NotIdentical $ifCond */
-        $ifCond = $if->cond;
-        return $this->isNull($ifCond->left) ? $ifCond->right : $ifCond->left;
-    }
-
-    private function isIfCondUsingAssignIdenticalVariable(Node $if, Node $assign): bool
-    {
-        if (! ($if instanceof If_ && $assign instanceof Assign)) {
-            return false;
-        }
-
-        return $if->cond instanceof Identical && $this->areNodesEqual($this->getIfVar($if), $assign->var);
-    }
-
     private function processAssign(Assign $assign, Node $prevNode, Node $nextNode, bool $isStartIf): ?Node
     {
         if ($assign instanceof Assign && property_exists(
@@ -189,15 +173,6 @@ CODE_SAMPLE
         }
 
         return $this->processAssignMayInNextNode($nextNode);
-    }
-
-    private function isIfCondUsingAssignNotIdenticalVariable(If_ $if, Node $expr): bool
-    {
-        if (! $expr instanceof MethodCall && ! $expr instanceof PropertyFetch) {
-            return false;
-        }
-
-        return $if->cond instanceof NotIdentical && ! $this->areNodesEqual($this->getIfVar($if), $expr->var);
     }
 
     private function processNullSafeExpr(Expr $expr): ?Expr
@@ -290,7 +265,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->isIfCondUsingAssignIdenticalVariable($mayNextIf, $nextNode->expr)) {
+        if ($this->ifManipulator->isIfCondUsingAssignIdenticalVariable($mayNextIf, $nextNode->expr)) {
             return $this->processNullSafeOperatorIdentical($mayNextIf, false);
         }
 
@@ -300,7 +275,7 @@ CODE_SAMPLE
     private function getNullSafeOnPrevAssignIsIf(If_ $if, Node $nextNode, ?Expr $expr): ?Expr
     {
         $prevIf = $if->getAttribute(AttributeKey::PREVIOUS_NODE);
-        if ($prevIf instanceof Expression && $this->isIfCondUsingAssignIdenticalVariable($if, $prevIf->expr)) {
+        if ($prevIf instanceof Expression && $this->ifManipulator->isIfCondUsingAssignIdenticalVariable($if, $prevIf->expr)) {
             $start = $prevIf;
             while ($prevIf instanceof Expression) {
                 $expr = $this->processNullSafeExpr($prevIf->expr->expr);
@@ -350,7 +325,7 @@ CODE_SAMPLE
             while ($node) {
                 /** @var If_ $if */
                 $if = $node->getAttribute(AttributeKey::NEXT_NODE);
-                if ($node instanceof Expression && $this->isIfCondUsingAssignIdenticalVariable($if, $node->expr)) {
+                if ($node instanceof Expression && $this->ifManipulator->isIfCondUsingAssignIdenticalVariable($if, $node->expr)) {
                     break;
                 }
 

--- a/rules/php80/src/Rector/If_/NullsafeOperatorRector.php
+++ b/rules/php80/src/Rector/If_/NullsafeOperatorRector.php
@@ -155,6 +155,19 @@ CODE_SAMPLE
             $nullSafe = $this->processNullSafeExprResult($expr, $nullSafeIdentifier);
         }
 
+        $nextOfNextNode = null;
+        if ($nextNode !== null) {
+            $nextOfNextNode = $nextNode->getAttribute(AttributeKey::NEXT_NODE);
+            while ($nextOfNextNode) {
+                if ($nextOfNextNode instanceof If_) {
+                    $if->stmts[2] = $this->processNullSafeOperatorNotIdentical($nextOfNextNode);
+                    return $if;
+                }
+
+                $nextOfNextNode = $nextOfNextNode->getAttribute(AttributeKey::NEXT_NODE);
+            }
+        }
+
         if (! $nextNode instanceof If_) {
             return new Assign($assign->var, $nullSafe);
         }

--- a/rules/php80/tests/Rector/If_/NullsafeOperatorRector/Fixture/fixture_not_identical.php.inc
+++ b/rules/php80/tests/Rector/If_/NullsafeOperatorRector/Fixture/fixture_not_identical.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Php80\Tests\Rector\If_\NullsafeOperatorRector\Fixture;
+
+class SomeClassNotIdentical
+{
+    public function f($o)
+    {
+        if ($o !== null) {
+            $user = $o->user;
+            if ($user !== null) {
+                $address = $user->getAddress();
+                if ($address !== null) {
+                    $country = $address->getCountry();
+                }
+            }
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Php80\Tests\Rector\If_\NullsafeOperatorRector\Fixture;
+
+class SomeClassNotIdentical
+{
+    public function f($o)
+    {
+        $country = $o?->user?->getAddress()?->getCountry();
+    }
+}
+
+?>

--- a/rules/php80/tests/Rector/If_/NullsafeOperatorRector/Fixture/fixture_not_identical_process_only_direct_if_after_assign.php.inc
+++ b/rules/php80/tests/Rector/If_/NullsafeOperatorRector/Fixture/fixture_not_identical_process_only_direct_if_after_assign.php.inc
@@ -1,0 +1,53 @@
+<?php
+
+namespace Rector\Php80\Tests\Rector\If_\NullsafeOperatorRector\Fixture;
+
+class SomeClassNotIdenticalProcessOnlyDirectAssignAfterIf
+{
+    public function f($o)
+    {
+        if ($o !== null) {
+            $user = $o->user;
+
+            echo 'STATEMENT HERE';
+
+            if ($user !== null) {
+                $address = $user->getAddress();
+
+                echo 'STATEMENT HERE';
+
+                if ($address !== null) {
+                    $country = $address->getCountry();
+                }
+            }
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Php80\Tests\Rector\If_\NullsafeOperatorRector\Fixture;
+
+class SomeClassNotIdenticalProcessOnlyDirectAssignAfterIf
+{
+    public function f($o)
+    {
+        if ($o !== null) {
+            $user = $o->user;
+
+            echo 'STATEMENT HERE';
+
+            if ($user !== null) {
+                $address = $user->getAddress();
+
+                echo 'STATEMENT HERE';
+
+                $country = $address?->getCountry();
+            }
+        }
+    }
+}
+
+?>

--- a/rules/php80/tests/Rector/If_/NullsafeOperatorRector/Fixture/fixture_not_identical_yoda.php.inc
+++ b/rules/php80/tests/Rector/If_/NullsafeOperatorRector/Fixture/fixture_not_identical_yoda.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\Php80\Tests\Rector\If_\NullsafeOperatorRector\Fixture;
+
+class SomeClassNotIdenticalYoda
+{
+    public function f($o)
+    {
+        if (null !== $o) {
+            $user = $o->user;
+            if (null !== $user) {
+                $address = $user->getAddress();
+                if (null !== $address) {
+                    $country = $address->getCountry();
+                }
+            }
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Php80\Tests\Rector\If_\NullsafeOperatorRector\Fixture;
+
+class SomeClassNotIdenticalYoda
+{
+    public function f($o)
+    {
+        $country = $o?->user?->getAddress()?->getCountry();
+    }
+}
+
+?>

--- a/rules/php80/tests/Rector/If_/NullsafeOperatorRector/Fixture/fixture_yoda.php.inc
+++ b/rules/php80/tests/Rector/If_/NullsafeOperatorRector/Fixture/fixture_yoda.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Php80\Tests\Rector\If_\NullsafeOperatorRector\Fixture;
+
+class SomeClassYoda
+{
+    public function f($o)
+    {
+        $o2 = $o->mayFail1();
+        if (null === $o2) {
+            return null;
+        }
+
+        return $o2->mayFail2();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Php80\Tests\Rector\If_\NullsafeOperatorRector\Fixture;
+
+class SomeClassYoda
+{
+    public function f($o)
+    {
+        return $o->mayFail1()?->mayFail2();
+    }
+}
+
+?>

--- a/rules/php80/tests/Rector/If_/NullsafeOperatorRector/Fixture/skip_not_identical_no_direct_assign_after_if.php.inc
+++ b/rules/php80/tests/Rector/If_/NullsafeOperatorRector/Fixture/skip_not_identical_no_direct_assign_after_if.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Php80\Tests\Rector\If_\NullsafeOperatorRector\Fixture;
+
+class SkipNotIdenticalNoDirectAssignAfterIf
+{
+    public function f($o)
+    {
+        if ($o !== null) {
+
+            echo 'STATEMENT HERE';
+
+            $user = $o->user;
+        }
+    }
+}
+
+?>

--- a/rules/php80/tests/Rector/If_/NullsafeOperatorRector/Fixture/skip_not_identical_not_null.php.inc
+++ b/rules/php80/tests/Rector/If_/NullsafeOperatorRector/Fixture/skip_not_identical_not_null.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Php80\Tests\Rector\If_\NullsafeOperatorRector\Fixture;
+
+class SkipNotIdenticalNotNull
+{
+    public function f($o)
+    {
+        if ($o !== 'abc') {
+            $user = $o->user;
+        }
+    }
+}
+
+?>

--- a/src/PhpParser/Node/Manipulator/IfManipulator.php
+++ b/src/PhpParser/Node/Manipulator/IfManipulator.php
@@ -365,4 +365,29 @@ final class IfManipulator
 
         return ! (bool) $if->elseifs;
     }
+
+    private function getIfVar(If_ $if): Node
+    {
+        /** @var Identical|NotIdentical $ifCond */
+        $ifCond = $if->cond;
+        return $this->constFetchManipulator->isNull($ifCond->left) ? $ifCond->right : $ifCond->left;
+    }
+
+    public function isIfCondUsingAssignIdenticalVariable(Node $if, Node $assign): bool
+    {
+        if (! ($if instanceof If_ && $assign instanceof Assign)) {
+            return false;
+        }
+
+        return $if->cond instanceof Identical && $this->betterStandardPrinter->areNodesEqual($this->getIfVar($if), $assign->var);
+    }
+
+    public function isIfCondUsingAssignNotIdenticalVariable(If_ $if, Node $expr): bool
+    {
+        if (! $expr instanceof MethodCall && ! $expr instanceof PropertyFetch) {
+            return false;
+        }
+
+        return $if->cond instanceof NotIdentical && ! $this->betterStandardPrinter->areNodesEqual($this->getIfVar($if), $expr->var);
+    }
 }

--- a/src/PhpParser/Node/Manipulator/IfManipulator.php
+++ b/src/PhpParser/Node/Manipulator/IfManipulator.php
@@ -101,7 +101,7 @@ final class IfManipulator
             return null;
         }
 
-        if (! $if->cond instanceof NotIdentical || ! $this->matchComparedNode($if->cond)) {
+        if (! $if->cond instanceof NotIdentical || ! $this->isNotIdenticalNullCompare($if->cond)) {
             return null;
         }
 
@@ -319,17 +319,13 @@ final class IfManipulator
         return null;
     }
 
-    private function matchComparedNode(NotIdentical $notIdentical): ?Expr
+    private function isNotIdenticalNullCompare(NotIdentical $notIdentical): bool
     {
-        if ($this->constFetchManipulator->isNull($notIdentical->right)) {
-            return $notIdentical->left;
+        if ($this->betterStandardPrinter->areNodesEqual($notIdentical->left, $notIdentical->right)) {
+            return false;
         }
 
-        if ($this->constFetchManipulator->isNull($notIdentical->left)) {
-            return $notIdentical->right;
-        }
-
-        return null;
+        return $this->constFetchManipulator->isNull($notIdentical->right) || $this->constFetchManipulator->isNull($notIdentical->left);
     }
 
     private function isIfWithOnlyStmtIf(If_ $if): bool

--- a/src/PhpParser/Node/Manipulator/IfManipulator.php
+++ b/src/PhpParser/Node/Manipulator/IfManipulator.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Expr\BinaryOp\NotIdentical;
 use PhpParser\Node\Expr\Exit_;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Foreach_;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Return_;
@@ -85,6 +86,27 @@ final class IfManipulator
         }
 
         return $this->matchComparedAndReturnedNode($if->cond, $returnNode);
+    }
+
+    /**
+     * Matches:
+     *
+     * if (<$value> !== null) {
+     *     $anotherValue = $value;
+     * }
+     */
+    public function matchIfNotNullNextAssignment(If_ $if): ?Assign
+    {
+        if ($if->stmts === []) {
+            return null;
+        }
+
+        $insideIfNode = $if->stmts[0];
+        if (! $insideIfNode instanceof Expression || ! $insideIfNode->expr instanceof Assign) {
+            return null;
+        }
+
+        return $insideIfNode->expr;
     }
 
     /**

--- a/src/PhpParser/Node/Manipulator/IfManipulator.php
+++ b/src/PhpParser/Node/Manipulator/IfManipulator.php
@@ -101,6 +101,10 @@ final class IfManipulator
             return null;
         }
 
+        if (! $if->cond instanceof NotIdentical || ! $this->matchComparedNode($if->cond)) {
+            return null;
+        }
+
         $insideIfNode = $if->stmts[0];
         if (! $insideIfNode instanceof Expression || ! $insideIfNode->expr instanceof Assign) {
             return null;
@@ -308,6 +312,19 @@ final class IfManipulator
         if (! $this->betterStandardPrinter->areNodesEqual($notIdentical->right, $return->expr)) {
             return null;
         }
+        if ($this->constFetchManipulator->isNull($notIdentical->left)) {
+            return $notIdentical->right;
+        }
+
+        return null;
+    }
+
+    private function matchComparedNode(NotIdentical $notIdentical): ?Expr
+    {
+        if ($this->constFetchManipulator->isNull($notIdentical->right)) {
+            return $notIdentical->left;
+        }
+
         if ($this->constFetchManipulator->isNull($notIdentical->left)) {
             return $notIdentical->right;
         }

--- a/src/PhpParser/Node/Manipulator/IfManipulator.php
+++ b/src/PhpParser/Node/Manipulator/IfManipulator.php
@@ -314,15 +314,15 @@ final class IfManipulator
         );
     }
 
-    public function isIfCondUsingAssignNotIdenticalVariable(If_ $if, Node $expr): bool
+    public function isIfCondUsingAssignNotIdenticalVariable(If_ $if, Node $node): bool
     {
-        if (! $expr instanceof MethodCall && ! $expr instanceof PropertyFetch) {
+        if (! $node instanceof MethodCall && ! $node instanceof PropertyFetch) {
             return false;
         }
 
         return $if->cond instanceof NotIdentical && ! $this->betterStandardPrinter->areNodesEqual(
             $this->getIfVar($if),
-            $expr->var
+            $node->var
         );
     }
 

--- a/src/PhpParser/Node/Manipulator/IfManipulator.php
+++ b/src/PhpParser/Node/Manipulator/IfManipulator.php
@@ -325,7 +325,9 @@ final class IfManipulator
             return false;
         }
 
-        return $this->constFetchManipulator->isNull($notIdentical->right) || $this->constFetchManipulator->isNull($notIdentical->left);
+        return $this->constFetchManipulator->isNull($notIdentical->right) || $this->constFetchManipulator->isNull(
+            $notIdentical->left
+        );
     }
 
     private function isIfWithOnlyStmtIf(If_ $if): bool

--- a/src/PhpParser/Node/Manipulator/NullsafeManipulator.php
+++ b/src/PhpParser/Node/Manipulator/NullsafeManipulator.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\NullsafeMethodCall;
 use PhpParser\Node\Expr\NullsafePropertyFetch;
+use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Identifier;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 
@@ -19,7 +20,7 @@ final class NullsafeManipulator
             return new NullsafeMethodCall($expr->var, $expr->name);
         }
 
-        if (property_exists($expr, 'var') && property_exists($expr, 'name')) {
+        if ($expr instanceof PropertyFetch) {
             return new NullsafePropertyFetch($expr->var, $expr->name);
         }
 

--- a/src/PhpParser/Node/Manipulator/NullsafeManipulator.php
+++ b/src/PhpParser/Node/Manipulator/NullsafeManipulator.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\PhpParser\Node\Manipulator;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\NullsafeMethodCall;
+use PhpParser\Node\Expr\NullsafePropertyFetch;
+use PhpParser\Node\Identifier;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+
+final class NullsafeManipulator
+{
+    public function processNullSafeExpr(Expr $expr): ?Expr
+    {
+        if ($expr instanceof MethodCall) {
+            return new NullsafeMethodCall($expr->var, $expr->name);
+        }
+
+        if (property_exists($expr, 'var') && property_exists($expr, 'name')) {
+            return new NullsafePropertyFetch($expr->var, $expr->name);
+        }
+
+        return null;
+    }
+
+    public function processNullSafeExprResult(?Expr $expr, Identifier $nextExprIdentifier): ?Expr
+    {
+        if ($expr === null) {
+            return null;
+        }
+
+        $parentIdentifier = $nextExprIdentifier->getAttribute(AttributeKey::PARENT_NODE);
+        if ($parentIdentifier instanceof MethodCall || $parentIdentifier instanceof NullsafeMethodCall) {
+            return new NullsafeMethodCall($expr, $nextExprIdentifier);
+        }
+
+        return new NullsafePropertyFetch($expr, $nextExprIdentifier);
+    }
+}


### PR DESCRIPTION
Added ability for : 

```diff
-        if ($o !== null) {
-            $user = $o->user;
-            if ($user !== null) {
-                $address = $user->getAddress();
-                if ($address !== null) {
-                    $country = $address->getCountry();
-                }
-            }
-        }
+        $country = $o?->user?->getAddress()?->getCountry();
```