### PR TITLE
[Downgrade] [PHP 7.3] Downgrade trailing commas in function calls

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "jean85/pretty-package-versions": "^1.5.1",
         "nette/robot-loader": "^3.2",
         "nette/utils": "^3.1",
-        "nikic/php-parser": "4.10.2",
+        "nikic/php-parser": "4.10.3",
         "phpstan/phpdoc-parser": "^0.4.9",
         "phpstan/phpstan": "^0.12.52",
         "phpstan/phpstan-phpunit": "^0.12.16",

--- a/config/set/downgrade-php73.php
+++ b/config/set/downgrade-php73.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Downgrade\Rector\LNumber\ChangePhpVersionInPlatformCheckRector;
+use Rector\DowngradePhp73\Rector\FuncCall\DowngradeTrailingCommasInFunctionCallsRector;
 use Rector\DowngradePhp73\Rector\List_\DowngradeListReferenceAssignmentRector;
 use Rector\DowngradePhp73\Rector\String_\DowngradeFlexibleHeredocSyntaxRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -15,4 +16,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->call('configure', [[
             ChangePhpVersionInPlatformCheckRector::TARGET_PHP_VERSION => 70300,
         ]]);
+    $services->set(DowngradeTrailingCommasInFunctionCallsRector::class);
 };

--- a/packages/node-type-resolver/src/Node/AttributeKey.php
+++ b/packages/node-type-resolver/src/Node/AttributeKey.php
@@ -231,5 +231,5 @@ final class AttributeKey
     /**
      * @var string
      */
-    public const TRAILING_COMMA = 'trailing_comma';
+    public const FUNC_ARGS_TRAILING_COMMA = 'trailing_comma';
 }

--- a/packages/node-type-resolver/src/Node/AttributeKey.php
+++ b/packages/node-type-resolver/src/Node/AttributeKey.php
@@ -227,4 +227,9 @@ final class AttributeKey
      * @var string
      */
     public const IS_FRESH_NODE = 'is_fresh_node';
+
+    /**
+     * @var string
+     */
+    public const TRAILING_COMMA = 'trailing_comma';
 }

--- a/rules/downgrade-php73/src/Rector/FuncCall/DowngradeTrailingCommasInFunctionCallsRector.php
+++ b/rules/downgrade-php73/src/Rector/FuncCall/DowngradeTrailingCommasInFunctionCallsRector.php
@@ -60,13 +60,17 @@ CODE_SAMPLE
         return [FuncCall::class, MethodCall::class, StaticCall::class];
     }
 
+    /**
+     * @param FuncCall|MethodCall|StaticCall $node
+     */
     public function refactor(Node $node): ?Node
     {
         if ($node->args) {
             $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
             $last = $node->args[array_key_last($node->args)];
-            $last->setAttribute(AttributeKey::TRAILING_COMMA, false);
+            $last->setAttribute(AttributeKey::FUNC_ARGS_TRAILING_COMMA, false);
         }
+
         return $node;
     }
 }

--- a/rules/downgrade-php73/src/Rector/FuncCall/DowngradeTrailingCommasInFunctionCallsRector.php
+++ b/rules/downgrade-php73/src/Rector/FuncCall/DowngradeTrailingCommasInFunctionCallsRector.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp73\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use Rector\Core\Rector\AbstractRector;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Rector\DowngradePhp73\Tests\Rector\FuncCall\DowngradeTrailingCommasInFunctionCallsRector\DowngradeTrailingCommasInFunctionCallsRectorTest
+ */
+final class DowngradeTrailingCommasInFunctionCallsRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Remove trailing commas in function calls', [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function __construct(string $value)
+    {
+        $compacted = compact(
+            'posts',
+            'units',
+        );
+    }
+}
+CODE_SAMPLE
+                    , <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function __construct(string $value)
+    {
+        $compacted = compact(
+            'posts',
+            'units'
+        );
+    }
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class, MethodCall::class, StaticCall::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        if ($node->args) {
+            $node->setAttribute(AttributeKey::ORIGINAL_NODE, null);
+            $last = $node->args[array_key_last($node->args)];
+            $last->setAttribute(AttributeKey::TRAILING_COMMA, false);
+        }
+        return $node;
+    }
+}

--- a/rules/downgrade-php73/tests/Rector/FuncCall/DowngradeTrailingCommasInFunctionCallsRector/DowngradeTrailingCommasInFunctionCallsRectorTest.php
+++ b/rules/downgrade-php73/tests/Rector/FuncCall/DowngradeTrailingCommasInFunctionCallsRector/DowngradeTrailingCommasInFunctionCallsRectorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp73\Tests\Rector\FuncCall\DowngradeTrailingCommasInFunctionCallsRector;
+
+use Iterator;
+use Rector\DowngradePhp73\Rector\FuncCall\DowngradeTrailingCommasInFunctionCallsRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class DowngradeTrailingCommasInFunctionCallsRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @requires PHP >= 7.3
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    protected function getRectorClass(): string
+    {
+        return DowngradeTrailingCommasInFunctionCallsRector::class;
+    }
+}

