### PR TITLE
[Downgrade] Fix parameter type widening issue, when method lives on the ancestor's interface

### DIFF
--- a/rules/downgrade-php72/src/Rector/ClassMethod/DowngradeParameterTypeWideningRector.php
+++ b/rules/downgrade-php72/src/Rector/ClassMethod/DowngradeParameterTypeWideningRector.php
@@ -152,6 +152,20 @@ CODE_SAMPLE
             $parentClassName = $ancestorClassOrInterface->getAttribute(AttributeKey::CLASS_NAME);
             /** @var ClassMethod */
             $classMethod = $this->nodeRepository->findClassMethod($parentClassName, $methodName);
+            /**
+             * If it doesn't find the method, it's because the method
+             * lives somewhere else.
+             * For instance, in test "interface_on_parent_class.php.inc",
+             * the ancestor abstract class is also retrieved
+             * as containing the method, but it does not: it is
+             * in its implemented interface. That happens because
+             * `ReflectionMethod` doesn't allow to do do the distinction.
+             * The interface is also retrieve though, so that method
+             * will eventually be refactored.
+             */
+            if (!$classMethod) {
+                continue;
+            }
             $this->removeParamTypeFromMethod($ancestorClassOrInterface, $position, $classMethod);
             $this->removeParamTypeFromMethodForChildren($parentClassName, $methodName, $position);
         }

--- a/rules/downgrade-php72/src/Rector/ClassMethod/DowngradeParameterTypeWideningRector.php
+++ b/rules/downgrade-php72/src/Rector/ClassMethod/DowngradeParameterTypeWideningRector.php
@@ -150,7 +150,6 @@ CODE_SAMPLE
         foreach ($ancestorAndInterfaceClassNames as $ancestorClassOrInterface) {
             /** @var string */
             $parentClassName = $ancestorClassOrInterface->getAttribute(AttributeKey::CLASS_NAME);
-            /** @var ClassMethod */
             $classMethod = $this->nodeRepository->findClassMethod($parentClassName, $methodName);
             /**
              * If it doesn't find the method, it's because the method
@@ -163,7 +162,7 @@ CODE_SAMPLE
              * The interface is also retrieve though, so that method
              * will eventually be refactored.
              */
-            if (!$classMethod) {
+            if ($classMethod === null) {
                 continue;
             }
             $this->removeParamTypeFromMethod($ancestorClassOrInterface, $position, $classMethod);

--- a/rules/downgrade-php72/tests/Rector/ClassMethod/DowngradeParameterTypeWideningRector/Fixture/interface_on_parent_class.php.inc
+++ b/rules/downgrade-php72/tests/Rector/ClassMethod/DowngradeParameterTypeWideningRector/Fixture/interface_on_parent_class.php.inc
@@ -1,0 +1,48 @@
+<?php
+
+namespace Rector\DowngradePhp72\Tests\Rector\ClassMethod\DowngradeParameterTypeWideningRector\Fixture;
+
+interface SomeInterface
+{
+    public function test(string $input);
+}
+
+abstract class AbstractSomeAncestorClass implements SomeInterface
+{
+}
+
+class SomeChildClass extends AbstractSomeAncestorClass
+{
+    public function test($input) // type omitted for $input
+    {
+        /* ... */
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\DowngradePhp72\Tests\Rector\ClassMethod\DowngradeParameterTypeWideningRector\Fixture;
+
+interface SomeInterface
+{
+    /**
+     * @param string $input
+     */
+    public function test($input);
+}
+
+abstract class AbstractSomeAncestorClass implements SomeInterface
+{
+}
+
+class SomeChildClass extends AbstractSomeAncestorClass
+{
+    public function test($input) // type omitted for $input
+    {
+        /* ... */
+    }
+}
+
+?>

--- a/rules/symfony5/src/Rector/New_/PropertyAccessorCreationBooleanToFlagsRector.php
+++ b/rules/symfony5/src/Rector/New_/PropertyAccessorCreationBooleanToFlagsRector.php
@@ -7,6 +7,7 @@ namespace Rector\Symfony5\Rector\New_;
 use PhpParser\Node;
 use PhpParser\Node\Expr\BinaryOp\BitwiseOr;
 use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Name;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -21,7 +22,7 @@ final class PropertyAccessorCreationBooleanToFlagsRector extends AbstractRector
     {
         return new RuleDefinition('Changes first argument of PropertyAccessor::__construct() to flags from boolean', [
             new CodeSample(
-                <<<'PHP'
+                <<<'CODE_SAMPLE'
 class SomeClass
 {
     public function run()
@@ -29,9 +30,9 @@ class SomeClass
         $propertyAccessor = new PropertyAccessor(true);
     }
 }
-PHP
+CODE_SAMPLE
                 ,
-                <<<'PHP'
+                <<<'CODE_SAMPLE'
 class SomeClass
 {
     public function run()
@@ -39,7 +40,7 @@ class SomeClass
         $propertyAccessor = new PropertyAccessor(PropertyAccessor::MAGIC_CALL | PropertyAccessor::MAGIC_GET | PropertyAccessor::MAGIC_SET);
     }
 }
-PHP
+CODE_SAMPLE
             ),
         ]);
     }
@@ -62,43 +63,41 @@ PHP
         }
 
         $isTrue = $this->isTrue($node->args[0]->value);
-        $flags = $this->prepareFlags($isTrue);
-        $node->args[0] = $this->createArg($flags);
+        $bitwiseOr = $this->prepareFlags($isTrue);
+        $node->args[0] = $this->createArg($bitwiseOr);
 
         return $node;
     }
 
