### PR TITLE
create LostCommentBeforeElseIf failing test

### DIFF
--- a/rules/solid/src/Rector/If_/RemoveAlwaysElseRector.php
+++ b/rules/solid/src/Rector/If_/RemoveAlwaysElseRector.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\Node\Stmt\Throw_;
 use Rector\Core\Rector\AbstractRector;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -87,6 +88,8 @@ CODE_SAMPLE
             $node->cond = $firstElseIf->cond;
             $node->stmts = $firstElseIf->stmts;
 
+            $this->copyCommentIfExists($firstElseIf, $node);
+
             return $node;
         }
 
@@ -106,5 +109,11 @@ CODE_SAMPLE
             || $lastStmt instanceof Throw_
             || $lastStmt instanceof Continue_
             || ($lastStmt instanceof Expression && $lastStmt->expr instanceof Exit_));
+    }
+
+    private function copyCommentIfExists(Node $from, Node $to): void
+    {
+        $nodeComments = $from->getAttribute(AttributeKey::COMMENTS);
+        $to->setAttribute(AttributeKey::COMMENTS, $nodeComments);
     }
 }

--- a/rules/solid/tests/Rector/If_/RemoveAlwaysElseRector/Fixture/lost_comment_before_elseif.php.inc
+++ b/rules/solid/tests/Rector/If_/RemoveAlwaysElseRector/Fixture/lost_comment_before_elseif.php.inc
@@ -1,0 +1,53 @@
+<?php
+
+namespace Rector\SOLID\Tests\Rector\If_\RemoveAlwaysElse\Fixture;
+
+class LostCommentBeforeElseIf
+{
+    public function convert($data)
+    {
+        if (is_array($data)) {
+            $res = [];
+            foreach ($data as $key => $value) {
+                $res[$this->convert($key)] = $this->convert($value);
+            }
+
+            return $res;
+        }      
+        // because ASCII is a subset of all charset
+        elseif (is_string($data) && !empty($data) && !is_numeric($data) && 'ASCII' !== mb_detect_encoding($data)) {
+            $data = $this->convertString($data);
+        }
+
+        return $data;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\SOLID\Tests\Rector\If_\RemoveAlwaysElse\Fixture;
+
+class LostCommentBeforeElseIf
+{
+    public function convert($data)
+    {
+        if (is_array($data)) {
+            $res = [];
+            foreach ($data as $key => $value) {
+                $res[$this->convert($key)] = $this->convert($value);
+            }
+
+            return $res;
+        }      
+        // because ASCII is a subset of all charset
+        if (is_string($data) && !empty($data) && !is_numeric($data) && 'ASCII' !== mb_detect_encoding($data)) {
+            $data = $this->convertString($data);
+        }
+
+        return $data;
+    }
+}
+
+?>

--- a/rules/solid/tests/Rector/If_/RemoveAlwaysElseRector/Fixture/lost_comment_before_elseif.php.inc
+++ b/rules/solid/tests/Rector/If_/RemoveAlwaysElseRector/Fixture/lost_comment_before_elseif.php.inc
@@ -13,7 +13,7 @@ class LostCommentBeforeElseIf
             }
 
             return $res;
-        }      
+        }
         // because ASCII is a subset of all charset
         elseif (is_string($data) && !empty($data) && !is_numeric($data) && 'ASCII' !== mb_detect_encoding($data)) {
             $data = $this->convertString($data);
@@ -38,9 +38,8 @@ class LostCommentBeforeElseIf
             foreach ($data as $key => $value) {
                 $res[$this->convert($key)] = $this->convert($value);
             }
-
             return $res;
-        }      
+        }
         // because ASCII is a subset of all charset
         if (is_string($data) && !empty($data) && !is_numeric($data) && 'ASCII' !== mb_detect_encoding($data)) {
             $data = $this->convertString($data);


### PR DESCRIPTION
failing test for this demo case https://getrector.org/demo/d44f46a5-640d-48b2-bc50-eda86215f03f#result

the comment `// because ASCII is a subset of all charset` is lost in the process of `RemoveAlwaysElseRector`