### PR TITLE
[CodeQuality] ForToForeachRector improvement on ArrayDimFetch handling

### DIFF
--- a/rules/code-quality/src/Rector/For_/ForToForeachRector.php
+++ b/rules/code-quality/src/Rector/For_/ForToForeachRector.php
@@ -33,6 +33,11 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
 final class ForToForeachRector extends AbstractRector
 {
     /**
+     * @var string
+     */
+    private const COUNT = 'count';
+
+    /**
      * @var AssignManipulator
      */
     private $assignManipulator;
@@ -192,7 +197,7 @@ CODE_SAMPLE
                 $this->keyValueName = $this->getName($initExpr->var);
             }
 
-            if ($this->isFuncCallName($initExpr->expr, 'count')) {
+            if ($this->isFuncCallName($initExpr->expr, self::COUNT)) {
                 $this->countValueVariable = $initExpr->var;
                 $this->countValueName = $this->getName($initExpr->var);
                 $this->iteratedExpr = $initExpr->expr->args[0]->value;
@@ -218,7 +223,7 @@ CODE_SAMPLE
         }
 
         // count($values)
-        if ($this->isFuncCallName($condExprs[0]->right, 'count')) {
+        if ($this->isFuncCallName($condExprs[0]->right, self::COUNT)) {
             /** @var FuncCall $countFuncCall */
             $countFuncCall = $condExprs[0]->right;
             $this->iteratedExpr = $countFuncCall->args[0]->value;
@@ -338,19 +343,6 @@ CODE_SAMPLE
         });
     }
 
-    private function isArgParentCount(?Node $node): bool
-    {
-        if ($node instanceof Arg) {
-            /** @var Node $parentNode */
-            $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
-            if ($this->isFuncCallName($parentNode, 'count')) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     /**
      * @param Expr[] $condExprs
      */
@@ -372,6 +364,19 @@ CODE_SAMPLE
             }
 
             return $this->isName($condExprs[0]->right, $keyValueName);
+        }
+
+        return false;
+    }
+
+    private function isArgParentCount(?Node $node): bool
+    {
+        if ($node instanceof Arg) {
+            /** @var Node $parentNode */
+            $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
+            if ($this->isFuncCallName($parentNode, self::COUNT)) {
+                return true;
+            }
         }
 
         return false;

--- a/rules/code-quality/src/Rector/For_/ForToForeachRector.php
+++ b/rules/code-quality/src/Rector/For_/ForToForeachRector.php
@@ -6,6 +6,7 @@ namespace Rector\CodeQuality\Rector\For_;
 
 use Doctrine\Inflector\Inflector;
 use PhpParser\Node;
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\Assign;
@@ -24,7 +25,6 @@ use Rector\Core\Rector\AbstractRector;
 use Rector\Core\RectorDefinition\CodeSample;
 use Rector\Core\RectorDefinition\RectorDefinition;
 use Rector\NodeTypeResolver\Node\AttributeKey;
-use PhpParser\Node\Arg;
 
 /**
  * @see \Rector\CodeQuality\Tests\Rector\For_\ForToForeachRector\ForToForeachRectorTest
@@ -259,7 +259,10 @@ CODE_SAMPLE
         return (bool) $this->betterNodeFinder->findFirst(
             $for->stmts,
             function (Node $node): bool {
-                return $node instanceof Assign && $node->var instanceof ArrayDimFetch && $this->isVariableName($node->var->dim, $this->keyValueName);
+                return $node instanceof Assign && $node->var instanceof ArrayDimFetch && $this->isVariableName(
+                    $node->var->dim,
+                    $this->keyValueName
+                );
             }
         );
     }

--- a/rules/code-quality/src/Rector/For_/ForToForeachRector.php
+++ b/rules/code-quality/src/Rector/For_/ForToForeachRector.php
@@ -19,6 +19,7 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\For_;
 use PhpParser\Node\Stmt\Foreach_;
+use PhpParser\Node\Stmt\Unset_;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\PhpParser\Node\Manipulator\AssignManipulator;
 use Rector\Core\Rector\AbstractRector;
@@ -157,6 +158,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($this->isArrayWithKeyValueNameUnsetted($node)) {
+            return null;
+        }
+
         $iteratedVariableSingle = $this->inflector->singularize($iteratedVariable);
         $foreach = $this->createForeach($node, $iteratedVariableSingle);
 
@@ -263,6 +268,18 @@ CODE_SAMPLE
                     $node->var->dim,
                     $this->keyValueName
                 );
+            }
+        );
+    }
+
+    private function isArrayWithKeyValueNameUnsetted(For_ $for): bool
+    {
+        return (bool) $this->betterNodeFinder->findFirst(
+            $for->stmts,
+            function (Node $node): bool {
+                /** @var Node|null $parent */
+                $parent = $node->getAttribute(AttributeKey::PARENT_NODE);
+                return $parent instanceof Unset_ && $node instanceof ArrayDimFetch;
             }
         );
     }

