### PR TITLE
[BUGFIX] Docs: Resolve link to doc block tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,7 @@ Rector helps you with 2 areas - major code changes and in daily work.
 It's a tool that [we develop](https://getrector.org/) and share for free, so
 anyone can automate their refactoring.
 
-[Hire us](https://getrector.org/contact) to skip learning Rector, AST and nodes,
-to educate your team about Rectors benefits and to setup Rector in your project,
-so that you can enjoy the 300 % development speed :+1:
+[Hire us](https://getrector.org/contact) to skip learning Rector, AST and nodes, to educate your team about Rectors benefits and to setup Rector in your project, so that you can enjoy the 300 % development speed :+1:
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,12 @@ Rector helps you with 2 areas - major code changes and in daily work.
 
 <br>
 
-It's a tool that [we develop](https://getrector.org/) and share for free, so you anyone can automate their refactoring.
+It's a tool that [we develop](https://getrector.org/) and share for free, so
+anyone can automate their refactoring.
 
-[Hire us](https://getrector.org/contact) to skip learning Rector, AST and nodes, to educate your team about Rectors benefits and to setup Rector in your project - so you can enjoy the 300 % development speed :+1:
+[Hire us](https://getrector.org/contact) to skip learning Rector, AST and nodes,
+to educate your team about Rectors benefits and to setup Rector in your project,
+so that you can enjoy the 300 % development speed :+1:
 
 <br>
 
@@ -72,7 +75,7 @@ It supports all versions of PHP from 5.2 and major open-source projects:
 - [How To Run Rector on Changed Files Only](/docs/how_to_run_rector_on_changed_files_only.md)
 - [How to Ignore Rule or Paths](/docs/how_to_ignore_rule_or_paths.md)
 - [How to Configure Rule](/docs/how_to_configure_rules.md)
-- [How To Work with Doc Block and Comments](/docs/how_to_work_with_doc_block_and_comments.md:2)
+- [How To Work with Doc Block and Comments](/docs/how_to_work_with_doc_block_and_comments.md)
 - [How run Rector in Docker](/docs/how_to_run_rector_in_docker.md)
 - [Add Checkstyle with your CI](/docs/checkstyle.md)
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ Rector helps you with 2 areas - major code changes and in daily work.
 
 <br>
 
-It's a tool that [we develop](https://getrector.org/) and share for free, so
-anyone can automate their refactoring.
+It's a tool that [we develop](https://getrector.org/) and share for free, so anyone can automate their refactoring.
 
 [Hire us](https://getrector.org/contact) to skip learning Rector, AST and nodes, to educate your team about Rectors benefits and to setup Rector in your project, so that you can enjoy the 300 % development speed :+1:
 


### PR DESCRIPTION
Remove wrongly appended part from the URI.

Tiny side change - replace "you anybody" with "anybody" in upper section.