### PR TITLE
Added tests for samples - proof of concept

### DIFF
--- a/rules/code-quality/src/Rector/Assign/CombinedAssignRector.php
+++ b/rules/code-quality/src/Rector/Assign/CombinedAssignRector.php
@@ -17,6 +17,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class CombinedAssignRector extends AbstractRector
 {
+    public $testSamples = true;
+
     /**
      * @var AssignAndBinaryMap
      */

--- a/rules/code-quality/src/Rector/Catch_/ThrowWithPreviousExceptionRector.php
+++ b/rules/code-quality/src/Rector/Catch_/ThrowWithPreviousExceptionRector.php
@@ -29,6 +29,8 @@ use Throwable;
  */
 final class ThrowWithPreviousExceptionRector extends AbstractRector
 {
+    public $testSamples = true;
+
     /**
      * @var int
      */

--- a/rules/code-quality/src/Rector/Concat/JoinStringConcatRector.php
+++ b/rules/code-quality/src/Rector/Concat/JoinStringConcatRector.php
@@ -18,6 +18,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class JoinStringConcatRector extends AbstractRector
 {
+    public $testSamples = true;
+
     /**
      * @var int
      */

--- a/rules/code-quality/src/Rector/Foreach_/UnusedForeachValueToArrayKeysRector.php
+++ b/rules/code-quality/src/Rector/Foreach_/UnusedForeachValueToArrayKeysRector.php
@@ -18,6 +18,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class UnusedForeachValueToArrayKeysRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/code-quality/src/Rector/FuncCall/InArrayAndArrayKeysToArrayKeyExistsRector.php
+++ b/rules/code-quality/src/Rector/FuncCall/InArrayAndArrayKeysToArrayKeyExistsRector.php
@@ -16,6 +16,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class InArrayAndArrayKeysToArrayKeyExistsRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/code-quality/src/Rector/FuncCall/IntvalToTypeCastRector.php
+++ b/rules/code-quality/src/Rector/FuncCall/IntvalToTypeCastRector.php
@@ -19,6 +19,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class IntvalToTypeCastRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/code-quality/src/Rector/FuncCall/SimplifyFuncGetArgsCountRector.php
+++ b/rules/code-quality/src/Rector/FuncCall/SimplifyFuncGetArgsCountRector.php
@@ -15,6 +15,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class SimplifyFuncGetArgsCountRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/code-quality/src/Rector/FuncCall/SimplifyInArrayValuesRector.php
+++ b/rules/code-quality/src/Rector/FuncCall/SimplifyInArrayValuesRector.php
@@ -15,6 +15,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class SimplifyInArrayValuesRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/code-quality/src/Rector/FuncCall/SingleInArrayToCompareRector.php
+++ b/rules/code-quality/src/Rector/FuncCall/SingleInArrayToCompareRector.php
@@ -18,6 +18,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class SingleInArrayToCompareRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/code-quality/src/Rector/Identical/SimplifyArraySearchRector.php
+++ b/rules/code-quality/src/Rector/Identical/SimplifyArraySearchRector.php
@@ -19,6 +19,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class SimplifyArraySearchRector extends AbstractRector
 {
+    public $testSamples = true;
+
     /**
      * @var BinaryOpManipulator
      */

--- a/rules/code-quality/src/Rector/Identical/StrlenZeroToIdenticalEmptyStringRector.php
+++ b/rules/code-quality/src/Rector/Identical/StrlenZeroToIdenticalEmptyStringRector.php
@@ -18,6 +18,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class StrlenZeroToIdenticalEmptyStringRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/code-quality/src/Rector/If_/CombineIfRector.php
+++ b/rules/code-quality/src/Rector/If_/CombineIfRector.php
@@ -17,6 +17,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class CombineIfRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Merges nested if statements', [

--- a/rules/code-quality/src/Rector/If_/ExplicitBoolCompareRector.php
+++ b/rules/code-quality/src/Rector/If_/ExplicitBoolCompareRector.php
@@ -33,6 +33,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class ExplicitBoolCompareRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Make if conditions more explicit', [

--- a/rules/code-quality/src/Rector/If_/ShortenElseIfRector.php
+++ b/rules/code-quality/src/Rector/If_/ShortenElseIfRector.php
@@ -16,6 +16,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class ShortenElseIfRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Shortens else/if to elseif', [

--- a/rules/code-quality/src/Rector/If_/SimplifyIfElseToTernaryRector.php
+++ b/rules/code-quality/src/Rector/If_/SimplifyIfElseToTernaryRector.php
@@ -21,6 +21,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class SimplifyIfElseToTernaryRector extends AbstractRector
 {
+    public $testSamples = true;
+
     /**
      * @var int
      */

--- a/rules/code-quality/src/Rector/If_/SimplifyIfIssetToNullCoalescingRector.php
+++ b/rules/code-quality/src/Rector/If_/SimplifyIfIssetToNullCoalescingRector.php
@@ -24,6 +24,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class SimplifyIfIssetToNullCoalescingRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Simplify binary if to null coalesce', [

--- a/rules/code-quality/src/Rector/LogicalAnd/LogicalToBooleanRector.php
+++ b/rules/code-quality/src/Rector/LogicalAnd/LogicalToBooleanRector.php
@@ -20,6 +20,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class LogicalToBooleanRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/code-quality/src/Rector/NotEqual/CommonNotEqualRector.php
+++ b/rules/code-quality/src/Rector/NotEqual/CommonNotEqualRector.php
@@ -17,6 +17,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class CommonNotEqualRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/code-quality/src/Rector/Ternary/ArrayKeyExistsTernaryThenValueToCoalescingRector.php
+++ b/rules/code-quality/src/Rector/Ternary/ArrayKeyExistsTernaryThenValueToCoalescingRector.php
@@ -20,6 +20,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class ArrayKeyExistsTernaryThenValueToCoalescingRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/code-quality/src/Rector/Ternary/SimplifyTautologyTernaryRector.php
+++ b/rules/code-quality/src/Rector/Ternary/SimplifyTautologyTernaryRector.php
@@ -18,6 +18,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class SimplifyTautologyTernaryRector extends AbstractRector
 {
+    public $testSamples = true;
+
     /**
      * @var BinaryOpManipulator
      */

--- a/rules/code-quality/src/Rector/Ternary/UnnecessaryTernaryExpressionRector.php
+++ b/rules/code-quality/src/Rector/Ternary/UnnecessaryTernaryExpressionRector.php
@@ -21,6 +21,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class UnnecessaryTernaryExpressionRector extends AbstractRector
 {
+    public $testSamples = true;
+
     /**
      * @var AssignAndBinaryMap
      */

--- a/rules/coding-style/src/Rector/Catch_/CatchExceptionNameMatchingTypeRector.php
+++ b/rules/coding-style/src/Rector/Catch_/CatchExceptionNameMatchingTypeRector.php
@@ -16,6 +16,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class CatchExceptionNameMatchingTypeRector extends AbstractRector
 {
+    public $testSamples = true;
+
     /**
      * @var string
      * @see https://regex101.com/r/xmfMAX/1

--- a/rules/coding-style/src/Rector/ClassConst/VarConstantCommentRector.php
+++ b/rules/coding-style/src/Rector/ClassConst/VarConstantCommentRector.php
@@ -20,6 +20,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class VarConstantCommentRector extends AbstractRector
 {
+    public $testSamples = true;
+
     /**
      * @var int
      */

--- a/rules/coding-style/src/Rector/ClassMethod/RemoveDoubleUnderscoreInMethodNameRector.php
+++ b/rules/coding-style/src/Rector/ClassMethod/RemoveDoubleUnderscoreInMethodNameRector.php
@@ -22,6 +22,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class RemoveDoubleUnderscoreInMethodNameRector extends AbstractRector
 {
+    public $testSamples = true;
+
     /**
      * @var string
      * @see https://regex101.com/r/oRrhDJ/3

--- a/rules/coding-style/src/Rector/Encapsed/EncapsedStringsToSprintfRector.php
+++ b/rules/coding-style/src/Rector/Encapsed/EncapsedStringsToSprintfRector.php
@@ -25,6 +25,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class EncapsedStringsToSprintfRector extends AbstractRector
 {
+    public $testSamples = true;
+
     /**
      * @var string
      */

--- a/rules/coding-style/src/Rector/FuncCall/CallUserFuncCallToVariadicRector.php
+++ b/rules/coding-style/src/Rector/FuncCall/CallUserFuncCallToVariadicRector.php
@@ -18,6 +18,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class CallUserFuncCallToVariadicRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Replace call_user_func_call with variadic', [

--- a/rules/coding-style/src/Rector/FuncCall/ConsistentPregDelimiterRector.php
+++ b/rules/coding-style/src/Rector/FuncCall/ConsistentPregDelimiterRector.php
@@ -20,6 +20,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class ConsistentPregDelimiterRector extends AbstractRector implements ConfigurableRectorInterface
 {
+    public $testSamples = true;
+
     /**
      * @api
      * @var string

--- a/rules/coding-style/src/Rector/FuncCall/StrictArraySearchRector.php
+++ b/rules/coding-style/src/Rector/FuncCall/StrictArraySearchRector.php
@@ -15,6 +15,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class StrictArraySearchRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/coding-style/src/Rector/FuncCall/VersionCompareFuncCallToConstantRector.php
+++ b/rules/coding-style/src/Rector/FuncCall/VersionCompareFuncCallToConstantRector.php
@@ -28,6 +28,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class VersionCompareFuncCallToConstantRector extends AbstractRector
 {
+    public $testSamples = true;
+
     /**
      * @var string[]
      */

--- a/rules/coding-style/src/Rector/Include_/FollowRequireByDirRector.php
+++ b/rules/coding-style/src/Rector/Include_/FollowRequireByDirRector.php
@@ -19,6 +19,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class FollowRequireByDirRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/coding-style/src/Rector/String_/SymplifyQuoteEscapeRector.php
+++ b/rules/coding-style/src/Rector/String_/SymplifyQuoteEscapeRector.php
@@ -17,6 +17,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class SymplifyQuoteEscapeRector extends AbstractRector
 {
+    public $testSamples = true;
+
     /**
      * @var string
      * @see https://regex101.com/r/qEkCe9/1
@@ -34,8 +36,8 @@ class SomeClass
 {
     public function run()
     {
-         $name = "\" Tom";
-         $name = '\' Sara';
+        $name = "\" Tom";
+        $name = '\' Sara';
     }
 }
 CODE_SAMPLE
@@ -45,8 +47,8 @@ class SomeClass
 {
     public function run()
     {
-         $name = '" Tom';
-         $name = "' Sara";
+        $name = '" Tom';
+        $name = "' Sara";
     }
 }
 CODE_SAMPLE

--- a/rules/coding-style/src/Rector/Ternary/TernaryConditionVariableAssignmentRector.php
+++ b/rules/coding-style/src/Rector/Ternary/TernaryConditionVariableAssignmentRector.php
@@ -18,6 +18,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class TernaryConditionVariableAssignmentRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/dead-code/src/Rector/BooleanAnd/RemoveAndTrueRector.php
+++ b/rules/dead-code/src/Rector/BooleanAnd/RemoveAndTrueRector.php
@@ -15,6 +15,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class RemoveAndTrueRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Remove and true that has no added value', [

--- a/rules/dead-code/src/Rector/Concat/RemoveConcatAutocastRector.php
+++ b/rules/dead-code/src/Rector/Concat/RemoveConcatAutocastRector.php
@@ -17,6 +17,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class RemoveConcatAutocastRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/dead-code/src/Rector/Foreach_/RemoveUnusedForeachKeyRector.php
+++ b/rules/dead-code/src/Rector/Foreach_/RemoveUnusedForeachKeyRector.php
@@ -15,6 +15,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class RemoveUnusedForeachKeyRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Remove unused key in foreach', [

--- a/rules/dead-code/src/Rector/FunctionLike/RemoveCodeAfterReturnRector.php
+++ b/rules/dead-code/src/Rector/FunctionLike/RemoveCodeAfterReturnRector.php
@@ -19,6 +19,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class RemoveCodeAfterReturnRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Remove dead code after return statement', [
@@ -28,8 +30,8 @@ class SomeClass
 {
     public function run(int $a)
     {
-         return $a;
-         $a++;
+        return $a;
+        $a++;
     }
 }
 CODE_SAMPLE
@@ -39,7 +41,7 @@ class SomeClass
 {
     public function run(int $a)
     {
-         return $a;
+        return $a;
     }
 }
 CODE_SAMPLE

--- a/rules/dead-code/src/Rector/If_/RemoveUnusedNonEmptyArrayBeforeForeachRector.php
+++ b/rules/dead-code/src/Rector/If_/RemoveUnusedNonEmptyArrayBeforeForeachRector.php
@@ -19,6 +19,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class RemoveUnusedNonEmptyArrayBeforeForeachRector extends AbstractRector
 {
+    public $testSamples = true;
+
     /**
      * @var IfManipulator
      */

--- a/rules/dead-code/src/Rector/Plus/RemoveDeadZeroAndOneOperationRector.php
+++ b/rules/dead-code/src/Rector/Plus/RemoveDeadZeroAndOneOperationRector.php
@@ -28,6 +28,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class RemoveDeadZeroAndOneOperationRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/dead-code/src/Rector/PropertyProperty/RemoveNullPropertyInitializationRector.php
+++ b/rules/dead-code/src/Rector/PropertyProperty/RemoveNullPropertyInitializationRector.php
@@ -19,6 +19,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class RemoveNullPropertyInitializationRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/dead-code/src/Rector/Switch_/RemoveDuplicatedCaseInSwitchRector.php
+++ b/rules/dead-code/src/Rector/Switch_/RemoveDuplicatedCaseInSwitchRector.php
@@ -18,6 +18,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class RemoveDuplicatedCaseInSwitchRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
@@ -30,14 +32,14 @@ class SomeClass
     public function run()
     {
         switch ($name) {
-             case 'clearHeader':
-                 return $this->modifyHeader($node, 'remove');
-             case 'clearAllHeaders':
-                 return $this->modifyHeader($node, 'replace');
-             case 'clearRawHeaders':
-                 return $this->modifyHeader($node, 'replace');
-             case '...':
-                 return 5;
+            case 'clearHeader':
+                return $this->modifyHeader($node, 'remove');
+            case 'clearAllHeaders':
+                return $this->modifyHeader($node, 'replace');
+            case 'clearRawHeaders':
+                return $this->modifyHeader($node, 'replace');
+            case '...':
+                return 5;
         }
     }
 }
@@ -49,13 +51,13 @@ class SomeClass
     public function run()
     {
         switch ($name) {
-             case 'clearHeader':
-                 return $this->modifyHeader($node, 'remove');
-             case 'clearAllHeaders':
-             case 'clearRawHeaders':
-                 return $this->modifyHeader($node, 'replace');
-             case '...':
-                 return 5;
+            case 'clearHeader':
+                return $this->modifyHeader($node, 'remove');
+            case 'clearAllHeaders':
+            case 'clearRawHeaders':
+                return $this->modifyHeader($node, 'replace');
+            case '...':
+                return 5;
         }
     }
 }

--- a/rules/downgrade-php74/src/Rector/ArrowFunction/ArrowFunctionToAnonymousFunctionRector.php
+++ b/rules/downgrade-php74/src/Rector/ArrowFunction/ArrowFunctionToAnonymousFunctionRector.php
@@ -23,6 +23,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class ArrowFunctionToAnonymousFunctionRector extends AbstractConvertToAnonymousFunctionRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
@@ -46,7 +48,7 @@ class SomeClass
     public function run()
     {
         $delimiter = ",";
-        $callable = function ($matches) use ($delimiter) {
+        $callable = function ($matches) use($delimiter) {
             return $delimiter . strtolower($matches[1]);
         };
     }

--- a/rules/downgrade-php74/src/Rector/Coalesce/DowngradeNullCoalescingOperatorRector.php
+++ b/rules/downgrade-php74/src/Rector/Coalesce/DowngradeNullCoalescingOperatorRector.php
@@ -18,6 +18,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class DowngradeNullCoalescingOperatorRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Remove null coalescing operator ??=', [

--- a/rules/downgrade-php74/src/Rector/FuncCall/DowngradeArrayMergeCallWithoutArgumentsRector.php
+++ b/rules/downgrade-php74/src/Rector/FuncCall/DowngradeArrayMergeCallWithoutArgumentsRector.php
@@ -17,6 +17,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class DowngradeArrayMergeCallWithoutArgumentsRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/downgrade-php74/src/Rector/Property/DowngradeTypedPropertyRector.php
+++ b/rules/downgrade-php74/src/Rector/Property/DowngradeTypedPropertyRector.php
@@ -13,6 +13,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class DowngradeTypedPropertyRector extends AbstractDowngradeTypedPropertyRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Changes property type definition from type definitions to `@var` annotations.', [
@@ -28,8 +30,8 @@ CODE_SAMPLE
 class SomeClass
 {
     /**
-    * @var string
-    */
+     * @var string
+     */
     private $property;
 }
 CODE_SAMPLE

--- a/rules/downgrade-php80/src/Rector/FunctionLike/DowngradeReturnMixedTypeDeclarationRector.php
+++ b/rules/downgrade-php80/src/Rector/FunctionLike/DowngradeReturnMixedTypeDeclarationRector.php
@@ -13,6 +13,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class DowngradeReturnMixedTypeDeclarationRector extends AbstractDowngradeReturnTypeDeclarationRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
@@ -20,8 +22,6 @@ final class DowngradeReturnMixedTypeDeclarationRector extends AbstractDowngradeR
             [
                 new ConfiguredCodeSample(
                     <<<'CODE_SAMPLE'
-<?php
-
 class SomeClass
 {
     public function getAnything(bool $flag): mixed
@@ -29,14 +29,12 @@ class SomeClass
         if ($flag) {
             return 1;
         }
-        return 'Hello world'
+        return 'Hello world';
     }
 }
 CODE_SAMPLE
                     ,
                     <<<'CODE_SAMPLE'
-<?php
-
 class SomeClass
 {
     /**
@@ -47,7 +45,7 @@ class SomeClass
         if ($flag) {
             return 1;
         }
-        return 'Hello world'
+        return 'Hello world';
     }
 }
 CODE_SAMPLE

--- a/rules/generic/src/Rector/ClassMethod/ChangeMethodVisibilityRector.php
+++ b/rules/generic/src/Rector/ClassMethod/ChangeMethodVisibilityRector.php
@@ -38,14 +38,14 @@ final class ChangeMethodVisibilityRector extends AbstractRector implements Confi
                 <<<'CODE_SAMPLE'
 class FrameworkClass
 {
-    protected someMethod()
+    protected function someMethod()
     {
     }
 }
 
 class MyClass extends FrameworkClass
 {
-    public someMethod()
+    public function someMethod()
     {
     }
 }
@@ -54,14 +54,14 @@ CODE_SAMPLE
                 <<<'CODE_SAMPLE'
 class FrameworkClass
 {
-    protected someMethod()
+    protected function someMethod()
     {
     }
 }
 
 class MyClass extends FrameworkClass
 {
-    protected someMethod()
+    protected function someMethod()
     {
     }
 }

--- a/rules/laravel/src/Rector/FuncCall/HelperFuncCallToFacadeClassRector.php
+++ b/rules/laravel/src/Rector/FuncCall/HelperFuncCallToFacadeClassRector.php
@@ -18,6 +18,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class HelperFuncCallToFacadeClassRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Change app() func calls to facade calls', [

--- a/rules/laravel/src/Rector/StaticCall/MinutesToSecondsInCacheRector.php
+++ b/rules/laravel/src/Rector/StaticCall/MinutesToSecondsInCacheRector.php
@@ -26,6 +26,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class MinutesToSecondsInCacheRector extends AbstractRector
 {
+    public $testSamples = true;
+
     /**
      * @var string
      */

--- a/rules/laravel/src/Rector/StaticCall/Redirect301ToPermanentRedirectRector.php
+++ b/rules/laravel/src/Rector/StaticCall/Redirect301ToPermanentRedirectRector.php
@@ -17,6 +17,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class Redirect301ToPermanentRedirectRector extends AbstractRector
 {
+    public $testSamples = true;
+
     /**
      * @var string[]
      */

--- a/rules/mysql-to-mysqli/src/Rector/FuncCall/MysqlFuncCallToMysqliRector.php
+++ b/rules/mysql-to-mysqli/src/Rector/FuncCall/MysqlFuncCallToMysqliRector.php
@@ -22,6 +22,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class MysqlFuncCallToMysqliRector extends AbstractRector
 {
+    public $testSamples = true;
+
     /**
      * @var string
      */

--- a/rules/mysql-to-mysqli/src/Rector/FuncCall/MysqlPConnectToMysqliConnectRector.php
+++ b/rules/mysql-to-mysqli/src/Rector/FuncCall/MysqlPConnectToMysqliConnectRector.php
@@ -20,6 +20,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class MysqlPConnectToMysqliConnectRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/naming/src/Rector/ClassMethod/RenameVariableToMatchNewTypeRector.php
+++ b/rules/naming/src/Rector/ClassMethod/RenameVariableToMatchNewTypeRector.php
@@ -21,6 +21,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class RenameVariableToMatchNewTypeRector extends AbstractRector
 {
+    public $testSamples = true;
+
     /**
      * @var ExpectedNameResolver
      */

--- a/rules/naming/src/Rector/Variable/UnderscoreToCamelCaseVariableNameRector.php
+++ b/rules/naming/src/Rector/Variable/UnderscoreToCamelCaseVariableNameRector.php
@@ -23,6 +23,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class UnderscoreToCamelCaseVariableNameRector extends AbstractRector
 {
+    public $testSamples = true;
+
     /**
      * @var ReservedKeywordAnalyzer
      */

--- a/rules/nette-code-quality/src/Rector/Identical/SubstrMinusToStringEndsWithRector.php
+++ b/rules/nette-code-quality/src/Rector/Identical/SubstrMinusToStringEndsWithRector.php
@@ -21,6 +21,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class SubstrMinusToStringEndsWithRector extends AbstractRector
 {
+    public $testSamples = true;
+
     /**
      * @var string
      */
@@ -38,7 +40,7 @@ substr($var, -4) === 'Test';
 CODE_SAMPLE
 ,
                     <<<'CODE_SAMPLE'
-! \Nette\Utils\Strings::endsWith($var, 'Test');
+!\Nette\Utils\Strings::endsWith($var, 'Test');
 \Nette\Utils\Strings::endsWith($var, 'Test');
 CODE_SAMPLE
                 ),

--- a/rules/nette-utils-code-quality/src/Rector/LNumber/ReplaceTimeNumberWithDateTimeConstantRector.php
+++ b/rules/nette-utils-code-quality/src/Rector/LNumber/ReplaceTimeNumberWithDateTimeConstantRector.php
@@ -18,6 +18,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class ReplaceTimeNumberWithDateTimeConstantRector extends AbstractRector
 {
+    public $testSamples = true;
+
     /**
      * @noRector
      * @var array<int, string>

--- a/rules/nette/src/Rector/FuncCall/SubstrStrlenFunctionToNetteUtilsStringsRector.php
+++ b/rules/nette/src/Rector/FuncCall/SubstrStrlenFunctionToNetteUtilsStringsRector.php
@@ -16,6 +16,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class SubstrStrlenFunctionToNetteUtilsStringsRector extends AbstractRector
 {
+    public $testSamples = true;
+
     /**
      * @var array<string, string>
      */

--- a/rules/nette/src/Rector/Identical/EndsWithFunctionToNetteUtilsStringsRector.php
+++ b/rules/nette/src/Rector/Identical/EndsWithFunctionToNetteUtilsStringsRector.php
@@ -18,6 +18,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class EndsWithFunctionToNetteUtilsStringsRector extends AbstractWithFunctionToNetteUtilsStringsRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
@@ -30,7 +32,6 @@ class SomeClass
     public function end($needle)
     {
         $content = 'Hi, my name is Tom';
-
         $yes = substr($content, -strlen($needle)) === $needle;
     }
 }
@@ -42,7 +43,6 @@ class SomeClass
     public function end($needle)
     {
         $content = 'Hi, my name is Tom';
-
         $yes = \Nette\Utils\Strings::endsWith($content, $needle);
     }
 }

--- a/rules/nette/src/Rector/Identical/StartsWithFunctionToNetteUtilsStringsRector.php
+++ b/rules/nette/src/Rector/Identical/StartsWithFunctionToNetteUtilsStringsRector.php
@@ -18,6 +18,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class StartsWithFunctionToNetteUtilsStringsRector extends AbstractWithFunctionToNetteUtilsStringsRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
@@ -30,7 +32,6 @@ class SomeClass
     public function start($needle)
     {
         $content = 'Hi, my name is Tom';
-
         $yes = substr($content, 0, strlen($needle)) === $needle;
     }
 }
@@ -42,7 +43,6 @@ class SomeClass
     public function start($needle)
     {
         $content = 'Hi, my name is Tom';
-
         $yes = \Nette\Utils\Strings::startsWith($content, $needle);
     }
 }

--- a/rules/nette/src/Rector/NotIdentical/StrposToStringsContainsRector.php
+++ b/rules/nette/src/Rector/NotIdentical/StrposToStringsContainsRector.php
@@ -22,6 +22,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class StrposToStringsContainsRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/order/src/Rector/Class_/OrderConstantsByVisibilityRector.php
+++ b/rules/order/src/Rector/Class_/OrderConstantsByVisibilityRector.php
@@ -16,6 +16,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class OrderConstantsByVisibilityRector extends AbstractConstantPropertyMethodOrderRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Orders constants by visibility', [

--- a/rules/order/src/Rector/Class_/OrderFirstLevelClassStatementsRector.php
+++ b/rules/order/src/Rector/Class_/OrderFirstLevelClassStatementsRector.php
@@ -20,6 +20,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class OrderFirstLevelClassStatementsRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Orders first level Class statements', [

--- a/rules/order/src/Rector/Class_/OrderMethodsByVisibilityRector.php
+++ b/rules/order/src/Rector/Class_/OrderMethodsByVisibilityRector.php
@@ -19,6 +19,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class OrderMethodsByVisibilityRector extends AbstractConstantPropertyMethodOrderRector
 {
+    public $testSamples = true;
+
     /**
      * @var string[]
      */

--- a/rules/order/src/Rector/Class_/OrderPropertiesByVisibilityRector.php
+++ b/rules/order/src/Rector/Class_/OrderPropertiesByVisibilityRector.php
@@ -17,6 +17,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class OrderPropertiesByVisibilityRector extends AbstractConstantPropertyMethodOrderRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Orders properties by visibility', [

--- a/rules/performance/src/Rector/FuncCall/PreslashSimpleFunctionRector.php
+++ b/rules/performance/src/Rector/FuncCall/PreslashSimpleFunctionRector.php
@@ -19,6 +19,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class PreslashSimpleFunctionRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/php-office/src/Rector/StaticCall/CellStaticToCoordinateRector.php
+++ b/rules/php-office/src/Rector/StaticCall/CellStaticToCoordinateRector.php
@@ -18,6 +18,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class CellStaticToCoordinateRector extends AbstractRector
 {
+    public $testSamples = true;
+
     /**
      * @var string[]
      */

--- a/rules/php-office/src/Rector/StaticCall/ChangeChartRendererRector.php
+++ b/rules/php-office/src/Rector/StaticCall/ChangeChartRendererRector.php
@@ -18,6 +18,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class ChangeChartRendererRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Change chart renderer', [
@@ -25,7 +27,7 @@ final class ChangeChartRendererRector extends AbstractRector
                 <<<'CODE_SAMPLE'
 final class SomeClass
 {
-    public function run(): void
+    public function run() : void
     {
         \PHPExcel_Settings::setChartRenderer($rendererName, $rendererLibraryPath);
     }
@@ -35,7 +37,7 @@ CODE_SAMPLE
                 <<<'CODE_SAMPLE'
 final class SomeClass
 {
-    public function run(): void
+    public function run() : void
     {
         \PHPExcel_Settings::setChartRenderer(\PhpOffice\PhpSpreadsheet\Chart\Renderer\JpGraph::class);
     }

--- a/rules/php-office/src/Rector/StaticCall/ChangeDataTypeForValueRector.php
+++ b/rules/php-office/src/Rector/StaticCall/ChangeDataTypeForValueRector.php
@@ -27,7 +27,7 @@ final class ChangeDataTypeForValueRector extends AbstractRector
                     <<<'CODE_SAMPLE'
 final class SomeClass
 {
-    public function run(): void
+    public function run() : void
     {
         $type = \PHPExcel_Cell_DataType::dataTypeForValue('value');
     }
@@ -37,7 +37,7 @@ CODE_SAMPLE
                     <<<'CODE_SAMPLE'
 final class SomeClass
 {
-    public function run(): void
+    public function run() : void
     {
         $type = \PhpOffice\PhpSpreadsheet\Cell\DefaultValueBinder::dataTypeForValue('value');
     }

--- a/rules/php-office/src/Rector/StaticCall/ChangeIOFactoryArgumentRector.php
+++ b/rules/php-office/src/Rector/StaticCall/ChangeIOFactoryArgumentRector.php
@@ -18,6 +18,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class ChangeIOFactoryArgumentRector extends AbstractRector
 {
+    public $testSamples = true;
+
     /**
      * @var string[]
      */
@@ -43,7 +45,7 @@ final class ChangeIOFactoryArgumentRector extends AbstractRector
                     <<<'CODE_SAMPLE'
 final class SomeClass
 {
-    public function run(): void
+    public function run() : void
     {
         $writer = \PHPExcel_IOFactory::createWriter('CSV');
     }
@@ -53,7 +55,7 @@ CODE_SAMPLE
                     <<<'CODE_SAMPLE'
 final class SomeClass
 {
-    public function run(): void
+    public function run() : void
     {
         $writer = \PHPExcel_IOFactory::createWriter('Csv');
     }

--- a/rules/php-office/src/Rector/StaticCall/ChangeSearchLocationToRegisterReaderRector.php
+++ b/rules/php-office/src/Rector/StaticCall/ChangeSearchLocationToRegisterReaderRector.php
@@ -19,6 +19,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class ChangeSearchLocationToRegisterReaderRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
@@ -28,7 +30,7 @@ final class ChangeSearchLocationToRegisterReaderRector extends AbstractRector
                     <<<'CODE_SAMPLE'
 final class SomeClass
 {
-    public function run(): void
+    public function run() : void
     {
         \PHPExcel_IOFactory::addSearchLocation($type, $location, $classname);
     }
@@ -38,7 +40,7 @@ CODE_SAMPLE
                     <<<'CODE_SAMPLE'
 final class SomeClass
 {
-    public function run(): void
+    public function run() : void
     {
         \PhpOffice\PhpSpreadsheet\IOFactory::registerReader($type, $classname);
     }

--- a/rules/php52/src/Rector/Property/VarToPublicPropertyRector.php
+++ b/rules/php52/src/Rector/Property/VarToPublicPropertyRector.php
@@ -15,6 +15,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class VarToPublicPropertyRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Remove unused private method', [

--- a/rules/php52/src/Rector/Switch_/ContinueToBreakInSwitchRector.php
+++ b/rules/php52/src/Rector/Switch_/ContinueToBreakInSwitchRector.php
@@ -22,6 +22,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class ContinueToBreakInSwitchRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/php53/src/Rector/FuncCall/DirNameFileConstantToDirConstantRector.php
+++ b/rules/php53/src/Rector/FuncCall/DirNameFileConstantToDirConstantRector.php
@@ -18,6 +18,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class DirNameFileConstantToDirConstantRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Convert dirname(__FILE__) to __DIR__', [

--- a/rules/php53/src/Rector/Ternary/TernaryToElvisRector.php
+++ b/rules/php53/src/Rector/Ternary/TernaryToElvisRector.php
@@ -19,6 +19,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class TernaryToElvisRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Use ?: instead of ?, where useful', [

--- a/rules/php53/src/Rector/Variable/ReplaceHttpServerVarsByServerRector.php
+++ b/rules/php53/src/Rector/Variable/ReplaceHttpServerVarsByServerRector.php
@@ -18,6 +18,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class ReplaceHttpServerVarsByServerRector extends AbstractRector
 {
+    public $testSamples = true;
+
     /**
      * @var string[]
      */

--- a/rules/php54/src/Rector/FuncCall/RemoveReferenceFromCallRector.php
+++ b/rules/php54/src/Rector/FuncCall/RemoveReferenceFromCallRector.php
@@ -15,6 +15,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class RemoveReferenceFromCallRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Remove & from function and method calls', [

--- a/rules/php56/src/Rector/FuncCall/PowToExpRector.php
+++ b/rules/php56/src/Rector/FuncCall/PowToExpRector.php
@@ -17,11 +17,13 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class PowToExpRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
             'Changes pow(val, val2) to ** (exp) parameter',
-            [new CodeSample('pow(1, 2);', '1**2;')]
+            [new CodeSample('pow(1, 2);', '1 ** 2;')]
         );
     }
 

--- a/rules/php70/src/Rector/Assign/ListSplitStringRector.php
+++ b/rules/php70/src/Rector/Assign/ListSplitStringRector.php
@@ -20,6 +20,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class ListSplitStringRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/php70/src/Rector/Assign/ListSwapArrayOrderRector.php
+++ b/rules/php70/src/Rector/Assign/ListSwapArrayOrderRector.php
@@ -20,6 +20,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class ListSwapArrayOrderRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/php70/src/Rector/FuncCall/MultiDirnameRector.php
+++ b/rules/php70/src/Rector/FuncCall/MultiDirnameRector.php
@@ -18,6 +18,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class MultiDirnameRector extends AbstractRector
 {
+    public $testSamples = true;
+
     /**
      * @var string
      */

--- a/rules/php70/src/Rector/FuncCall/RenameMktimeWithoutArgsToTimeRector.php
+++ b/rules/php70/src/Rector/FuncCall/RenameMktimeWithoutArgsToTimeRector.php
@@ -17,6 +17,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class RenameMktimeWithoutArgsToTimeRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/php70/src/Rector/Ternary/TernaryToNullCoalescingRector.php
+++ b/rules/php70/src/Rector/Ternary/TernaryToNullCoalescingRector.php
@@ -20,6 +20,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class TernaryToNullCoalescingRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/php70/src/Rector/Variable/WrapVariableVariableNameInCurlyBracesRector.php
+++ b/rules/php70/src/Rector/Variable/WrapVariableVariableNameInCurlyBracesRector.php
@@ -17,6 +17,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class WrapVariableVariableNameInCurlyBracesRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/php71/src/Rector/BinaryOp/IsIterableRector.php
+++ b/rules/php71/src/Rector/BinaryOp/IsIterableRector.php
@@ -14,6 +14,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class IsIterableRector extends AbstractIsAbleFunCallRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/php71/src/Rector/ClassConst/PublicConstantVisibilityRector.php
+++ b/rules/php71/src/Rector/ClassConst/PublicConstantVisibilityRector.php
@@ -18,6 +18,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class PublicConstantVisibilityRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/php71/src/Rector/FuncCall/RemoveExtraParametersRector.php
+++ b/rules/php71/src/Rector/FuncCall/RemoveExtraParametersRector.php
@@ -25,6 +25,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class RemoveExtraParametersRector extends AbstractRector
 {
+    public $testSamples = true;
+
     /**
      * @var CallReflectionResolver
      */

--- a/rules/php72/src/Rector/FuncCall/CreateFunctionToAnonymousFunctionRector.php
+++ b/rules/php72/src/Rector/FuncCall/CreateFunctionToAnonymousFunctionRector.php
@@ -33,6 +33,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class CreateFunctionToAnonymousFunctionRector extends AbstractConvertToAnonymousFunctionRector
 {
+    public $testSamples = true;
+
     /**
      * @var InlineCodeParser
      */
@@ -64,7 +66,7 @@ class ClassWithCreateFunction
 {
     public function run()
     {
-        $callable = function($matches) use ($delimiter) {
+        $callable = function ($matches) use($delimiter) {
             return $delimiter . strtolower($matches[1]);
         };
     }

--- a/rules/php72/src/Rector/FuncCall/StringifyDefineRector.php
+++ b/rules/php72/src/Rector/FuncCall/StringifyDefineRector.php
@@ -18,6 +18,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class StringifyDefineRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Make first argument of define() string', [
@@ -27,8 +29,8 @@ class SomeClass
 {
     public function run(int $a)
     {
-         define(CONSTANT_2, 'value');
-         define('CONSTANT', 'value');
+        define(CONSTANT_2, 'value');
+        define('CONSTANT', 'value');
     }
 }
 CODE_SAMPLE
@@ -38,8 +40,8 @@ class SomeClass
 {
     public function run(int $a)
     {
-         define('CONSTANT_2', 'value');
-         define('CONSTANT', 'value');
+        define('CONSTANT_2', 'value');
+        define('CONSTANT', 'value');
     }
 }
 CODE_SAMPLE

--- a/rules/php72/src/Rector/FuncCall/StringsAssertNakedRector.php
+++ b/rules/php72/src/Rector/FuncCall/StringsAssertNakedRector.php
@@ -21,6 +21,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class StringsAssertNakedRector extends AbstractRector
 {
+    public $testSamples = true;
+
     /**
      * @var Parser
      */

--- a/rules/php72/src/Rector/While_/WhileEachToForeachRector.php
+++ b/rules/php72/src/Rector/While_/WhileEachToForeachRector.php
@@ -23,6 +23,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class WhileEachToForeachRector extends AbstractRector
 {
+    public $testSamples = true;
+
     /**
      * @var AssignManipulator
      */

--- a/rules/php73/src/Rector/BinaryOp/IsCountableRector.php
+++ b/rules/php73/src/Rector/BinaryOp/IsCountableRector.php
@@ -14,6 +14,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class IsCountableRector extends AbstractIsAbleFunCallRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/php73/src/Rector/FuncCall/SensitiveDefineRector.php
+++ b/rules/php73/src/Rector/FuncCall/SensitiveDefineRector.php
@@ -16,6 +16,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class SensitiveDefineRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/php73/src/Rector/FuncCall/SetCookieRector.php
+++ b/rules/php73/src/Rector/FuncCall/SetCookieRector.php
@@ -26,6 +26,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class SetCookieRector extends AbstractRector
 {
+    public $testSamples = true;
+
     /**
      * Conversion table from argument index to options name
      * @var array<int, string>

--- a/rules/php73/src/Rector/FuncCall/StringifyStrNeedlesRector.php
+++ b/rules/php73/src/Rector/FuncCall/StringifyStrNeedlesRector.php
@@ -18,6 +18,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class StringifyStrNeedlesRector extends AbstractRector
 {
+    public $testSamples = true;
+
     /**
      * @var string[]
      */

--- a/rules/php74/src/Rector/Assign/NullCoalescingOperatorRector.php
+++ b/rules/php74/src/Rector/Assign/NullCoalescingOperatorRector.php
@@ -19,6 +19,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class NullCoalescingOperatorRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Use null coalescing operator ??=', [

--- a/rules/php74/src/Rector/Class_/ClassConstantToSelfClassRector.php
+++ b/rules/php74/src/Rector/Class_/ClassConstantToSelfClassRector.php
@@ -20,6 +20,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class ClassConstantToSelfClassRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Change `__CLASS__` to self::class', [
@@ -27,20 +29,20 @@ final class ClassConstantToSelfClassRector extends AbstractRector
                 <<<'CODE_SAMPLE'
 class SomeClass
 {
-   public function callOnMe()
-   {
-       var_dump(__CLASS__);
-   }
+    public function callOnMe()
+    {
+        var_dump(__CLASS__);
+    }
 }
 CODE_SAMPLE
                 ,
                 <<<'CODE_SAMPLE'
 class SomeClass
 {
-   public function callOnMe()
-   {
-       var_dump(self::class);
-   }
+    public function callOnMe()
+    {
+        var_dump(self::class);
+    }
 }
 CODE_SAMPLE
             ),

--- a/rules/php74/src/Rector/Closure/ClosureToArrowFunctionRector.php
+++ b/rules/php74/src/Rector/Closure/ClosureToArrowFunctionRector.php
@@ -22,6 +22,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class ClosureToArrowFunctionRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Change closure to arrow function', [

--- a/rules/php74/src/Rector/Double/RealToFloatTypeCastRector.php
+++ b/rules/php74/src/Rector/Double/RealToFloatTypeCastRector.php
@@ -17,6 +17,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class RealToFloatTypeCastRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Change deprecated (real) to (float)', [

--- a/rules/php74/src/Rector/FuncCall/FilterVarToAddSlashesRector.php
+++ b/rules/php74/src/Rector/FuncCall/FilterVarToAddSlashesRector.php
@@ -18,6 +18,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class FilterVarToAddSlashesRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
@@ -25,12 +27,12 @@ final class FilterVarToAddSlashesRector extends AbstractRector
             [
                 new CodeSample(
                     <<<'CODE_SAMPLE'
-$var= "Satya's here!";
+$var = "Satya's here!";
 filter_var($var, FILTER_SANITIZE_MAGIC_QUOTES);
 CODE_SAMPLE
                     ,
                     <<<'CODE_SAMPLE'
-$var= "Satya's here!";
+$var = "Satya's here!";
 addslashes($var);
 CODE_SAMPLE
                 ),

--- a/rules/php74/src/Rector/FuncCall/GetCalledClassToStaticClassRector.php
+++ b/rules/php74/src/Rector/FuncCall/GetCalledClassToStaticClassRector.php
@@ -18,6 +18,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class GetCalledClassToStaticClassRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Change get_called_class() to static::class', [
@@ -25,20 +27,20 @@ final class GetCalledClassToStaticClassRector extends AbstractRector
                 <<<'CODE_SAMPLE'
 class SomeClass
 {
-   public function callOnMe()
-   {
-       var_dump(get_called_class());
-   }
+    public function callOnMe()
+    {
+        var_dump(get_called_class());
+    }
 }
 CODE_SAMPLE
                 ,
                 <<<'CODE_SAMPLE'
 class SomeClass
 {
-   public function callOnMe()
-   {
-       var_dump(static::class);
-   }
+    public function callOnMe()
+    {
+        var_dump(static::class);
+    }
 }
 CODE_SAMPLE
             ),

--- a/rules/php74/src/Rector/FuncCall/MbStrrposEncodingArgumentPositionRector.php
+++ b/rules/php74/src/Rector/FuncCall/MbStrrposEncodingArgumentPositionRector.php
@@ -20,6 +20,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class MbStrrposEncodingArgumentPositionRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/php74/src/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector.php
+++ b/rules/php74/src/Rector/Property/RestoreDefaultNullToNullableTypePropertyRector.php
@@ -23,6 +23,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class RestoreDefaultNullToNullableTypePropertyRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/php74/src/Rector/StaticCall/ExportToReflectionFunctionRector.php
+++ b/rules/php74/src/Rector/StaticCall/ExportToReflectionFunctionRector.php
@@ -21,6 +21,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class ExportToReflectionFunctionRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/php80/src/Rector/Catch_/RemoveUnusedVariableInCatchRector.php
+++ b/rules/php80/src/Rector/Catch_/RemoveUnusedVariableInCatchRector.php
@@ -18,6 +18,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class RemoveUnusedVariableInCatchRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Remove unused variable in catch()', [

--- a/rules/php80/src/Rector/FuncCall/ClassOnObjectRector.php
+++ b/rules/php80/src/Rector/FuncCall/ClassOnObjectRector.php
@@ -19,6 +19,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class ClassOnObjectRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/php80/src/Rector/Identical/StrEndsWithRector.php
+++ b/rules/php80/src/Rector/Identical/StrEndsWithRector.php
@@ -22,6 +22,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class StrEndsWithRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Change helper functions to str_ends_with()', [

--- a/rules/php80/src/Rector/NotIdentical/StrContainsRector.php
+++ b/rules/php80/src/Rector/NotIdentical/StrContainsRector.php
@@ -21,6 +21,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class StrContainsRector extends AbstractRector
 {
+    public $testSamples = true;
+
     /**
      * @var string[]
      */

--- a/rules/php80/src/Rector/Ternary/GetDebugTypeRector.php
+++ b/rules/php80/src/Rector/Ternary/GetDebugTypeRector.php
@@ -18,6 +18,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class GetDebugTypeRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(

--- a/rules/phpunit/src/Rector/MethodCall/GetMockBuilderGetMockToCreateMockRector.php
+++ b/rules/phpunit/src/Rector/MethodCall/GetMockBuilderGetMockToCreateMockRector.php
@@ -17,6 +17,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class GetMockBuilderGetMockToCreateMockRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Remove getMockBuilder() to createMock()', [

--- a/rules/restoration/src/Rector/ClassConstFetch/MissingClassConstantReferenceToStringRector.php
+++ b/rules/restoration/src/Rector/ClassConstFetch/MissingClassConstantReferenceToStringRector.php
@@ -17,6 +17,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class MissingClassConstantReferenceToStringRector extends AbstractRector
 {
+    public $testSamples = true;
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Convert missing class reference to string', [

--- a/rules/symfony/src/Rector/ClassMethod/ActionSuffixRemoverRector.php
+++ b/rules/symfony/src/Rector/ClassMethod/ActionSuffixRemoverRector.php
@@ -17,6 +17,8 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class ActionSuffixRemoverRector extends AbstractRector
 {
+    public $testSamples = true;
+
     /**
      * @var ControllerMethodAnalyzer
      */

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -38,6 +38,8 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
 {
     use AbstractRectorTrait;
 
+    public $testSamples = false;
+
     /**
      * @var string[]
      */

--- a/tests/Samples/SamplesTest.php
+++ b/tests/Samples/SamplesTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Rector\Core\Tests\Samples;
+
+use PhpParser\NodeTraverser;
+use PhpParser\PrettyPrinter\Standard;
+use Rector\Core\HttpKernel\RectorKernel;
+use Rector\Core\PhpParser\Parser\NikicPhpParserFactory;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Testing\Finder\RectorsFinder;
+use Rector\Testing\PhpConfigPrinter\PhpConfigPrinterFactory;
+use Symplify\PackageBuilder\Testing\AbstractKernelTestCase;
+use Symplify\SmartFileSystem\SmartFileSystem;
+
+class SamplesTest extends AbstractKernelTestCase
+{
+    /** @var SmartFileSystem */
+    private $smartFileSystem;
+
+    protected function setUp(): void
+    {
+        $this->smartFileSystem = new SmartFileSystem();
+    }
+
+    public function testSamples()
+    {
+        $this->createContainerWithAllRectors();
+
+        $parserFactory = self::$container->get(NikicPhpParserFactory::class);
+        $parser = $parserFactory->create();
+        $traverser = new NodeTraverser();
+        $printer = new Standard();
+
+        foreach (self::$container->getServiceIds() as $serviceId) {
+            $service = self::$container->get($serviceId);
+            if (!$service instanceof AbstractRector) {
+                continue;
+            }
+
+            if (!$service->testSamples) {
+                continue;
+            }
+
+            $traverser->addVisitor($service);
+            $ruleDefinition = $service->getRuleDefinition();
+            foreach ($ruleDefinition->getCodeSamples() as $sample) {
+                $badCode = $sample->getBadCode();
+                if (strpos($badCode, '<?php') === false) {
+                    $badCode = "<?php\n" . $badCode;
+                }
+
+                $nodes = $parser->parse($badCode);
+                $newNodes = $traverser->traverse($nodes);
+                $this->assertEquals($sample->getGoodCode(), $printer->prettyPrint($newNodes));
+            }
+            $traverser->removeVisitor($service);
+        }
+    }
+
+    private function createContainerWithAllRectors(): void
+    {
+        $servicesFinder = new RectorsFinder();
+        $coreRectorClasses = $servicesFinder->findCoreRectorClasses();
+
+        $listForConfig = [];
+        foreach ($coreRectorClasses as $serviceClass) {
+            $listForConfig[$serviceClass] = null;
+        }
+
+        $filePath = sprintf(sys_get_temp_dir() . '/rector_sample_tests/all_rectors.php');
+        $this->createPhpConfigFileAndDumpToPath($listForConfig, $filePath);
+
+        $this->bootKernelWithConfigs(RectorKernel::class, [$filePath]);
+    }
+
+    private function createPhpConfigFileAndDumpToPath(array $serviceClassesWithConfiguration, string $filePath): void
+    {
+        $phpConfigPrinterFactory = new PhpConfigPrinterFactory();
+        $smartPhpConfigPrinter = $phpConfigPrinterFactory->create();
+
+        $fileContent = $smartPhpConfigPrinter->printConfiguredServices($serviceClassesWithConfiguration);
+        $this->smartFileSystem->dumpFile($filePath, $fileContent);
+    }
+}


### PR DESCRIPTION
Hi,
I was thinking if it would be possible to automatically test code samples which are required in rule definition, so I prepared this proof of concept and add it to over 100 rules.
It works now for all "simple" replacing rules like  strpos -> contains etc.
Not working for rules where the type of class / interface is needed. Probably because of some missing visitor(s) or something like that. Maybe you will give me some hint how to use it in this test.