### PR TITLE
Fix CallTypeAnalyzer when methodName is null

### DIFF
--- a/rules/generic/src/NodeTypeAnalyzer/CallTypeAnalyzer.php
+++ b/rules/generic/src/NodeTypeAnalyzer/CallTypeAnalyzer.php
@@ -83,6 +83,10 @@ final class CallTypeAnalyzer
         /** @var string $methodName */
         $methodName = $this->nodeNameResolver->getName($node->name);
 
+        if (! $methodName) {
+            return [];
+        }
+
         $scope = $node->getAttribute(AttributeKey::SCOPE);
         if (! $scope instanceof Scope) {
             return [];

--- a/rules/generic/src/NodeTypeAnalyzer/CallTypeAnalyzer.php
+++ b/rules/generic/src/NodeTypeAnalyzer/CallTypeAnalyzer.php
@@ -80,7 +80,6 @@ final class CallTypeAnalyzer
     {
         $classReflection = $this->reflectionProvider->getClass($className);
 
-        /** @var string $methodName */
         $methodName = $this->nodeNameResolver->getName($node->name);
 
         if (! $methodName) {


### PR DESCRIPTION
Argument 1 passed to PHPStan\Reflection\ClassReflection::hasMethod() must be of the type string, null given

Happens when I have this code:

```
protected function createFormControl(Container $form): IControl
{
    $method = 'add' . ucfirst($this->type);
    $control = $form->$method($this->getKey(), $this->getTitle(), $this->multiple);
    return $control;
}
```

Probably all $foo->$bar calls fails on this