### PR TITLE
Fixed inconsistent naming: PHP_7_3 to PHP_73

### DIFF
--- a/rules/php71/tests/Rector/FuncCall/CountOnNullRector/CountOnNullRectorWithPHP73Test.php
+++ b/rules/php71/tests/Rector/FuncCall/CountOnNullRector/CountOnNullRectorWithPHP73Test.php
@@ -32,6 +32,6 @@ final class CountOnNullRectorWithPHP73Test extends AbstractRectorTestCase
 
     protected function getPhpVersion(): int
     {
-        return PhpVersion::PHP_7_3;
+        return PhpVersion::PHP_73;
     }
 }

--- a/rules/polyfill/src/FeatureSupport/FunctionSupportResolver.php
+++ b/rules/polyfill/src/FeatureSupport/FunctionSupportResolver.php
@@ -23,7 +23,7 @@ final class FunctionSupportResolver
         ],
         PhpVersion::PHP_71 => ['is_iterable'],
         PhpVersion::PHP_72 => ['spl_object_id', 'stream_isatty'],
-        PhpVersion::PHP_7_3 => ['array_key_first', 'array_key_last', 'hrtime', 'is_countable'],
+        PhpVersion::PHP_73 => ['array_key_first', 'array_key_last', 'hrtime', 'is_countable'],
         PhpVersion::PHP_74 => ['get_mangled_object_vars', 'mb_str_split', 'password_algos'],
     ];
 

--- a/src/ValueObject/PhpVersion.php
+++ b/src/ValueObject/PhpVersion.php
@@ -52,7 +52,7 @@ final class PhpVersion
      * @api
      * @var int
      */
-    public const PHP_7_3 = 70300;
+    public const PHP_73 = 70300;
 
     /**
      * @api


### PR DESCRIPTION
There constants `PHP_70`, `PHP_71`, etc, but somehow for 7.3 it was `PHP_7_3`. Fixed it as `PHP_73` to make it consistent