### PR TITLE
[Downgrade] Composer's platform check must use the PHP version below

### DIFF
--- a/config/set/downgrade-php70.php
+++ b/config/set/downgrade-php70.php
@@ -13,6 +13,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(DowngradeTypeReturnDeclarationRector::class);
     $services->set(ChangePhpVersionInPlatformCheckRector::class)
         ->call('configure', [[
-            ChangePhpVersionInPlatformCheckRector::TARGET_PHP_VERSION => 70000,
+            ChangePhpVersionInPlatformCheckRector::TARGET_PHP_VERSION => 50600,
         ]]);
 };

--- a/config/set/downgrade-php71.php
+++ b/config/set/downgrade-php71.php
@@ -20,7 +20,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(DowngradeClassConstantVisibilityRector::class);
     $services->set(ChangePhpVersionInPlatformCheckRector::class)
         ->call('configure', [[
-            ChangePhpVersionInPlatformCheckRector::TARGET_PHP_VERSION => 70100,
+            ChangePhpVersionInPlatformCheckRector::TARGET_PHP_VERSION => 70000,
         ]]);
     $services->set(DowngradePipeToMultiCatchExceptionRector::class);
     $services->set(SymmetricArrayDestructuringToListRector::class);

--- a/config/set/downgrade-php72.php
+++ b/config/set/downgrade-php72.php
@@ -14,7 +14,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(DowngradeReturnObjectTypeDeclarationRector::class);
     $services->set(ChangePhpVersionInPlatformCheckRector::class)
         ->call('configure', [[
-            ChangePhpVersionInPlatformCheckRector::TARGET_PHP_VERSION => 70200,
+            ChangePhpVersionInPlatformCheckRector::TARGET_PHP_VERSION => 70100,
         ]]);
     $services->set(DowngradeParameterTypeWideningRector::class);
 };

--- a/config/set/downgrade-php73.php
+++ b/config/set/downgrade-php73.php
@@ -15,7 +15,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(DowngradeListReferenceAssignmentRector::class);
     $services->set(ChangePhpVersionInPlatformCheckRector::class)
         ->call('configure', [[
-            ChangePhpVersionInPlatformCheckRector::TARGET_PHP_VERSION => 70300,
+            ChangePhpVersionInPlatformCheckRector::TARGET_PHP_VERSION => 70200,
         ]]);
     $services->set(DowngradeTrailingCommasInFunctionCallsRector::class);
     $services->set(SetCookieOptionsArrayToArgumentsRector::class);

--- a/config/set/downgrade-php74.php
+++ b/config/set/downgrade-php74.php
@@ -28,7 +28,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(DowngradeArrayMergeCallWithoutArgumentsRector::class);
     $services->set(ChangePhpVersionInPlatformCheckRector::class)
         ->call('configure', [[
-            ChangePhpVersionInPlatformCheckRector::TARGET_PHP_VERSION => 70400,
+            ChangePhpVersionInPlatformCheckRector::TARGET_PHP_VERSION => 70300,
         ]]);
     $services->set(DowngradeFreadFwriteFalsyToNegationRector::class);
 };

--- a/config/set/downgrade-php80.php
+++ b/config/set/downgrade-php80.php
@@ -26,7 +26,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(DowngradeReturnMixedTypeDeclarationRector::class);
     $services->set(DowngradeReturnStaticTypeDeclarationRector::class);
     $services->set(ChangePhpVersionInPlatformCheckRector::class)->call('configure', [[
-        ChangePhpVersionInPlatformCheckRector::TARGET_PHP_VERSION => 80000,
+        ChangePhpVersionInPlatformCheckRector::TARGET_PHP_VERSION => 70400,
     ]]);
     $services->set(DowngradePropertyPromotionToConstructorPropertyAssignRector::class);
     $services->set(DowngradeNonCapturingCatchesRector::class);

