### PR TITLE
Typo in the helper text, uses undefined constant

### DIFF
--- a/src/Bootstrap/NoRectorsLoadedReporter.php
+++ b/src/Bootstrap/NoRectorsLoadedReporter.php
@@ -32,7 +32,7 @@ final class NoRectorsLoadedReporter
 
         $this->symfonyStyle->title('Add set of rules to "rector.php"');
         $this->symfonyStyle->writeln('  $parameters = $containerConfigurator->parameters();');
-        $this->symfonyStyle->writeln('  $parameters->set(Option::SET, [...]);');
+        $this->symfonyStyle->writeln('  $parameters->set(Option::SETS, [...]);');
         $this->symfonyStyle->newLine(2);
 
         $this->symfonyStyle->title('Missing "rector.php" in your project? Let Rector create it for you');


### PR DESCRIPTION
Here is the constant:

https://github.com/rectorphp/rector/blob/668753b63826dce3f59951e3320482d50295234b/src/Configuration/Option.php#L104