### PR TITLE
fix rector autoload when used as a global dependency

### DIFF
--- a/bin/rector.php
+++ b/bin/rector.php
@@ -30,6 +30,7 @@ $autoloadIncluder = new AutoloadIncluder();
 $autoloadIncluder->includeCwdVendorAutoloadIfExists();
 $autoloadIncluder->autoloadProjectAutoloaderFile();
 $autoloadIncluder->includeDependencyOrRepositoryVendorAutoloadIfExists();
+$autoloadIncluder->autoloadComposerGlobalAutoloaerIfExists();
 $autoloadIncluder->autoloadFromCommandLine();
 
 $symfonyStyleFactory = new SymfonyStyleFactory(new PrivatesCaller());
@@ -102,6 +103,14 @@ final class AutoloadIncluder
      * this autoloads the project vendor/autoload.php, including Rector
      */
     public function autoloadProjectAutoloaderFile(): void
+    {
+        $this->loadIfExistsAndNotLoadedYet(__DIR__ . '/../../autoload.php');
+    }
+
+    /**
+     * Experimental: In case Rector is installed as global composer dependency
+     */
+    public function autoloadComposerGlobalAutoloaerIfExists(): void
     {
         $this->loadIfExistsAndNotLoadedYet(__DIR__ . '/../../../autoload.php');
     }

--- a/bin/rector.php
+++ b/bin/rector.php
@@ -103,7 +103,7 @@ final class AutoloadIncluder
      */
     public function autoloadProjectAutoloaderFile(): void
     {
-        $this->loadIfExistsAndNotLoadedYet(__DIR__ . '/../../autoload.php');
+        $this->loadIfExistsAndNotLoadedYet(__DIR__ . '/../../../autoload.php');
     }
 
     public function autoloadFromCommandLine(): void


### PR DESCRIPTION
like in other tools which work with the autoloader in global space, we need to use a proper path:

example https://github.com/sabre-io/dav/blob/d596e2b49cfc9cee27628fc52adb194502607af4/bin/sabredav.php#L28-L38

closes https://github.com/rectorphp/rector/issues/4725