### PR TITLE
[MysqlQueryMysqlErrorWithLinkRector] Remove already existing connection parameter from function call

### DIFF
--- a/rules/mysql-to-mysqli/src/Rector/FuncCall/MysqlQueryMysqlErrorWithLinkRector.php
+++ b/rules/mysql-to-mysqli/src/Rector/FuncCall/MysqlQueryMysqlErrorWithLinkRector.php
@@ -158,7 +158,7 @@ CODE_SAMPLE
     {
         /** @var string $functionName */
         $functionName = $this->getName($funcCall);
-        if (!isset(self::FUNCTION_CONNECTION_PARAMETER_POSITION_MAP[$functionName])){
+        if (! isset(self::FUNCTION_CONNECTION_PARAMETER_POSITION_MAP[$functionName])){
             return;
         }
 

--- a/rules/mysql-to-mysqli/src/Rector/FuncCall/MysqlQueryMysqlErrorWithLinkRector.php
+++ b/rules/mysql-to-mysqli/src/Rector/FuncCall/MysqlQueryMysqlErrorWithLinkRector.php
@@ -50,6 +50,29 @@ final class MysqlQueryMysqlErrorWithLinkRector extends AbstractRector
         'mysql_thread_id' => 'mysqli_thread_id',
     ];
 
+    /**
+     * @var array<string, int>
+     */
+    private const FUNCTION_CONNECTION_PARAMETER_POSITION_MAP = [
+        'mysql_affected_rows' => 0,
+        'mysql_client_encoding' => 0,
+        'mysql_close' => 0,
+        'mysql_errno' => 0,
+        'mysql_error' => 0,
+        'mysql_get_host_info' => 0,
+        'mysql_get_proto_info' => 0,
+        'mysql_get_server_info' => 0,
+        'mysql_info' => 0,
+        'mysql_insert_id' => 0,
+        'mysql_ping' => 0,
+        'mysql_query' => 1,
+        'mysql_real_escape_string' => 1,
+        'mysql_select_db' => 1,
+        'mysql_set_charset' => 1,
+        'mysql_stat' => 0,
+        'mysql_thread_id' => 0,
+    ];
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
@@ -114,6 +137,8 @@ CODE_SAMPLE
             ) {
                 $connectionVariable = $this->findConnectionVariable($node);
 
+                $this->removeExistingConnectionParameter($node);
+
                 if ($connectionVariable === null) {
                     return null;
                 }
@@ -127,6 +152,18 @@ CODE_SAMPLE
         }
 
         return null;
+    }
+
+    private function removeExistingConnectionParameter(FuncCall $funcCall): void
+    {
+        /** @var string $functionName */
+        $functionName = $this->getName($funcCall);
+        if (!isset(self::FUNCTION_CONNECTION_PARAMETER_POSITION_MAP[$functionName])){
+            return;
+        }
+
+        $connectionPosition = self::FUNCTION_CONNECTION_PARAMETER_POSITION_MAP[$functionName];
+        unset($funcCall->args[$connectionPosition]);
     }
 
     private function isProbablyMysql(Node $node): bool

--- a/rules/mysql-to-mysqli/tests/Rector/FuncCall/MysqlQueryMysqlErrorWithLinkRector/Fixture/connection_provided.php.inc
+++ b/rules/mysql-to-mysqli/tests/Rector/FuncCall/MysqlQueryMysqlErrorWithLinkRector/Fixture/connection_provided.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\MysqlToMysqli\Tests\Rector\FuncCall\MysqlQueryMysqlErrorWithLinkRector\Fixture;
+
+class ConnectionProvided
+{
+    public function run()
+    {
+        $link = mysqli_connect('host', 'user', 'pass');
+        $res = mysql_query("INSERT INTO ", $link) or die (mysql_error());
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\MysqlToMysqli\Tests\Rector\FuncCall\MysqlQueryMysqlErrorWithLinkRector\Fixture;
+
+class ConnectionProvided
+{
+    public function run()
+    {
+        $link = mysqli_connect('host', 'user', 'pass');
+        $res = mysqli_query($link, "INSERT INTO ") or die (mysqli_error($link));
+    }
+}
+
+?>


### PR DESCRIPTION
While looking at #4233 I found out that the `MysqlQueryMysqlErrorWithLinkRector` rule duplicates connection paramter in function call if one was already provided. 

## Example with error:
```diff
- $res = mysql_query("INSERT INTO ", $link);
+ $res = mysqli_query($link, "INSERT INTO ", $link);
```

## Expected behaviour:
```diff
- $res = mysql_query("INSERT INTO ", $link);
+ $res = mysqli_query($link, "INSERT INTO ");
```