### PR TITLE
dont run jobs on forks, because gh-tokens are not available

### DIFF
--- a/.github/workflows/daily_pull_requests.yaml
+++ b/.github/workflows/daily_pull_requests.yaml
@@ -7,6 +7,9 @@ on:
 
 jobs:
     daily_pull_requests:
+        # dont run jobs on forks, because gh-tokens are not available 
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        
         strategy:
             fail-fast: false
             matrix:


### PR DESCRIPTION
similar to https://github.com/rectorphp/rector/pull/4808