--- a/rules/code-quality/src/Rector/For_/ForToForeachRector.php
+++ b/rules/code-quality/src/Rector/For_/ForToForeachRector.php
@@ -308,11 +308,8 @@ CODE_SAMPLE
                 return null;
             }
 
-            if ($parentNode instanceof Arg) {
-                $parentNode = $parentNode->getAttribute(AttributeKey::PARENT_NODE);
-                if ($this->isFuncCallName($parentNode, 'count')) {
-                    return null;
-                }
+            if ($this->isArgParentCount($parentNode)) {
+                return null;
             }
 
             // is dim same as key value name, ...[$i]
@@ -322,6 +319,19 @@ CODE_SAMPLE
 
             return $singleValue;
         });
+    }
+
+    private function isArgParentCount(?Node $node): bool
+    {
+        if ($node instanceof Arg) {
+            /** @var Node $parentNode */
+            $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
+            if ($this->isFuncCallName($parentNode, 'count')) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/rules/code-quality/src/Rector/For_/ForToForeachRector.php
+++ b/rules/code-quality/src/Rector/For_/ForToForeachRector.php
@@ -277,7 +277,7 @@ CODE_SAMPLE
         return (bool) $this->betterNodeFinder->findFirst(
             $for->stmts,
             function (Node $node): bool {
-                /** @var Node|null $parent */
+                /** @var Node $parent */
                 $parent = $node->getAttribute(AttributeKey::PARENT_NODE);
                 return $parent instanceof Unset_ && $node instanceof ArrayDimFetch;
             }

--- a/rules/code-quality/tests/Rector/For_/ForToForeachRector/Fixture/dont_change_passed_count_arg_as_dimfetch.php.inc
+++ b/rules/code-quality/tests/Rector/For_/ForToForeachRector/Fixture/dont_change_passed_count_arg_as_dimfetch.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rector\CodeQuality\Tests\Rector\For_\ForToForeachRector\Fixture;
+
+class NestedFirstUsed
+{
+    public function run($tokens)
+    {
+        for ($i = 0, $c = count($tokens); $i < $c; $i++) {
+            for ($i2 = 0, $c2 = count($tokens[$i]); $i2 < $c2; $i2++) {
+                var_dump($tokens[$i]);
+            }
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CodeQuality\Tests\Rector\For_\ForToForeachRector\Fixture;
+
+class NestedFirstUsed
+{
+    public function run($tokens)
+    {
+        foreach ($tokens as $i => $token) {
+            for ($i2 = 0, $c2 = count($tokens[$i]); $i2 < $c2; $i2++) {
+                var_dump($token);
+            }
+        }
+    }
+}
+
+?>

--- a/rules/code-quality/tests/Rector/For_/ForToForeachRector/Fixture/skip_has_array_dim_fetch_in_assign_var.php.inc
+++ b/rules/code-quality/tests/Rector/For_/ForToForeachRector/Fixture/skip_has_array_dim_fetch_in_assign_var.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\CodeQuality\Tests\Rector\For_\ForToForeachRector\Fixture;
+
+class SkipHasArrayDimFetchInAssignVar
+{
+    public function run($tokens)
+    {
+        for ($i = 0, $c = count($tokens); $i < $c; $i++) {
+            $tokens[$i] = [];
+        }
+    }
+}
+
+?>

--- a/rules/code-quality/tests/Rector/For_/ForToForeachRector/Fixture/skip_unset.php.inc
+++ b/rules/code-quality/tests/Rector/For_/ForToForeachRector/Fixture/skip_unset.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\CodeQuality\Tests\Rector\For_\ForToForeachRector\Fixture;
+
+class SkipUnset
+{
+    public function run($tokens)
+    {
+        for ($i = 0, $c = count($tokens); $i < $c; $i++) {
+            unset($tokens[$i]);
+        }
+    }
+}
+
+?>


### PR DESCRIPTION
Got 2 more false positive on : 

- skip re-assign array with same key on for statements 
- do not change use array dim fetch in count($var)

This patch handle them.