### PR TITLE
[PHP 8.0] Add SetStateToStaticRector

### DIFF
--- a/config/set/php80.php
+++ b/config/set/php80.php
@@ -8,6 +8,7 @@ use Rector\Php80\Rector\Catch_\RemoveUnusedVariableInCatchRector;
 use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 use Rector\Php80\Rector\Class_\StringableForToStringRector;
+use Rector\Php80\Rector\ClassMethod\SetStateToStaticRector;
 use Rector\Php80\Rector\FuncCall\ClassOnObjectRector;
 use Rector\Php80\Rector\FuncCall\TokenGetAllToObjectRector;
 use Rector\Php80\Rector\FunctionLike\UnionTypesRector;
@@ -53,4 +54,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 new ArgumentAdder('Nette\Utils\Strings', 'replace', 2, 'replacement', ''),
             ]),
         ]]);
+
+    $services->set(SetStateToStaticRector::class);
 };

--- a/rules/php80/src/Rector/ClassMethod/SetStateToStaticRector.php
+++ b/rules/php80/src/Rector/ClassMethod/SetStateToStaticRector.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Php80\Rector\ClassMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\ValueObject\MethodName;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\Php80\Tests\Rector\ClassMethod\SetStateToStaticRector\SetStateToStaticRectorTest
+ */
+final class SetStateToStaticRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Adds static visibility to __set_state() methods', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function __set_state($properties) {
+
+    }
+}
+CODE_SAMPLE
+,
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public static function __set_state($properties) {
+
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [
+            ClassMethod::class,
+        ];
+    }
+
+    /**
+     * @param ClassMethod $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($this->shouldSkip($node)) {
+            return null;
+        }
+
+        $this->makeStatic($node);
+
+        return $node;
+    }
+
+    private function shouldSkip(ClassMethod $classMethod): bool
+    {
+        if (! $this->isName($classMethod, MethodName::SET_STATE)) {
+            return true;
+        }
+
+        if ($classMethod->isStatic()) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/rules/php80/tests/Rector/ClassMethod/SetStateToStaticRector/Fixture/no_static.php.inc
+++ b/rules/php80/tests/Rector/ClassMethod/SetStateToStaticRector/Fixture/no_static.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Php80\Tests\Rector\ClassMethod\SetStateToStaticRector\Fixture;
+
+class NoStatic
+{
+    public function __set_state($array)
+    {
+        return new NoStatic();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Php80\Tests\Rector\ClassMethod\SetStateToStaticRector\Fixture;
+
+class NoStatic
+{
+    public static function __set_state($array)
+    {
+        return new NoStatic();
+    }
+}
+
+?>

--- a/rules/php80/tests/Rector/ClassMethod/SetStateToStaticRector/SetStateToStaticRectorTest.php
+++ b/rules/php80/tests/Rector/ClassMethod/SetStateToStaticRector/SetStateToStaticRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Php80\Tests\Rector\ClassMethod\SetStateToStaticRector;
+
+use Iterator;
+use Rector\Php80\Rector\ClassMethod\SetStateToStaticRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class SetStateToStaticRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    protected function getRectorClass(): string
+    {
+        return SetStateToStaticRector::class;
+    }
+}

--- a/rules/php80/tests/Rector/ClassMethod/SetStateToStaticRector/SetStateToStaticRectorTest.php
+++ b/rules/php80/tests/Rector/ClassMethod/SetStateToStaticRector/SetStateToStaticRectorTest.php
@@ -13,6 +13,7 @@ final class SetStateToStaticRectorTest extends AbstractRectorTestCase
 {
     /**
      * @dataProvider provideData()
+     * @requires PHP < 8.0
      */
     public function test(SmartFileInfo $fileInfo): void
     {

--- a/src/ValueObject/MethodName.php
+++ b/src/ValueObject/MethodName.php
@@ -27,4 +27,6 @@ final class MethodName
      * @var string
      */
     public const TEAR_DOWN = 'tearDown';
+
+    public const SET_STATE = '__set_state';
 }

--- a/src/ValueObject/MethodName.php
+++ b/src/ValueObject/MethodName.php
@@ -28,5 +28,8 @@ final class MethodName
      */
     public const TEAR_DOWN = 'tearDown';
 
+    /**
+     * @var string
+     */
     public const SET_STATE = '__set_state';
 }


### PR DESCRIPTION
Part of #4765. I didn't use `ChangeMethodVisibilityRector` as it required a class name to be specified and this one should be a generic one.

A way to use generic `ChangeMethodVisibilityRector` could be to refactor it to not require class name but I don't know if that's a visible solution for you.