### PR TITLE
remove double `**` glob to speedup bootstrapping

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -7,8 +7,8 @@ use Rector\Core\ValueObject\ProjectType;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
-    $containerConfigurator->import(__DIR__ . '/../packages/*/config/config.*');
-    $containerConfigurator->import(__DIR__ . '/../rules/*/config/config.*');
+    $containerConfigurator->import(__DIR__ . '/../packages/*/config/config.php');
+    $containerConfigurator->import(__DIR__ . '/../rules/*/config/config.php');
     $containerConfigurator->import(__DIR__ . '/services.php');
     $containerConfigurator->import(__DIR__ . '/../utils/*/config/config.php', null, true);
 

--- a/config/config.php
+++ b/config/config.php
@@ -7,10 +7,10 @@ use Rector\Core\ValueObject\ProjectType;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
-    $containerConfigurator->import(__DIR__ . '/../packages/**/config/config.*');
-    $containerConfigurator->import(__DIR__ . '/../rules/**/config/config.*');
+    $containerConfigurator->import(__DIR__ . '/../packages/*/config/config.*');
+    $containerConfigurator->import(__DIR__ . '/../rules/*/config/config.*');
     $containerConfigurator->import(__DIR__ . '/services.php');
-    $containerConfigurator->import(__DIR__ . '/../utils/**/config/config.php', null, true);
+    $containerConfigurator->import(__DIR__ . '/../utils/*/config/config.php', null, true);
 
     $parameters = $containerConfigurator->parameters();
 


### PR DESCRIPTION
with this change a `php bin/rector` on my machine finishes in ~13 seconds instead of ~50 seconds.
blackfire shows a 70% performance improvement

![grafik](https://user-images.githubusercontent.com/120441/100777863-9f2e6c80-3406-11eb-8e8a-7ed82d68b0c4.png)

refs https://github.com/rectorphp/rector/issues/4723

I did very rough testing, by e.g. compare the result of `php bin/rector dump-nodes` before/after the PR.
this did not show any issues. lets see what CI thinks about such a change.