### PR TITLE
Fixed typo: Alais => Alias

### DIFF
--- a/packages/better-php-doc-parser/src/PhpDocNodeFactory/AbstractPhpDocNodeFactory.php
+++ b/packages/better-php-doc-parser/src/PhpDocNodeFactory/AbstractPhpDocNodeFactory.php
@@ -88,7 +88,7 @@ abstract class AbstractPhpDocNodeFactory
             return $namespacedTargetEntity;
         }
 
-        $resolvedType = $this->objectTypeSpecifier->narrowToFullyQualifiedOrAlaisedObjectType(
+        $resolvedType = $this->objectTypeSpecifier->narrowToFullyQualifiedOrAliasedObjectType(
             $node,
             new ObjectType($targetEntity)
         );

--- a/packages/node-type-resolver/src/NodeTypeResolver.php
+++ b/packages/node-type-resolver/src/NodeTypeResolver.php
@@ -189,7 +189,7 @@ final class NodeTypeResolver
             return $staticType;
         }
 
-        return $this->objectTypeSpecifier->narrowToFullyQualifiedOrAlaisedObjectType($node, $staticType);
+        return $this->objectTypeSpecifier->narrowToFullyQualifiedOrAliasedObjectType($node, $staticType);
     }
 
     public function isNumberType(Node $node): bool

--- a/packages/static-type-mapper/src/PhpDocParser/IdentifierTypeMapper.php
+++ b/packages/static-type-mapper/src/PhpDocParser/IdentifierTypeMapper.php
@@ -81,7 +81,7 @@ final class IdentifierTypeMapper implements PhpDocTypeMapperInterface
 
         $objectType = new ObjectType($typeNode->name);
 
-        return $this->objectTypeSpecifier->narrowToFullyQualifiedOrAlaisedObjectType($node, $objectType);
+        return $this->objectTypeSpecifier->narrowToFullyQualifiedOrAliasedObjectType($node, $objectType);
     }
 
     private function mapSelf(Node $node): Type

--- a/rules/coding-style/tests/Rector/Namespace_/ImportFullyQualifiedNamesRector/Fixture/keep_aliased.php.inc
+++ b/rules/coding-style/tests/Rector/Namespace_/ImportFullyQualifiedNamesRector/Fixture/keep_aliased.php.inc
@@ -4,7 +4,7 @@ namespace Rector\CodingStyle\Tests\Rector\Namespace_\ImportFullyQualifiedNamesRe
 
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
-final class KeepAlaised
+final class KeepAliased
 {
     private const SUPPORTED_HTTP_METHODS = [
         HttpRequest::METHOD_GET

--- a/rules/nette-to-symfony/src/Rector/ClassMethod/RenameEventNamesInEventSubscriberRector.php
+++ b/rules/nette-to-symfony/src/Rector/ClassMethod/RenameEventNamesInEventSubscriberRector.php
@@ -193,7 +193,7 @@ CODE_SAMPLE
 
     private function resolveClassConstAliasMatch(ArrayItem $arrayItem, EventInfo $eventInfo): bool
     {
-        foreach ($eventInfo->getOldClassConstAlaises() as $netteClassConst) {
+        foreach ($eventInfo->getOldClassConstAliases() as $netteClassConst) {
             $classConstFetchNode = $arrayItem->key;
             if ($classConstFetchNode === null) {
                 continue;

--- a/rules/nette-to-symfony/src/ValueObject/EventInfo.php
+++ b/rules/nette-to-symfony/src/ValueObject/EventInfo.php
@@ -29,21 +29,21 @@ final class EventInfo
     /**
      * @var string[]
      */
-    private $oldClassConstAlaises = [];
+    private $oldClassConstAliases = [];
 
     /**
      * @param string[] $oldStringAliases
-     * @param string[] $oldClassConstAlaises
+     * @param string[] $oldClassConstAliases
      */
     public function __construct(
         array $oldStringAliases,
-        array $oldClassConstAlaises,
+        array $oldClassConstAliases,
         string $class,
         string $constant,
         string $eventClass
     ) {
         $this->oldStringAliases = $oldStringAliases;
-        $this->oldClassConstAlaises = $oldClassConstAlaises;
+        $this->oldClassConstAliases = $oldClassConstAliases;
         $this->class = $class;
         $this->constant = $constant;
         $this->eventClass = $eventClass;
@@ -60,9 +60,9 @@ final class EventInfo
     /**
      * @return string[]
      */
-    public function getOldClassConstAlaises(): array
+    public function getOldClassConstAliases(): array
     {
-        return $this->oldClassConstAlaises;
+        return $this->oldClassConstAliases;
     }
 
     public function getClass(): string

--- a/rules/type-declaration/src/PHPStan/Type/ObjectTypeSpecifier.php
+++ b/rules/type-declaration/src/PHPStan/Type/ObjectTypeSpecifier.php
@@ -22,7 +22,7 @@ final class ObjectTypeSpecifier
     /**
      * @return AliasedObjectType|FullyQualifiedObjectType|ObjectType|MixedType
      */
-    public function narrowToFullyQualifiedOrAlaisedObjectType(Node $node, ObjectType $objectType): Type
+    public function narrowToFullyQualifiedOrAliasedObjectType(Node $node, ObjectType $objectType): Type
     {
         /** @var Use_[]|null $uses */
         $uses = $node->getAttribute(AttributeKey::USE_NODES);


### PR DESCRIPTION
I discovered a typo in a few places: the word "Alias" had been written as "Alais".

I fixed it