--- a/rules/downgrade-php73/tests/Rector/FuncCall/DowngradeTrailingCommasInFunctionCallsRector/Fixture/fixture.php.inc
+++ b/rules/downgrade-php73/tests/Rector/FuncCall/DowngradeTrailingCommasInFunctionCallsRector/Fixture/fixture.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\DowngradePhp73\Tests\Rector\FuncCall\DowngradeTrailingCommasInFunctionCallsRector\Fixture;
+
+class FixtureClass
+{
+    public function run()
+    {
+        compact('posts','units',);
+        $this->setData('posts','units',);
+        self::run('posts','units',);
+        self::run('posts',
+                  'units',);
+        $this->setOnClick("[Zip ID: {$modelid}]  {$e->getMessage($modelId,)}",);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\DowngradePhp73\Tests\Rector\FuncCall\DowngradeTrailingCommasInFunctionCallsRector\Fixture;
+
+class FixtureClass
+{
+    public function run()
+    {
+        compact('posts', 'units');
+        $this->setData('posts', 'units');
+        self::run('posts', 'units');
+        self::run('posts',
+                  'units');
+        $this->setOnClick("[Zip ID: {$modelid}]  {$e->getMessage($modelId)}");
+    }
+}
+
+?>

--- a/rules/downgrade-php73/tests/Rector/FuncCall/DowngradeTrailingCommasInFunctionCallsRector/Fixture/fixture.php.inc
+++ b/rules/downgrade-php73/tests/Rector/FuncCall/DowngradeTrailingCommasInFunctionCallsRector/Fixture/fixture.php.inc
@@ -11,6 +11,7 @@ class FixtureClass
         self::run('posts','units',);
         self::run('posts',
                   'units',);
+
         $this->setOnClick("[Zip ID: {$modelid}]  {$e->getMessage($modelId,)}",);
     }
 }
@@ -28,9 +29,9 @@ class FixtureClass
         compact('posts', 'units');
         $this->setData('posts', 'units');
         self::run('posts', 'units');
-        self::run('posts',
-                  'units');
-        $this->setOnClick("[Zip ID: {$modelid}]  {$e->getMessage($modelId)}");
+        self::run('posts', 'units');
+
+        $this->setOnClick("[Zip ID: {$modelid}]  {{$e->getMessage($modelId)}}");
     }
 }
 

--- a/rules/mysql-to-mysqli/src/Rector/FuncCall/MysqlQueryMysqlErrorWithLinkRector.php
+++ b/rules/mysql-to-mysqli/src/Rector/FuncCall/MysqlQueryMysqlErrorWithLinkRector.php
@@ -154,18 +154,6 @@ CODE_SAMPLE
         return null;
     }
 
-    private function removeExistingConnectionParameter(FuncCall $funcCall): void
-    {
-        /** @var string $functionName */
-        $functionName = $this->getName($funcCall);
-        if (! isset(self::FUNCTION_CONNECTION_PARAMETER_POSITION_MAP[$functionName])) {
-            return;
-        }
-
-        $connectionPosition = self::FUNCTION_CONNECTION_PARAMETER_POSITION_MAP[$functionName];
-        unset($funcCall->args[$connectionPosition]);
-    }
-
     private function isProbablyMysql(Node $node): bool
     {
         if ($this->isObjectType($node, 'mysqli')) {
@@ -197,6 +185,18 @@ CODE_SAMPLE
         });
 
         return $connectionAssign !== null ? $connectionAssign->var : null;
+    }
+
+    private function removeExistingConnectionParameter(FuncCall $funcCall): void
+    {
+        /** @var string $functionName */
+        $functionName = $this->getName($funcCall);
+        if (! isset(self::FUNCTION_CONNECTION_PARAMETER_POSITION_MAP[$functionName])) {
+            return;
+        }
+
+        $connectionPosition = self::FUNCTION_CONNECTION_PARAMETER_POSITION_MAP[$functionName];
+        unset($funcCall->args[$connectionPosition]);
     }
 
     private function isUnionTypeWithResourceSubType(Type $staticType, ResourceType $resourceType): bool

--- a/rules/php80/src/Rector/ClassMethod/SetStateToStaticRector.php
+++ b/rules/php80/src/Rector/ClassMethod/SetStateToStaticRector.php
@@ -68,11 +68,6 @@ CODE_SAMPLE
         if (! $this->isName($classMethod, MethodName::SET_STATE)) {
             return true;
         }
-
-        if ($classMethod->isStatic()) {
-            return true;
-        }
-
-        return false;
+        return $classMethod->isStatic();
     }
 }

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -517,7 +517,7 @@ final class BetterStandardPrinter extends Standard
         $last = end($nodes);
 
         if ($last instanceof Node) {
-            $trailingComma = $last->getAttribute(AttributeKey::TRAILING_COMMA);
+            $trailingComma = $last->getAttribute(AttributeKey::FUNC_ARGS_TRAILING_COMMA);
             if ($trailingComma === false) {
                 $result = rtrim($result, ',');
             }

--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -510,6 +510,22 @@ final class BetterStandardPrinter extends Standard
         return '`' . $encapsedStringPart->value . '`';
     }
 
+    protected function pCommaSeparated(array $nodes): string
+    {
+        $result = parent::pCommaSeparated($nodes);
+
+        $last = end($nodes);
+
+        if ($last instanceof Node) {
+            $trailingComma = $last->getAttribute(AttributeKey::TRAILING_COMMA);
+            if ($trailingComma === false) {
+                $result = rtrim($result, ',');
+            }
+        }
+
+        return $result;
+    }
+
     /**
      * @param Node[] $stmts
      * @return Node[]|mixed[]

--- a/src/ValueObject/PhpVersionFeature.php
+++ b/src/ValueObject/PhpVersionFeature.php
@@ -16,6 +16,9 @@ final class PhpVersionFeature
      */
     public const ELVIS_OPERATOR = 50300;
 
+    /**
+     * @var int
+     */
     public const DATE_TIME_INTERFACE = 50500;
 
     /**


### PR DESCRIPTION
Merge of https://github.com/rectorphp/rector/pull/4273

<br>

Closes https://github.com/rectorphp/rector/pull/4273