### PR TITLE
[Symfony 5.2] Rename setProviderKey()/getProviderKey() to setFirewallName()/getFirewallName()

### DIFF
--- a/config/set/symfony52.php
+++ b/config/set/symfony52.php
@@ -51,4 +51,18 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 ),
             ]),
         ]]);
+
+    $services->set(RenameMethodRector::class)
+        ->call('configure', [[
+            new MethodCallRename('Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken', 'setProviderKey', 'setFirewallName'),
+            new MethodCallRename('Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken', 'getProviderKey', 'getFirewallName'),
+            new MethodCallRename('Symfony\Component\Security\Core\Authentication\Token\RememberMeToken', 'setProviderKey', 'setFirewallName'),
+            new MethodCallRename('Symfony\Component\Security\Core\Authentication\Token\RememberMeToken', 'getProviderKey', 'getFirewallName'),
+            new MethodCallRename('Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken', 'setProviderKey', 'setFirewallName'),
+            new MethodCallRename('Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken', 'getProviderKey', 'getFirewallName'),
+            new MethodCallRename('Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken', 'setProviderKey', 'setFirewallName'),
+            new MethodCallRename('Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken', 'getProviderKey', 'getFirewallName'),
+            new MethodCallRename('Symfony\Component\Security\Http\Authentication\DefaultAuthenticationSuccessHandler', 'setProviderKey', 'setFirewallName'),
+            new MethodCallRename('Symfony\Component\Security\Http\Authentication\DefaultAuthenticationSuccessHandler', 'getProviderKey', 'getFirewallName'),
+        ]]);
 };

--- a/config/set/symfony52.php
+++ b/config/set/symfony52.php
@@ -54,15 +54,17 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(RenameMethodRector::class)
         ->call('configure', [[
-            new MethodCallRename('Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken', 'setProviderKey', 'setFirewallName'),
-            new MethodCallRename('Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken', 'getProviderKey', 'getFirewallName'),
-            new MethodCallRename('Symfony\Component\Security\Core\Authentication\Token\RememberMeToken', 'setProviderKey', 'setFirewallName'),
-            new MethodCallRename('Symfony\Component\Security\Core\Authentication\Token\RememberMeToken', 'getProviderKey', 'getFirewallName'),
-            new MethodCallRename('Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken', 'setProviderKey', 'setFirewallName'),
-            new MethodCallRename('Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken', 'getProviderKey', 'getFirewallName'),
-            new MethodCallRename('Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken', 'setProviderKey', 'setFirewallName'),
-            new MethodCallRename('Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken', 'getProviderKey', 'getFirewallName'),
-            new MethodCallRename('Symfony\Component\Security\Http\Authentication\DefaultAuthenticationSuccessHandler', 'setProviderKey', 'setFirewallName'),
-            new MethodCallRename('Symfony\Component\Security\Http\Authentication\DefaultAuthenticationSuccessHandler', 'getProviderKey', 'getFirewallName'),
+            RenameMethodRector::METHOD_CALL_RENAMES => ValueObjectInliner::inline([
+                new MethodCallRename('Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken', 'setProviderKey', 'setFirewallName'),
+                new MethodCallRename('Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken', 'getProviderKey', 'getFirewallName'),
+                new MethodCallRename('Symfony\Component\Security\Core\Authentication\Token\RememberMeToken', 'setProviderKey', 'setFirewallName'),
+                new MethodCallRename('Symfony\Component\Security\Core\Authentication\Token\RememberMeToken', 'getProviderKey', 'getFirewallName'),
+                new MethodCallRename('Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken', 'setProviderKey', 'setFirewallName'),
+                new MethodCallRename('Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken', 'getProviderKey', 'getFirewallName'),
+                new MethodCallRename('Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken', 'setProviderKey', 'setFirewallName'),
+                new MethodCallRename('Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken', 'getProviderKey', 'getFirewallName'),
+                new MethodCallRename('Symfony\Component\Security\Http\Authentication\DefaultAuthenticationSuccessHandler', 'setProviderKey', 'setFirewallName'),
+                new MethodCallRename('Symfony\Component\Security\Http\Authentication\DefaultAuthenticationSuccessHandler', 'getProviderKey', 'getFirewallName'),
+            ]),
         ]]);
 };


### PR DESCRIPTION
Part of #4824