### PR TITLE
Do not enforce interface-typing for classes with wider public API than defined by interface

### DIFF
--- a/rules/solid/src/Rector/ClassMethod/UseInterfaceOverImplementationInConstructorRector.php
+++ b/rules/solid/src/Rector/ClassMethod/UseInterfaceOverImplementationInConstructorRector.php
@@ -9,6 +9,8 @@ use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\MethodName;
+use ReflectionClass;
+use ReflectionMethod;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -179,11 +181,13 @@ CODE_SAMPLE
      */
     private function getPublicMethods(string $fqcn): array
     {
+        $reflection = new ReflectionClass($fqcn);
+
         return array_map(
-            static function (\ReflectionMethod $method) {
+            static function (ReflectionMethod $method) {
                 return $method->name;
             },
-            (new \ReflectionClass($fqcn))->getMethods(\ReflectionMethod::IS_PUBLIC)
+            $reflection->getMethods(ReflectionMethod::IS_PUBLIC)
         );
     }
 }

--- a/rules/solid/src/Rector/ClassMethod/UseInterfaceOverImplementationInConstructorRector.php
+++ b/rules/solid/src/Rector/ClassMethod/UseInterfaceOverImplementationInConstructorRector.php
@@ -101,6 +101,10 @@ CODE_SAMPLE
                 continue;
             }
 
+            if ($this->classHasWiderPublicApiThanInterface($typeName, $interfaceNames[0])) {
+                continue;
+            }
+
             $param->type = new FullyQualified($interfaceNames[0]);
         }
 
@@ -158,5 +162,28 @@ CODE_SAMPLE
         }
 
         return array_values($interfaceNames);
+    }
+
+    private function classHasWiderPublicApiThanInterface(string $className, string $interfaceName): bool
+    {
+        $classMethods = $this->getPublicMethods($className);
+        $interfaceMethods = $this->getPublicMethods($interfaceName);
+
+        return count(array_diff($classMethods, $interfaceMethods)) > 0;
+    }
+
+    /**
+     * @param string $fqcn Fully qualified class/interface name
+     *
+     * @return string[]
+     */
+    private function getPublicMethods(string $fqcn): array
+    {
+        return array_map(
+            static function (\ReflectionMethod $method) {
+                return $method->name;
+            },
+            (new \ReflectionClass($fqcn))->getMethods(\ReflectionMethod::IS_PUBLIC)
+        );
     }
 }

--- a/rules/solid/tests/Rector/ClassMethod/UseInterfaceOverImplementationInConstructorRector/Fixture/skip_class_that_implements_single_interface_but_defines_own_public_methods.php.inc
+++ b/rules/solid/tests/Rector/ClassMethod/UseInterfaceOverImplementationInConstructorRector/Fixture/skip_class_that_implements_single_interface_but_defines_own_public_methods.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\SOLID\Tests\Rector\ClassMethod\UseInterfaceOverImplementationInConstructorRector\Fixture;
+
+use Rector\SOLID\Tests\Rector\ClassMethod\UseInterfaceOverImplementationInConstructorRector\Source\ClassThatImplementsInterfaceAndDefinesOwnPublicMethods;
+
+class SkipClassThatImplementsSingleInterfaceButDefinesOwnPublicMethods
+{
+    public function __construct(ClassThatImplementsInterfaceAndDefinesOwnPublicMethods $someImplementation)
+    {
+    }
+}

--- a/rules/solid/tests/Rector/ClassMethod/UseInterfaceOverImplementationInConstructorRector/Fixture/skip_class_that_implements_single_interface_but_uses_trait_with_additional_methods.php.inc
+++ b/rules/solid/tests/Rector/ClassMethod/UseInterfaceOverImplementationInConstructorRector/Fixture/skip_class_that_implements_single_interface_but_uses_trait_with_additional_methods.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\SOLID\Tests\Rector\ClassMethod\UseInterfaceOverImplementationInConstructorRector\Fixture;
+
+use Rector\SOLID\Tests\Rector\ClassMethod\UseInterfaceOverImplementationInConstructorRector\Source\ClassThatImplementsInterfaceAndUsesTraitWithAdditionalMethods;
+
+class SkipClassThatImplementsSingleInterfaceButUsesTraitWithAdditionalMethods
+{
+    public function __construct(ClassThatImplementsInterfaceAndUsesTraitWithAdditionalMethods $someImplementation)
+    {
+    }
+}

--- a/rules/solid/tests/Rector/ClassMethod/UseInterfaceOverImplementationInConstructorRector/Source/ClassThatImplementsInterfaceAndDefinesOwnPublicMethods.php
+++ b/rules/solid/tests/Rector/ClassMethod/UseInterfaceOverImplementationInConstructorRector/Source/ClassThatImplementsInterfaceAndDefinesOwnPublicMethods.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\SOLID\Tests\Rector\ClassMethod\UseInterfaceOverImplementationInConstructorRector\Source;
+
+final class ClassThatImplementsInterfaceAndDefinesOwnPublicMethods implements InterfaceFour
+{
+    public function foo(): string
+    {
+        return 'bar';
+    }
+}

