### PR TITLE
Add function call inside string test case

### DIFF
--- a/rules/downgrade-php73/tests/Rector/FuncCall/DowngradeTrailingCommasInFunctionCallsRector/Fixture/function_call_inside_string.php.inc
+++ b/rules/downgrade-php73/tests/Rector/FuncCall/DowngradeTrailingCommasInFunctionCallsRector/Fixture/function_call_inside_string.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\DowngradePhp73\Tests\Rector\FuncCall\DowngradeTrailingCommasInFunctionCallsRector\Fixture;
+
+class FunctionCallInsideString
+{
+    public function run()
+    {
+        $value = "{$this->method("test")}";
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\DowngradePhp73\Tests\Rector\FuncCall\DowngradeTrailingCommasInFunctionCallsRector\Fixture;
+
+class FunctionCallInsideString
+{
+    public function run()
+    {
+        $value = "{$this->method("test")}";
+    }
+}
+
+?>


### PR DESCRIPTION
This MR provides a test case which fails with the current implementation of `DowngradeTrailingCommasInFunctionCallsRector`

```
    ---------- begin diff ----------
--- Original
+++ New
@@ -1,3 +1,3 @@
 <?php

-$value = "{$this->method("test")}";
+$value = "{{$this->method("test")}}";
    ----------- end diff -----------
```