### PR TITLE
[Downgrade] Add ".0" after downgrading the numeric literal separator on floats

### DIFF
--- a/rules/downgrade-php74/src/Rector/LNumber/DowngradeNumericLiteralSeparatorRector.php
+++ b/rules/downgrade-php74/src/Rector/LNumber/DowngradeNumericLiteralSeparatorRector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\DowngradePhp74\Rector\LNumber;
 
+use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Scalar\DNumber;
 use PhpParser\Node\Scalar\LNumber;
@@ -68,6 +69,17 @@ CODE_SAMPLE
         }
 
         $node->value = (string) $node->value;
+
+        /**
+         * This code follows a guess, to avoid modifying floats needlessly.
+         * If the node is a float, but it doesn't contain ".",
+         * then it's likely that the number was forced to be a float
+         * by adding ".0" at the end (eg: 0.0).
+         * Then, add it again.
+         */
+        if ($node instanceof DNumber && ! Strings::contains($node->value, '.')) {
+            $node->value .= '.0';
+        }
         return $node;
     }
 

--- a/rules/downgrade-php74/tests/Rector/LNumber/DowngradeNumericLiteralSeparatorRector/Fixture/no_change.php.inc
+++ b/rules/downgrade-php74/tests/Rector/LNumber/DowngradeNumericLiteralSeparatorRector/Fixture/no_change.php.inc
@@ -8,6 +8,7 @@ class NoChangeClass
     {
         $int = 1000;
         $float = 1000500.001;
+        $forced_float = 1000500.0;
         $negative_int = -1000;
         $negative_float = -1000500.001;
         $binary = 0b11111111;


### PR DESCRIPTION
Fixes #4881.

As explained in https://github.com/rectorphp/rector/issues/4881#issuecomment-745127760:

> if the downgraded float doesn't have `.`, then quite likely it was forced to be a float by doing `0.0` instead of `0` (for instance, Symfony does this approach). Then add `.0` again on the downgraded number (which is a string).