### PR TITLE
make sure we don't get a diff in which every line is different

### DIFF
--- a/packages/testing/src/PHPUnit/AbstractRectorTestCase.php
+++ b/packages/testing/src/PHPUnit/AbstractRectorTestCase.php
@@ -479,9 +479,16 @@ abstract class AbstractRectorTestCase extends AbstractKernelTestCase
             StaticFixtureUpdater::updateFixtureContent($originalFileInfo, $changedContent, $fixtureFileInfo);
             $contents = $expectedFileInfo->getContents();
 
+            // make sure we don't get a diff in which every line is different (because of differences in EOL)
+            $contents = $this->normalizeNewlines($contents);
+
             // if not exact match, check the regex version (useful for generated hashes/uuids in the code)
             $this->assertStringMatchesFormat($contents, $changedContent, $relativeFilePathFromCwd);
         }
+    }
+
+    private function normalizeNewlines(string $string):string {
+        return preg_replace('/\r\n|\r|\n/', "\n", $string);
     }
 
     private function createContainerWithAllRectors(): void


### PR DESCRIPTION
.. because of differences in EOL. Fixes phpunit DIFFs when test fail on Windows.

closes https://github.com/rectorphp/rector/issues/4712

**Diff-Format before this PR:**
```diff
There was 1 failure:

1) Rector\SOLID\Tests\Rector\If_\RemoveAlwaysElseRector\RemoveAlwaysElseRectorTest::test with data set #7 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
rules/solid/tests/Rector/If_/RemoveAlwaysElseRector/Fixture/lost_comment_before_elseif.php.inc
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
 #Warning: Strings contain different line endings!
-<?php
-
-namespace Rector\SOLID\Tests\Rector\If_\RemoveAlwaysElse\Fixture;
-
-class LostCommentBeforeElseIf
-{
-    public function convert($data)
-    {
-        if (is_array($data)) {
-            $res = [];
-            foreach ($data as $key => $value) {
-                $res[$this->convert($key)] = $this->convert($value);
-            }
-            return $res;
-        }
-        // because ASCII is a subset of all charset
-        if (is_string($data) && !empty($data) && !is_numeric($data) && 'ASCII' !== mb_detect_encoding($data)) {
-            $data = $this->convertString($data);
-        }
-
-        return $data;
-    }
-}
-
-?>
+<?php
+
+namespace Rector\SOLID\Tests\Rector\If_\RemoveAlwaysElse\Fixture;
+
+class LostCommentBeforeElseIf
+{
+    public function convert($data)
+    {
+        if (is_array($data)) {
+            $res = [];
+            foreach ($data as $key => $value) {
+                $res[$this->convert($key)] = $this->convert($value);
+            }
+            return $res;
+        }
+        if (is_string($data) && !empty($data) && !is_numeric($data) && 'ASCII' !== mb_detect_encoding($data)) {
+            $data = $this->convertString($data);
+        }
+
+        return $data;
+    }
+}
+
+?>

C:\dvl\GitHub\rector\packages\testing\src\PHPUnit\AbstractRectorTestCase.php:483
C:\dvl\GitHub\rector\packages\testing\src\PHPUnit\AbstractRectorTestCase.php:308
C:\dvl\GitHub\rector\rules\solid\tests\Rector\If_\RemoveAlwaysElseRector\RemoveAlwaysElseRectorTest.php:19
```

**Diff format after this PR:**
```diff
There was 1 failure:

1) Rector\SOLID\Tests\Rector\If_\RemoveAlwaysElseRector\RemoveAlwaysElseRectorTest::test with data set #7 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
rules/solid/tests/Rector/If_/RemoveAlwaysElseRector/Fixture/lost_comment_before_elseif.php.inc
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
             }
             return $res;
         }
-        // because ASCII is a subset of all charset
         if (is_string($data) && !empty($data) && !is_numeric($data) && 'ASCII' !== mb_detect_encoding($data)) {
             $data = $this->convertString($data);
         }

C:\dvl\GitHub\rector\packages\testing\src\PHPUnit\AbstractRectorTestCase.php:486
C:\dvl\GitHub\rector\packages\testing\src\PHPUnit\AbstractRectorTestCase.php:308
C:\dvl\GitHub\rector\rules\solid\tests\Rector\If_\RemoveAlwaysElseRector\RemoveAlwaysElseRectorTest.php:19
```