### PR TITLE
Donwgrade PHP 7.4: Added covariant rule to set

### DIFF
--- a/config/set/downgrade-php74.php
+++ b/config/set/downgrade-php74.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Rector\Downgrade\Rector\LNumber\ChangePhpVersionInPlatformCheckRector;
 use Rector\DowngradePhp74\Rector\Array_\DowngradeArraySpreadRector;
 use Rector\DowngradePhp74\Rector\ArrowFunction\ArrowFunctionToAnonymousFunctionRector;
+use Rector\DowngradePhp74\Rector\ClassMethod\DowngradeCovarianReturnTypeRector;
 use Rector\DowngradePhp74\Rector\Coalesce\DowngradeNullCoalescingOperatorRector;
 use Rector\DowngradePhp74\Rector\FuncCall\DowngradeArrayMergeCallWithoutArgumentsRector;
 use Rector\DowngradePhp74\Rector\FuncCall\DowngradeStripTagsCallWithArrayRector;
@@ -16,6 +17,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
     $services->set(DowngradeTypedPropertyRector::class);
     $services->set(ArrowFunctionToAnonymousFunctionRector::class);
+    $services->set(DowngradeCovarianReturnTypeRector::class);
     $services->set(DowngradeNullCoalescingOperatorRector::class);
     $services->set(DowngradeNumericLiteralSeparatorRector::class);
     $services->set(DowngradeStripTagsCallWithArrayRector::class);


### PR DESCRIPTION
I forgot to add the new rule `DowngradeCovarianReturnTypeRector` to the `downgrade-php74` set on PR #4755 (published yesterday). Fixed now