### PR TITLE
[Downgrade PHP 7.1] feature/downgrade iterable pseudo type

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -4396,7 +4396,66 @@ Turns parent EntityRepository class to constructor dependency
 
 <br>
 
+<<<<<<< HEAD
 ### RemoveRedundantDefaultClassAnnotationValuesRector
+=======
+## DowngradeIterablePseudoTypeParamDeclarationRector
+
+Remove the iterable pseudo type params, add `@param` tags instead
+
+:wrench: **configure it!**
+
+- class: `Rector\DowngradePhp71\Rector\FunctionLike\DowngradeIterablePseudoTypeParamDeclarationRector`
+
+```php
+use Rector\DowngradePhp71\Rector\FunctionLike\DowngradeIterablePseudoTypeParamDeclarationRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->set(DowngradeIterablePseudoTypeParamDeclarationRector::class)
+        ->call('configure', [[
+            DowngradeIterablePseudoTypeParamDeclarationRector::ADD_DOC_BLOCK => true,
+        ]]);
+};
+```
+
+↓
+
+```diff
+ <?php
+
+ class SomeClass
+ {
+-    public function run(iterable $iterator)
++    /**
++     * @param mixed[]|\Traversable $iterator
++     */
++    public function run($iterator)
+     {
+         // do something
+     }
+ }
+```
+
+<br>
+
+## DowngradeNullableTypeReturnDeclarationRector
+
+Remove returning nullable types, add a `@return` tag instead
+
+:wrench: **configure it!**
+
+- class: `Rector\DowngradePhp71\Rector\FunctionLike\DowngradeNullableTypeReturnDeclarationRector`
+
+```php
+use Rector\DowngradePhp71\Rector\FunctionLike\DowngradeNullableTypeReturnDeclarationRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+>>>>>>> cc7b21f70... [Downgrade PHP 7.1] iterable pseudo-type
 
 Removes redundant default values from Doctrine ORM annotations on class level
 
@@ -4411,6 +4470,59 @@ Removes redundant default values from Doctrine ORM annotations on class level
   */
  class SomeClass
  {
+<<<<<<< HEAD
+=======
+-    public function getResponseOrNothing(bool $flag): ?string
++    /**
++     * @return string|null
++     */
++    public function getResponseOrNothing(bool $flag)
+     {
+        // do something
+     }
+ }
+```
+
+<br>
+
+## DowngradeNullableTypeReturnDeclarationRector
+
+Remove returning iterable pseudo type, add a `@return` tag instead
+
+:wrench: **configure it!**
+
+- class: `Rector\DowngradePhp71\Rector\FunctionLike\DowngradeIterablePseudoTypeReturnDeclarationRector`
+
+```php
+use Rector\DowngradePhp71\Rector\FunctionLike\DowngradeIterablePseudoTypeReturnDeclarationRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->set(DowngradeIterablePseudoTypeReturnDeclarationRector::class)
+        ->call('configure', [[
+            DowngradeIterablePseudoTypeReturnDeclarationRector::ADD_DOC_BLOCK => true,
+        ]]);
+};
+```
+
+↓
+
+```diff
+ <?php
+
+ class SomeClass
+ {
+-    public function run(): iterable
++    /**
++     * @return mixed[]|\Traversable
++     */
++    public function run($iterator)
+     {
+        // do something
+     }
+>>>>>>> cc7b21f70... [Downgrade PHP 7.1] iterable pseudo-type
  }
 ```
 

--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1,4 +1,6 @@
-# 625 Rules Overview
+# 626 Rules Overview
+
+<br>
 
 ## Categories
 
