### PR TITLE
[DX] Fixes #4724 Filename too long, rename ChangeQuerySetParametersMethodParameterFromArrayToArrayCollectionRector to ChangeSetParametersArrayToArrayCollectionRector

### DIFF
--- a/rules/doctrine-code-quality/src/Rector/MethodCall/ChangeSetParametersArrayToArrayCollectionRector.php
+++ b/rules/doctrine-code-quality/src/Rector/MethodCall/ChangeSetParametersArrayToArrayCollectionRector.php
@@ -20,9 +20,9 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @see https://github.com/doctrine/orm/blob/2.7/UPGRADE.md#query-querybuilder-and-nativequery-parameters-bc-break
- * @see \Rector\DoctrineCodeQuality\Tests\Rector\MethodCall\ChangeQuerySetParametersMethodParameterFromArrayToArrayCollectionRector\ChangeQuerySetParametersMethodParameterFromArrayToArrayCollectionRectorTest
+ * @see \Rector\DoctrineCodeQuality\Tests\Rector\MethodCall\ChangeSetParametersArrayToArrayCollectionRector\ChangeSetParametersArrayToArrayCollectionRectorTest
  */
-final class ChangeQuerySetParametersMethodParameterFromArrayToArrayCollectionRector extends AbstractRector
+final class ChangeSetParametersArrayToArrayCollectionRector extends AbstractRector
 {
     /**
      * @return string[]

--- a/rules/doctrine-code-quality/tests/Rector/MethodCall/ChangeSetParametersArrayToArrayCollectionRector/ChangeSetParametersArrayToArrayCollectionRectorTest.php
+++ b/rules/doctrine-code-quality/tests/Rector/MethodCall/ChangeSetParametersArrayToArrayCollectionRector/ChangeSetParametersArrayToArrayCollectionRectorTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Rector\DoctrineCodeQuality\Tests\Rector\MethodCall\ChangeQuerySetParametersMethodParameterFromArrayToArrayCollectionRector;
+namespace Rector\DoctrineCodeQuality\Tests\Rector\MethodCall\ChangeSetParametersArrayToArrayCollectionRector;
 
 use Iterator;
-use Rector\DoctrineCodeQuality\Rector\MethodCall\ChangeQuerySetParametersMethodParameterFromArrayToArrayCollectionRector;
+use Rector\DoctrineCodeQuality\Rector\MethodCall\ChangeSetParametersArrayToArrayCollectionRector;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
-final class ChangeQuerySetParametersMethodParameterFromArrayToArrayCollectionRectorTest extends AbstractRectorTestCase
+final class ChangeSetParametersArrayToArrayCollectionRectorTest extends AbstractRectorTestCase
 {
     /**
      * @dataProvider provideData()
@@ -26,6 +26,6 @@ final class ChangeQuerySetParametersMethodParameterFromArrayToArrayCollectionRec
 
     protected function getRectorClass(): string
     {
-        return ChangeQuerySetParametersMethodParameterFromArrayToArrayCollectionRector::class;
+        return ChangeSetParametersArrayToArrayCollectionRector::class;
     }
 }

--- a/rules/doctrine-code-quality/tests/Rector/MethodCall/ChangeSetParametersArrayToArrayCollectionRector/Fixture/extends_entity_repository.php.inc
+++ b/rules/doctrine-code-quality/tests/Rector/MethodCall/ChangeSetParametersArrayToArrayCollectionRector/Fixture/extends_entity_repository.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\DoctrineCodeQuality\Tests\Rector\MethodCall\ChangeQuerySetParametersMethodParameterFromArrayToArrayCollectionRector\Fixture;
+namespace Rector\DoctrineCodeQuality\Tests\Rector\MethodCall\ChangeSetParametersArrayToArrayCollectionRector\Fixture;
 
 use Doctrine\ORM\EntityRepository;
 
@@ -24,7 +24,7 @@ class SomeRepository extends EntityRepository
 -----
 <?php
 
-namespace Rector\DoctrineCodeQuality\Tests\Rector\MethodCall\ChangeQuerySetParametersMethodParameterFromArrayToArrayCollectionRector\Fixture;
+namespace Rector\DoctrineCodeQuality\Tests\Rector\MethodCall\ChangeSetParametersArrayToArrayCollectionRector\Fixture;
 
 use Doctrine\ORM\EntityRepository;
 


### PR DESCRIPTION
Before : 71 chars, after: 47 chars.

```bash
php > echo strlen('ChangeQuerySetParametersMethodParameterFromArrayToArrayCollectionRector');
71
php > echo strlen('ChangeSetParametersArrayToArrayCollectionRector');
47
```