+    private function shouldSkip(New_ $new): bool
+    {
+        if (! $new->class instanceof Name) {
+            return true;
+        }
+
+        if (! $this->isName($new->class, 'Symfony\Component\PropertyAccess\PropertyAccessor')) {
+            return true;
+        }
+        return ! $this->isBool($new->args[0]->value);
+    }
+
     private function prepareFlags(bool $currentValue): BitwiseOr
     {
-        $magicGet = $this->createClassConstFetch('Symfony\Component\PropertyAccess\PropertyAccessor', 'MAGIC_GET');
+        $classConstFetch = $this->createClassConstFetch(
+            'Symfony\Component\PropertyAccess\PropertyAccessor',
+            'MAGIC_GET'
+        );
         $magicSet = $this->createClassConstFetch('Symfony\Component\PropertyAccess\PropertyAccessor', 'MAGIC_SET');
-        if (!$currentValue) {
-            return new BitwiseOr($magicGet, $magicSet);
+        if (! $currentValue) {
+            return new BitwiseOr($classConstFetch, $magicSet);
         }
 
         return new BitwiseOr(
             new BitwiseOr(
                 $this->createClassConstFetch('Symfony\Component\PropertyAccess\PropertyAccessor', 'MAGIC_CALL'),
-                $magicGet,
+                $classConstFetch,
             ),
             $magicSet,
         );
-    }
-
-    private function shouldSkip(New_ $new_): bool
-    {
-        if (! $new_->class instanceof Node\Name) {
-            return true;
-        }
-
-        if (! $this->isName($new_->class, 'Symfony\Component\PropertyAccess\PropertyAccessor')) {
-            return true;
-        }
-
-        if (! $this->isBool($new_->args[0]->value)) {
-            return true;
-        }
-
-        return false;
     }
 }


### PR DESCRIPTION
Fix issue: When running `DowngradeParameterTypeWideningRector` on this code:

```php
interface SomeInterface
{
    public function test(string $input);
}

abstract class AbstractSomeAncestorClass implements SomeInterface
{
}

class SomeChildClass extends AbstractSomeAncestorClass
{
    public function test($input) // type omitted for $input
    {
        /* ... */
    }
}
```

it is also attempting to refactor method `test` in `AbstractSomeAncestorClass`, because `RefactorMethod` indicates that this class contains this method. But it does not: this method lives only on `SomeInterface`.

Now, if the method is not found on the class, then skip it. This works because the interface is also refactored, so the method will be converted there.