@@ -24,7 +26,7 @@
 
 - [DoctrineGedmoToKnplabs](#doctrinegedmotoknplabs) (7)
 
-- [DowngradePhp71](#downgradephp71) (4)
+- [DowngradePhp71](#downgradephp71) (6)
 
 - [DowngradePhp72](#downgradephp72) (2)
 
@@ -56,7 +58,7 @@
 
 - [Nette](#nette) (20)
 
-- [NetteCodeQuality](#nettecodequality) (6)
+- [NetteCodeQuality](#nettecodequality) (7)
 
 - [NetteKdyby](#nettekdyby) (4)
 
@@ -134,13 +136,15 @@
 
 - [SymfonyPHPUnit](#symfonyphpunit) (1)
 
-- [SymfonyPhpConfig](#symfonyphpconfig) (3)
+- [SymfonyPhpConfig](#symfonyphpconfig) (1)
 
 - [Transform](#transform) (12)
 
 - [Twig](#twig) (1)
 
 - [TypeDeclaration](#typedeclaration) (10)
+
+<br>
 
 ## Architecture
 
@@ -362,7 +366,7 @@ Moves array options to fluent setter method calls.
 use Rector\CakePHP\Rector\MethodCall\ArrayToFluentCallRector;
 use Rector\CakePHP\ValueObject\ArrayToFluentCall;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symplify\SymfonyPhpConfig\ValueObjectInliner::inline(s;
+use Symplify\SymfonyPhpConfig\ValueObjectInliner;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
@@ -4396,66 +4400,7 @@ Turns parent EntityRepository class to constructor dependency
 
 <br>
 
-<<<<<<< HEAD
 ### RemoveRedundantDefaultClassAnnotationValuesRector
-=======
-## DowngradeIterablePseudoTypeParamDeclarationRector
-
-Remove the iterable pseudo type params, add `@param` tags instead
-
-:wrench: **configure it!**
-
-- class: `Rector\DowngradePhp71\Rector\FunctionLike\DowngradeIterablePseudoTypeParamDeclarationRector`
-
-```php
-use Rector\DowngradePhp71\Rector\FunctionLike\DowngradeIterablePseudoTypeParamDeclarationRector;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $services = $containerConfigurator->services();
-
-    $services->set(DowngradeIterablePseudoTypeParamDeclarationRector::class)
-        ->call('configure', [[
-            DowngradeIterablePseudoTypeParamDeclarationRector::ADD_DOC_BLOCK => true,
-        ]]);
-};
-```
-
-↓
-
-```diff
- <?php
-
- class SomeClass
- {
--    public function run(iterable $iterator)
-+    /**
-+     * @param mixed[]|\Traversable $iterator
-+     */
-+    public function run($iterator)
-     {
-         // do something
-     }
- }
-```
-
-<br>
-
-## DowngradeNullableTypeReturnDeclarationRector
-
-Remove returning nullable types, add a `@return` tag instead
-
-:wrench: **configure it!**
-
-- class: `Rector\DowngradePhp71\Rector\FunctionLike\DowngradeNullableTypeReturnDeclarationRector`
-
-```php
-use Rector\DowngradePhp71\Rector\FunctionLike\DowngradeNullableTypeReturnDeclarationRector;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $services = $containerConfigurator->services();
->>>>>>> cc7b21f70... [Downgrade PHP 7.1] iterable pseudo-type
 
 Removes redundant default values from Doctrine ORM annotations on class level
 
@@ -4470,59 +4415,6 @@ Removes redundant default values from Doctrine ORM annotations on class level
   */
  class SomeClass
  {
-<<<<<<< HEAD
-=======
--    public function getResponseOrNothing(bool $flag): ?string
-+    /**
-+     * @return string|null
-+     */
-+    public function getResponseOrNothing(bool $flag)
-     {
-        // do something
-     }
- }
-```
-
-<br>
-
-## DowngradeNullableTypeReturnDeclarationRector
-
-Remove returning iterable pseudo type, add a `@return` tag instead
-
-:wrench: **configure it!**
-
-- class: `Rector\DowngradePhp71\Rector\FunctionLike\DowngradeIterablePseudoTypeReturnDeclarationRector`
-
-```php
-use Rector\DowngradePhp71\Rector\FunctionLike\DowngradeIterablePseudoTypeReturnDeclarationRector;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $services = $containerConfigurator->services();
-
-    $services->set(DowngradeIterablePseudoTypeReturnDeclarationRector::class)
-        ->call('configure', [[
-            DowngradeIterablePseudoTypeReturnDeclarationRector::ADD_DOC_BLOCK => true,
-        ]]);
-};
-```
-
-↓
-
-```diff
- <?php
-
- class SomeClass
- {
--    public function run(): iterable
-+    /**
-+     * @return mixed[]|\Traversable
-+     */
-+    public function run($iterator)
-     {
-        // do something
-     }
->>>>>>> cc7b21f70... [Downgrade PHP 7.1] iterable pseudo-type
  }
 ```
 
@@ -4929,6 +4821,90 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 +   const PUBLIC_CONST_B = 2;
 +   const PROTECTED_CONST = 3;
 +   const PRIVATE_CONST = 4;
+ }
+```
+
+<br>
+
+### DowngradeIterablePseudoTypeParamDeclarationRector
+
+Remove the iterable pseudo type params, add `@param` tags instead
+
+:wrench: **configure it!**
+
+- class: `Rector\DowngradePhp71\Rector\FunctionLike\DowngradeIterablePseudoTypeParamDeclarationRector`
+
+```php
+use Rector\DowngradePhp71\Rector\FunctionLike\DowngradeIterablePseudoTypeParamDeclarationRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->set(DowngradeIterablePseudoTypeParamDeclarationRector::class)
+        ->call('configure', [[
+            DowngradeIterablePseudoTypeParamDeclarationRector::ADD_DOC_BLOCK => true,
+        ]]);
+};
+```
+
+↓
+
+```diff
+ <?php
+
+ class SomeClass
+ {
+-    public function run(iterable $iterator)
++    /**
++     * @param mixed[]|\Traversable $iterator
++     */
++    public function run($iterator)
+     {
+         // do something
+     }
+ }
+```
+
+<br>
+
+### DowngradeIterablePseudoTypeReturnDeclarationRector
+
+Remove returning iterable pseud type, add a `@return` tag instead
+
+:wrench: **configure it!**
+
+- class: `Rector\DowngradePhp71\Rector\FunctionLike\DowngradeIterablePseudoTypeReturnDeclarationRector`
+
+```php
+use Rector\DowngradePhp71\Rector\FunctionLike\DowngradeIterablePseudoTypeReturnDeclarationRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->set(DowngradeIterablePseudoTypeReturnDeclarationRector::class)
+        ->call('configure', [[
+            DowngradeIterablePseudoTypeReturnDeclarationRector::ADD_DOC_BLOCK => true,
+        ]]);
+};
+```
+
+↓
+
+```diff
+ <?php
+
+ class SomeClass
+ {
+-    public function run(): iterable
++    /**
++     * @return mixed[]|\Traversable
++     */
++    public function run()
+     {
+         // do something
+     }
  }
 ```
 
@@ -8549,6 +8525,21 @@ Move `@inject` properties to constructor, if there already is one
 +        $this->someDependency = $someDependency;
      }
  }
+```
+
+<br>
+
+### SubstrMinusToStringEndsWithRector
+
+Change `substr` function with minus to `Strings::endsWith()`
+
+- class: `Rector\NetteCodeQuality\Rector\Identical\SubstrMinusToStringEndsWithRector`
+
+```diff
+-substr($var, -4) !== 'Test';
+-substr($var, -4) === 'Test';
++! \Nette\Utils\Strings::endsWith($var, 'Test');
++\Nette\Utils\Strings::endsWith($var, 'Test');
 ```
 
 <br>
@@ -15444,100 +15435,6 @@ Make sure there is `public(),` `autowire(),` `autoconfigure()` calls on `default
 
 <br>
 
-### ChangeServiceArgumentsToMethodCallRector
-
-Change `$service->arg(...)` to `$service->call(...)`
-
-:wrench: **configure it!**
-
-- class: `Rector\SymfonyPhpConfig\Rector\MethodCall\ChangeServiceArgumentsToMethodCallRector`
-
-```php
-use Rector\SymfonyPhpConfig\Rector\MethodCall\ChangeServiceArgumentsToMethodCallRector;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $services = $containerConfigurator->services();
-
-    $services->set(ChangeServiceArgumentsToMethodCallRector::class)
-        ->call('configure', [[
-            ChangeServiceArgumentsToMethodCallRector::CLASS_TYPE_TO_METHOD_NAME => [
-                'SomeClass' => 'configure',
-            ],
-        ]]);
-};
-```
-
-↓
-
-```diff
- use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-
- return static function (ContainerConfigurator $containerConfigurator): void {
-     $services = $containerConfigurator->services();
-
-     $services->set(SomeClass::class)
--        ->arg('$key', 'value');
-+        ->call('configure', [[
-+            '$key' => 'value
-+        ]]);
- }
-```
-
-<br>
-
-### ReplaceArrayWithObjectRector
-
-Replace complex array configuration in configs with value object
-
-:wrench: **configure it!**
-
-- class: `Rector\SymfonyPhpConfig\Rector\ArrayItem\ReplaceArrayWithObjectRector`
-
-```php
-use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
-use Rector\Renaming\ValueObject\MethodCallRename;
-use Rector\SymfonyPhpConfig\Rector\ArrayItem\ReplaceArrayWithObjectRector;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $services = $containerConfigurator->services();
-
-    $services->set(ReplaceArrayWithObjectRector::class)
-        ->call('configure', [[
-            ReplaceArrayWithObjectRector::CONSTANT_NAMES_TO_VALUE_OBJECTS => [
-                RenameMethodRector::OLD_TO_NEW_METHODS_BY_CLASS => MethodCallRename::class,
-            ],
-        ]]);
-};
-```
-
-↓
-
-```diff
- use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
- use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-
- return static function (ContainerConfigurator $containerConfigurator): void {
-     $services = $containerConfigurator->services();
-
-     $services->set(RenameMethodRector::class)
-         ->call('configure', [[
--            RenameMethodRector::OLD_TO_NEW_METHODS_BY_CLASS => [
--                'Illuminate\Auth\Access\Gate' => [
--                    'access' => 'inspect',
--                ]
--            ]]
--        ]);
-+            RenameMethodRector::OLD_TO_NEW_METHODS_BY_CLASS => \Symplify\SymfonyPhpConfig\ValueObjectInliner::inline([
-+                new \Rector\Renaming\ValueObject\MethodCallRename('Illuminate\Auth\Access\Gate', 'access', 'inspect'),
-+            ])
-+        ]]);
- }
-```
-
-<br>
-
 ## Transform
 
 ### ArgumentFuncCallToMethodCallRector
@@ -15786,7 +15683,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(NewToStaticCallRector::class)
         ->call('configure', [[
-            NewToStaticCallRector::TYPE_TO_STATIC_CALLS => ValueObjectInliner::inline([new NewToStaticCall('Cookie', 'Cookie', 'create')]),
+            NewToStaticCallRector::TYPE_TO_STATIC_CALLS => ValueObjectInliner::inline([
+                new NewToStaticCall('Cookie', 'Cookie', 'create'),
+            ]),
         ]]);
 };
 ```

--- a/rules/downgrade-php71/src/Rector/FunctionLike/AbstractDowngradeParamDeclarationRector.php
+++ b/rules/downgrade-php71/src/Rector/FunctionLike/AbstractDowngradeParamDeclarationRector.php
@@ -9,9 +9,14 @@ use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
+use PHPStan\Type\IntersectionType;
+use PHPStan\Type\IterableType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\UnionType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\DowngradePhp71\Contract\Rector\DowngradeParamDeclarationRectorInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
+use Traversable;
 
 abstract class AbstractDowngradeParamDeclarationRector extends AbstractDowngradeRector implements DowngradeParamDeclarationRectorInterface
 {
@@ -58,6 +63,11 @@ abstract class AbstractDowngradeParamDeclarationRector extends AbstractDowngrade
 
             if ($param->type !== null) {
                 $type = $this->staticTypeMapper->mapPhpParserNodePHPStanType($param->type);
+
+                if ($type instanceof IterableType) {
+                    $type = new UnionType([$type, new IntersectionType([new ObjectType(Traversable::class)])]);
+                }
+
                 $paramName = $this->getName($param->var) ?? '';
                 $phpDocInfo->changeParamType($type, $param, $paramName);
             }

--- a/rules/downgrade-php71/src/Rector/FunctionLike/AbstractDowngradeReturnDeclarationRector.php
+++ b/rules/downgrade-php71/src/Rector/FunctionLike/AbstractDowngradeReturnDeclarationRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\DowngradePhp71\Rector\FunctionLike;
 
 use PhpParser\Node;
+use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use PHPStan\Type\IntersectionType;
@@ -44,19 +45,22 @@ abstract class AbstractDowngradeReturnDeclarationRector extends AbstractDowngrad
         return $node;
     }
 
-    private function addDocBlockReturn(ClassMethod $classMethod): void
+    /**
+     * @param ClassMethod|Function_ $functionLike
+     */
+    private function addDocBlockReturn(FunctionLike $functionLike): void
     {
         /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $classMethod->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $functionLike->getAttribute(AttributeKey::PHP_DOC_INFO);
         if ($phpDocInfo === null) {
-            $phpDocInfo = $this->phpDocInfoFactory->createEmpty($classMethod);
+            $phpDocInfo = $this->phpDocInfoFactory->createEmpty($functionLike);
         }
 
-        if ($classMethod->returnType === null) {
+        if ($functionLike->returnType === null) {
             return;
         }
 
-        $type = $this->staticTypeMapper->mapPhpParserNodePHPStanType($classMethod->returnType);
+        $type = $this->staticTypeMapper->mapPhpParserNodePHPStanType($functionLike->returnType);
         if ($type instanceof IterableType) {
             $type = new UnionType([$type, new IntersectionType([new ObjectType(Traversable::class)])]);
         }

--- a/rules/downgrade-php71/src/Rector/FunctionLike/AbstractDowngradeReturnDeclarationRector.php
+++ b/rules/downgrade-php71/src/Rector/FunctionLike/AbstractDowngradeReturnDeclarationRector.php
@@ -36,25 +36,31 @@ abstract class AbstractDowngradeReturnDeclarationRector extends AbstractDowngrad
         }
 
         if ($this->addDocBlock) {
-            /** @var PhpDocInfo|null $phpDocInfo */
-            $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
-            if ($phpDocInfo === null) {
-                $phpDocInfo = $this->phpDocInfoFactory->createEmpty($node);
-            }
-
-            if ($node->returnType !== null) {
-                $type = $this->staticTypeMapper->mapPhpParserNodePHPStanType($node->returnType);
-
-                if ($type instanceof IterableType) {
-                    $type = new UnionType([$type, new IntersectionType([new ObjectType(Traversable::class)])]);
-                }
-
-                $phpDocInfo->changeReturnType($type);
-            }
+            $this->addDocBlockReturn($node);
         }
 
         $node->returnType = null;
 
         return $node;
+    }
+
+    private function addDocBlockReturn(ClassMethod $classMethod): void
+    {
+        /** @var PhpDocInfo|null $phpDocInfo */
+        $phpDocInfo = $classMethod->getAttribute(AttributeKey::PHP_DOC_INFO);
+        if ($phpDocInfo === null) {
+            $phpDocInfo = $this->phpDocInfoFactory->createEmpty($classMethod);
+        }
+
+        if ($classMethod->returnType === null) {
+            return;
+        }
+
+        $type = $this->staticTypeMapper->mapPhpParserNodePHPStanType($classMethod->returnType);
+        if ($type instanceof IterableType) {
+            $type = new UnionType([$type, new IntersectionType([new ObjectType(Traversable::class)])]);
+        }
+
+        $phpDocInfo->changeReturnType($type);
     }
 }

--- a/rules/downgrade-php71/src/Rector/FunctionLike/AbstractDowngradeReturnDeclarationRector.php
+++ b/rules/downgrade-php71/src/Rector/FunctionLike/AbstractDowngradeReturnDeclarationRector.php
@@ -7,9 +7,14 @@ namespace Rector\DowngradePhp71\Rector\FunctionLike;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
+use PHPStan\Type\IntersectionType;
+use PHPStan\Type\IterableType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\UnionType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\DowngradePhp71\Contract\Rector\DowngradeReturnDeclarationRectorInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
+use Traversable;
 
 abstract class AbstractDowngradeReturnDeclarationRector extends AbstractDowngradeRector implements DowngradeReturnDeclarationRectorInterface
 {
@@ -39,6 +44,11 @@ abstract class AbstractDowngradeReturnDeclarationRector extends AbstractDowngrad
 
             if ($node->returnType !== null) {
                 $type = $this->staticTypeMapper->mapPhpParserNodePHPStanType($node->returnType);
+
+                if ($type instanceof IterableType) {
+                    $type = new UnionType([$type, new IntersectionType([new ObjectType(Traversable::class)])]);
+                }
+
                 $phpDocInfo->changeReturnType($type);
             }
         }

--- a/rules/downgrade-php71/src/Rector/FunctionLike/DowngradeIterablePseudoTypeParamDeclarationRector.php
+++ b/rules/downgrade-php71/src/Rector/FunctionLike/DowngradeIterablePseudoTypeParamDeclarationRector.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp71\Rector\FunctionLike;
+
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Param;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\DowngradePhp71\Tests\Rector\FunctionLike\DowngradeIterablePseudoTypeParamDeclarationRector\DowngradeIterablePseudoTypeParamDeclarationRectorTest
+ */
+final class DowngradeIterablePseudoTypeParamDeclarationRector extends AbstractDowngradeParamDeclarationRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Remove the iterable pseudo type params, add @param tags instead',
+            [
+                new ConfiguredCodeSample(
+                    <<<'CODE_SAMPLE'
+<?php
+
+class SomeClass
+{
+    public function run(iterable $iterator)
+    {
+        // do something
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+<?php
+
+class SomeClass
+{
+    /**
+     * @param mixed[]|\Traversable $iterator
+     */
+    public function run($iterator)
+    {
+        // do something
+    }
+}
+CODE_SAMPLE
+,
+                    [
+                        self::ADD_DOC_BLOCK => true,
+                    ]
+                ),
+            ]
+        );
+    }
+
+    public function shouldRemoveParamDeclaration(Param $param): bool
+    {
+        if ($param->type === null) {
+            return false;
+        }
+
+        return $param->type instanceof Identifier && $param->type->toString() === 'iterable';
+    }
+}

--- a/rules/downgrade-php71/src/Rector/FunctionLike/DowngradeIterablePseudoTypeReturnDeclarationRector.php
+++ b/rules/downgrade-php71/src/Rector/FunctionLike/DowngradeIterablePseudoTypeReturnDeclarationRector.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp71\Rector\FunctionLike;
+
+use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\DowngradePhp71\Tests\Rector\FunctionLike\DowngradeNullableTypeReturnDeclarationRector\DowngradeNullableTypeReturnDeclarationRectorTest
+ */
+final class DowngradeIterablePseudoTypeReturnDeclarationRector extends AbstractDowngradeReturnDeclarationRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Remove returning iterable pseud type, add a @return tag instead',
+            [
+                new ConfiguredCodeSample(
+                    <<<'CODE_SAMPLE'
+<?php
+
+class SomeClass
+{
+    public function run(): iterable
+    {
+        // do something
+    }
+}
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+<?php
+
+class SomeClass
+{
+    /**
+     * @return mixed[]|\Traversable
+     */
+    public function run()
+    {
+        // do something
+    }
+}
+CODE_SAMPLE
+,
+                    [
+                        self::ADD_DOC_BLOCK => true,
+                    ]
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @param ClassMethod|Function_ $functionLike
+     */
+    public function shouldRemoveReturnDeclaration(FunctionLike $functionLike): bool
+    {
+        if ($functionLike->returnType === null) {
+            return false;
+        }
+
+        return $functionLike->returnType instanceof Identifier && $functionLike->returnType->toString() === 'iterable';
+    }
+}

--- a/rules/downgrade-php71/src/Rector/FunctionLike/DowngradeIterablePseudoTypeReturnDeclarationRector.php
+++ b/rules/downgrade-php71/src/Rector/FunctionLike/DowngradeIterablePseudoTypeReturnDeclarationRector.php
@@ -11,7 +11,7 @@ use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
- * @see \Rector\DowngradePhp71\Tests\Rector\FunctionLike\DowngradeNullableTypeReturnDeclarationRector\DowngradeNullableTypeReturnDeclarationRectorTest
+ * @see \Rector\DowngradePhp71\Tests\Rector\FunctionLike\DowngradeIterablePseudoTypeReturnDeclarationRector\DowngradeIterablePseudoTypeReturnDeclarationRectorTest
  */
 final class DowngradeIterablePseudoTypeReturnDeclarationRector extends AbstractDowngradeReturnDeclarationRector
 {

--- a/rules/downgrade-php71/src/Rector/FunctionLike/DowngradeIterablePseudoTypeReturnDeclarationRector.php
+++ b/rules/downgrade-php71/src/Rector/FunctionLike/DowngradeIterablePseudoTypeReturnDeclarationRector.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\DowngradePhp71\Rector\FunctionLike;
 
 use PhpParser\Node\FunctionLike;
-use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
@@ -62,10 +61,12 @@ CODE_SAMPLE
      */
     public function shouldRemoveReturnDeclaration(FunctionLike $functionLike): bool
     {
-        if ($functionLike->returnType === null) {
+        $functionLikeReturnType = $functionLike->returnType;
+
+        if ($functionLikeReturnType === null) {
             return false;
         }
 
-        return $functionLike->returnType instanceof Identifier && $functionLike->returnType->toString() === 'iterable';
+        return $this->isName($functionLikeReturnType, 'iterable');
     }
 }

--- a/rules/downgrade-php71/tests/Rector/FunctionLike/DowngradeIterablePseudoTypeParamDeclarationRector/DowngradeIterablePseudoTypeParamDeclarationRectorTest.php
+++ b/rules/downgrade-php71/tests/Rector/FunctionLike/DowngradeIterablePseudoTypeParamDeclarationRector/DowngradeIterablePseudoTypeParamDeclarationRectorTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp71\Tests\Rector\FunctionLike\DowngradeIterablePseudoTypeParamDeclarationRector;
+
+use Iterator;
+use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\DowngradePhp71\Rector\FunctionLike\DowngradeIterablePseudoTypeParamDeclarationRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class DowngradeIterablePseudoTypeParamDeclarationRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    protected function getRectorClass(): string
+    {
+        return DowngradeIterablePseudoTypeParamDeclarationRector::class;
+    }
+
+    protected function getPhpVersion(): string
+    {
+        return PhpVersionFeature::BEFORE_ITERABLE_TYPE;
+    }
+}

--- a/rules/downgrade-php71/tests/Rector/FunctionLike/DowngradeIterablePseudoTypeParamDeclarationRector/DowngradeIterablePseudoTypeParamDeclarationRectorTest.php
+++ b/rules/downgrade-php71/tests/Rector/FunctionLike/DowngradeIterablePseudoTypeParamDeclarationRector/DowngradeIterablePseudoTypeParamDeclarationRectorTest.php
@@ -30,8 +30,8 @@ final class DowngradeIterablePseudoTypeParamDeclarationRectorTest extends Abstra
         return DowngradeIterablePseudoTypeParamDeclarationRector::class;
     }
 
-    protected function getPhpVersion(): string
+    protected function getPhpVersion(): int
     {
-        return PhpVersionFeature::BEFORE_ITERABLE_TYPE;
+        return PhpVersionFeature::ITERABLE_TYPE - 1;
     }
 }

--- a/rules/downgrade-php71/tests/Rector/FunctionLike/DowngradeIterablePseudoTypeParamDeclarationRector/Fixture/fixture.php.inc
+++ b/rules/downgrade-php71/tests/Rector/FunctionLike/DowngradeIterablePseudoTypeParamDeclarationRector/Fixture/fixture.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\DowngradePhp71\Tests\Rector\FunctionLike\DowngradeIterablePseudoTypeParamDeclarationRector\Fixture;
+
+class SomeClass
+{
+    public function run(iterable $iterator)
+    {
+        // do something
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\DowngradePhp71\Tests\Rector\FunctionLike\DowngradeIterablePseudoTypeParamDeclarationRector\Fixture;
+
+class SomeClass
+{
+    /**
+     * @param mixed[]|\Traversable $iterator
+     */
+    public function run($iterator)
+    {
+        // do something
+    }
+}
+
+?>

--- a/rules/downgrade-php71/tests/Rector/FunctionLike/DowngradeIterablePseudoTypeReturnDeclarationRector/DowngradeIterablePseudoTypeReturnDeclarationRectorTest.php
+++ b/rules/downgrade-php71/tests/Rector/FunctionLike/DowngradeIterablePseudoTypeReturnDeclarationRector/DowngradeIterablePseudoTypeReturnDeclarationRectorTest.php
@@ -30,8 +30,8 @@ final class DowngradeIterablePseudoTypeReturnDeclarationRectorTest extends Abstr
         return DowngradeIterablePseudoTypeReturnDeclarationRector::class;
     }
 
-    protected function getPhpVersion(): string
+    protected function getPhpVersion(): int
     {
-        return PhpVersionFeature::BEFORE_ITERABLE_TYPE;
+        return PhpVersionFeature::ITERABLE_TYPE - 1;
     }
 }

--- a/rules/downgrade-php71/tests/Rector/FunctionLike/DowngradeIterablePseudoTypeReturnDeclarationRector/DowngradeIterablePseudoTypeReturnDeclarationRectorTest.php
+++ b/rules/downgrade-php71/tests/Rector/FunctionLike/DowngradeIterablePseudoTypeReturnDeclarationRector/DowngradeIterablePseudoTypeReturnDeclarationRectorTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp71\Tests\Rector\FunctionLike\DowngradeIterablePseudoTypeReturnDeclarationRector;
+
+use Iterator;
+use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\DowngradePhp71\Rector\FunctionLike\DowngradeIterablePseudoTypeReturnDeclarationRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class DowngradeIterablePseudoTypeReturnDeclarationRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    protected function getRectorClass(): string
+    {
+        return DowngradeIterablePseudoTypeReturnDeclarationRector::class;
+    }
+
+    protected function getPhpVersion(): string
+    {
+        return PhpVersionFeature::BEFORE_ITERABLE_TYPE;
+    }
+}

--- a/rules/downgrade-php71/tests/Rector/FunctionLike/DowngradeIterablePseudoTypeReturnDeclarationRector/Fixture/fixture.php.inc
+++ b/rules/downgrade-php71/tests/Rector/FunctionLike/DowngradeIterablePseudoTypeReturnDeclarationRector/Fixture/fixture.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\DowngradePhp71\Tests\Rector\FunctionLike\DowngradeIterablePseudoTypeReturnDeclarationRector\Fixture;
+
+class SomeClass
+{
+    public function run(): iterable
+    {
+        // do something
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\DowngradePhp71\Tests\Rector\FunctionLike\DowngradeIterablePseudoTypeReturnDeclarationRector\Fixture;
+
+class SomeClass
+{
+    /**
+     * @return mixed[]|\Traversable
+     */
+    public function run()
+    {
+        // do something
+    }
+}
+
+?>


### PR DESCRIPTION
Rebase of https://github.com/rectorphp/rector/pull/4649

- [Downgrade PHP 7.1] iterable pseudo-type
- fix PHP version type
