### PR TITLE
Add issue labels to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1_Bug_report.md
@@ -1,5 +1,6 @@
 ---
 name: Bug Report
+labels: bug
 about: Report errors and problems
 ---
 

--- a/.github/ISSUE_TEMPLATE/2_Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/2_Feature_request.md
@@ -1,5 +1,6 @@
 ---
 name: Feature Request
+labels: feature
 about: RFC and ideas for new features and improvements
 ---
 

--- a/.github/ISSUE_TEMPLATE/3_Support_question.md
+++ b/.github/ISSUE_TEMPLATE/3_Support_question.md
@@ -1,5 +1,6 @@
 ---
 name: Support Question
+labels: support
 about: Questions about using this library
 ---
 


### PR DESCRIPTION
With this PR issue templates are adjusted to automatically preselect issue-labels.

That way issues get some basic categorization and should be easier to navigate.
Its not exactly what was requested in #4705 but its a start which does not need big maintenance efforts

Refs https://github.com/rectorphp/rector/issues/4705