--- a/rules/symfony5/src/Rector/New_/PropertyAccessorCreationBooleanToFlagsRector.php
+++ b/rules/symfony5/src/Rector/New_/PropertyAccessorCreationBooleanToFlagsRector.php
@@ -7,6 +7,7 @@ namespace Rector\Symfony5\Rector\New_;
 use PhpParser\Node;
 use PhpParser\Node\Expr\BinaryOp\BitwiseOr;
 use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Name;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -21,7 +22,7 @@ final class PropertyAccessorCreationBooleanToFlagsRector extends AbstractRector
     {
         return new RuleDefinition('Changes first argument of PropertyAccessor::__construct() to flags from boolean', [
             new CodeSample(
-                <<<'PHP'
+                <<<'CODE_SAMPLE'
 class SomeClass
 {
     public function run()
@@ -29,9 +30,9 @@ class SomeClass
         $propertyAccessor = new PropertyAccessor(true);
     }
 }
-PHP
+CODE_SAMPLE
                 ,
-                <<<'PHP'
+                <<<'CODE_SAMPLE'
 class SomeClass
 {
     public function run()
@@ -39,7 +40,7 @@ class SomeClass
         $propertyAccessor = new PropertyAccessor(PropertyAccessor::MAGIC_CALL | PropertyAccessor::MAGIC_GET | PropertyAccessor::MAGIC_SET);
     }
 }
-PHP
+CODE_SAMPLE
             ),
         ]);
     }
@@ -62,43 +63,41 @@ PHP
         }
 
         $isTrue = $this->isTrue($node->args[0]->value);
-        $flags = $this->prepareFlags($isTrue);
-        $node->args[0] = $this->createArg($flags);
+        $bitwiseOr = $this->prepareFlags($isTrue);
+        $node->args[0] = $this->createArg($bitwiseOr);
 
         return $node;
     }
 
+    private function shouldSkip(New_ $new): bool
+    {
+        if (! $new->class instanceof Name) {
+            return true;
+        }
+
+        if (! $this->isName($new->class, 'Symfony\Component\PropertyAccess\PropertyAccessor')) {
+            return true;
+        }
+        return ! $this->isBool($new->args[0]->value);
+    }
+
     private function prepareFlags(bool $currentValue): BitwiseOr
     {
-        $magicGet = $this->createClassConstFetch('Symfony\Component\PropertyAccess\PropertyAccessor', 'MAGIC_GET');
+        $classConstFetch = $this->createClassConstFetch(
+            'Symfony\Component\PropertyAccess\PropertyAccessor',
+            'MAGIC_GET'
+        );
         $magicSet = $this->createClassConstFetch('Symfony\Component\PropertyAccess\PropertyAccessor', 'MAGIC_SET');
-        if (!$currentValue) {
-            return new BitwiseOr($magicGet, $magicSet);
+        if (! $currentValue) {
+            return new BitwiseOr($classConstFetch, $magicSet);
         }
 
         return new BitwiseOr(
             new BitwiseOr(
                 $this->createClassConstFetch('Symfony\Component\PropertyAccess\PropertyAccessor', 'MAGIC_CALL'),
-                $magicGet,
+                $classConstFetch,
             ),
             $magicSet,
         );
-    }
-
-    private function shouldSkip(New_ $new_): bool
-    {
-        if (! $new_->class instanceof Node\Name) {
-            return true;
-        }
-
-        if (! $this->isName($new_->class, 'Symfony\Component\PropertyAccess\PropertyAccessor')) {
-            return true;
-        }
-
-        if (! $this->isBool($new_->args[0]->value)) {
-            return true;
-        }
-
-        return false;
     }
 }


### PR DESCRIPTION
When using set `downgrading-php80`, we're downgrading from PHP 8.0 to its previous version, i.e. 7.4. Hence, Composer's platform check (on `vendor/composer/platform_check.php`) must do `if (!(PHP_VERSION_ID >= 70400)) {` (not `80000`).

Fixed for all downgrade sets.