### PR TITLE
dont run weekly jobs on forks, because gh-tokens are not available

### DIFF
--- a/.github/workflows/weekly_pull_requests.yaml
+++ b/.github/workflows/weekly_pull_requests.yaml
@@ -7,6 +7,10 @@ on:
 
 jobs:
     weekly_pull_requests:
+
+        # dont run jobs on forks, because gh-tokens are not available 
+        if: github.event.pull_request.head.repo.full_name == github.repository
+
         strategy:
             fail-fast: false
             matrix:


### PR DESCRIPTION
Try to fix a error which I get in GitHub Action every week

![7F430463-989D-4DC9-B5FC-AD250530B8F8](https://user-images.githubusercontent.com/120441/101274381-e5d0ed80-379d-11eb-88da-dc6a07d62f47.png)