--- a/rules/solid/tests/Rector/ClassMethod/UseInterfaceOverImplementationInConstructorRector/Source/ClassThatImplementsInterfaceAndDefinesOwnPublicMethods.php
+++ b/rules/solid/tests/Rector/ClassMethod/UseInterfaceOverImplementationInConstructorRector/Source/ClassThatImplementsInterfaceAndDefinesOwnPublicMethods.php
@@ -10,4 +10,8 @@ final class ClassThatImplementsInterfaceAndDefinesOwnPublicMethods implements In
     {
         return 'bar';
     }
+
+    public function methodFromInterface(): void
+    {
+    }
 }

--- a/rules/solid/tests/Rector/ClassMethod/UseInterfaceOverImplementationInConstructorRector/Source/ClassThatImplementsInterfaceAndUsesTraitWithAdditionalMethods.php
+++ b/rules/solid/tests/Rector/ClassMethod/UseInterfaceOverImplementationInConstructorRector/Source/ClassThatImplementsInterfaceAndUsesTraitWithAdditionalMethods.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\SOLID\Tests\Rector\ClassMethod\UseInterfaceOverImplementationInConstructorRector\Source;
+
+final class ClassThatImplementsInterfaceAndUsesTraitWithAdditionalMethods implements InterfaceFive
+{
+    use TraitOne;
+}

--- a/rules/solid/tests/Rector/ClassMethod/UseInterfaceOverImplementationInConstructorRector/Source/ClassThatImplementsInterfaceAndUsesTraitWithAdditionalMethods.php
+++ b/rules/solid/tests/Rector/ClassMethod/UseInterfaceOverImplementationInConstructorRector/Source/ClassThatImplementsInterfaceAndUsesTraitWithAdditionalMethods.php
@@ -7,4 +7,8 @@ namespace Rector\SOLID\Tests\Rector\ClassMethod\UseInterfaceOverImplementationIn
 final class ClassThatImplementsInterfaceAndUsesTraitWithAdditionalMethods implements InterfaceFive
 {
     use TraitOne;
+
+    public function methodFromInterface(): void
+    {
+    }
 }

--- a/rules/solid/tests/Rector/ClassMethod/UseInterfaceOverImplementationInConstructorRector/Source/InterfaceFive.php
+++ b/rules/solid/tests/Rector/ClassMethod/UseInterfaceOverImplementationInConstructorRector/Source/InterfaceFive.php
@@ -6,5 +6,5 @@ namespace Rector\SOLID\Tests\Rector\ClassMethod\UseInterfaceOverImplementationIn
 
 interface InterfaceFive
 {
-
+    public function methodFromInterface(): void;
 }

--- a/rules/solid/tests/Rector/ClassMethod/UseInterfaceOverImplementationInConstructorRector/Source/InterfaceFive.php
+++ b/rules/solid/tests/Rector/ClassMethod/UseInterfaceOverImplementationInConstructorRector/Source/InterfaceFive.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\SOLID\Tests\Rector\ClassMethod\UseInterfaceOverImplementationInConstructorRector\Source;
+
+interface InterfaceFive
+{
+
+}

--- a/rules/solid/tests/Rector/ClassMethod/UseInterfaceOverImplementationInConstructorRector/Source/InterfaceFour.php
+++ b/rules/solid/tests/Rector/ClassMethod/UseInterfaceOverImplementationInConstructorRector/Source/InterfaceFour.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\SOLID\Tests\Rector\ClassMethod\UseInterfaceOverImplementationInConstructorRector\Source;
+
+interface InterfaceFour
+{
+
+}

--- a/rules/solid/tests/Rector/ClassMethod/UseInterfaceOverImplementationInConstructorRector/Source/InterfaceFour.php
+++ b/rules/solid/tests/Rector/ClassMethod/UseInterfaceOverImplementationInConstructorRector/Source/InterfaceFour.php
@@ -6,5 +6,5 @@ namespace Rector\SOLID\Tests\Rector\ClassMethod\UseInterfaceOverImplementationIn
 
 interface InterfaceFour
 {
-
+    public function methodFromInterface(): void;
 }

--- a/rules/solid/tests/Rector/ClassMethod/UseInterfaceOverImplementationInConstructorRector/Source/TraitOne.php
+++ b/rules/solid/tests/Rector/ClassMethod/UseInterfaceOverImplementationInConstructorRector/Source/TraitOne.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\SOLID\Tests\Rector\ClassMethod\UseInterfaceOverImplementationInConstructorRector\Source;
+
+trait TraitOne
+{
+    public function traitMethod(): void
+    {
+    }
+}


### PR DESCRIPTION
Closes #4844

EDIT: update closing keyword to "Closes" by @TomasVotruba 