### PR TITLE
[Symfony Code Quality] Fixes EventListenerToEventSubscriberRector do not replace method call properly

### DIFF
--- a/rules/symfony-code-quality/src/Rector/Class_/EventListenerToEventSubscriberRector.php
+++ b/rules/symfony-code-quality/src/Rector/Class_/EventListenerToEventSubscriberRector.php
@@ -333,6 +333,10 @@ CODE_SAMPLE
             }
         }
 
+        if (! isset($methodName, $priority)) {
+            return;
+        }
+
         if ($priority !== 0) {
             $methodNameWithPriorityArray = new Array_();
             $methodNameWithPriorityArray->items[] = new ArrayItem(new String_($methodName));

--- a/rules/symfony-code-quality/tests/Rector/Class_/EventListenerToEventSubscriberRector/Fixture/multiple_listeners_called_once.php.inc
+++ b/rules/symfony-code-quality/tests/Rector/Class_/EventListenerToEventSubscriberRector/Fixture/multiple_listeners_called_once.php.inc
@@ -19,7 +19,7 @@ class MultipleListenersCalledOnce
 
 namespace Rector\SymfonyCodeQuality\Tests\Rector\Class_\EventListenerToEventSubscriberRector\Fixture;
 
-class MultipleMethodsCalledOnceEventSubscriber implements \Symfony\Component\EventDispatcher\EventSubscriberInterface
+class MultipleListenersCalledOnceEventSubscriber implements \Symfony\Component\EventDispatcher\EventSubscriberInterface
 {
     public function singles()
     {

--- a/rules/symfony-code-quality/tests/Rector/Class_/EventListenerToEventSubscriberRector/Fixture/multiple_listeners_called_once.php.inc
+++ b/rules/symfony-code-quality/tests/Rector/Class_/EventListenerToEventSubscriberRector/Fixture/multiple_listeners_called_once.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\SymfonyCodeQuality\Tests\Rector\Class_\EventListenerToEventSubscriberRector\Fixture;
 
-class MultipleMethodsCalledOnce
+class MultipleListenersCalledOnce
 {
     public function singles()
     {

--- a/rules/symfony-code-quality/tests/Rector/Class_/EventListenerToEventSubscriberRector/Fixture/multiple_listeners_called_once.php.inc
+++ b/rules/symfony-code-quality/tests/Rector/Class_/EventListenerToEventSubscriberRector/Fixture/multiple_listeners_called_once.php.inc
@@ -1,0 +1,40 @@
+<?php
+
+namespace Rector\SymfonyCodeQuality\Tests\Rector\Class_\EventListenerToEventSubscriberRector\Fixture;
+
+class MultipleMethodsCalledOnce
+{
+    public function singles()
+    {
+    }
+
+    public function second()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\SymfonyCodeQuality\Tests\Rector\Class_\EventListenerToEventSubscriberRector\Fixture;
+
+class MultipleMethodsCalledOnceEventSubscriber implements \Symfony\Component\EventDispatcher\EventSubscriberInterface
+{
+    public function singles()
+    {
+    }
+
+    public function second()
+    {
+    }
+    /**
+     * @return mixed[]
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return ['single_event' => 'singles', 'single_second_event' => 'second'];
+    }
+}
+
+?>

--- a/rules/symfony-code-quality/tests/Rector/Class_/EventListenerToEventSubscriberRector/Fixture/multiple_listeners_with_non_kernel.php.inc
+++ b/rules/symfony-code-quality/tests/Rector/Class_/EventListenerToEventSubscriberRector/Fixture/multiple_listeners_with_non_kernel.php.inc
@@ -8,7 +8,7 @@ class MultipleMethodsWithNonKernel
     {
     }
 
-    public function unkownMethod()
+    public function unknownMethod()
     {
     }
 }

--- a/rules/symfony-code-quality/tests/Rector/Class_/EventListenerToEventSubscriberRector/Fixture/multiple_listeners_with_non_kernel.php.inc
+++ b/rules/symfony-code-quality/tests/Rector/Class_/EventListenerToEventSubscriberRector/Fixture/multiple_listeners_with_non_kernel.php.inc
@@ -1,0 +1,40 @@
+<?php
+
+namespace Rector\SymfonyCodeQuality\Tests\Rector\Class_\EventListenerToEventSubscriberRector\Fixture;
+
+class MultipleMethodsWithNonKernel
+{
+    public function singles()
+    {
+    }
+
+    public function unkownMethod()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\SymfonyCodeQuality\Tests\Rector\Class_\EventListenerToEventSubscriberRector\Fixture;
+
+class MultipleMethodsWithNonKernelEventSubscriber implements \Symfony\Component\EventDispatcher\EventSubscriberInterface
+{
+    public function singles()
+    {
+    }
+
+    public function unknownMethod()
+    {
+    }
+    /**
+     * @return mixed[]
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return ['single_event' => 'singles'];
+    }
+}
+
+?>

--- a/rules/symfony-code-quality/tests/Rector/Class_/EventListenerToEventSubscriberRector/config/listener_services.xml
+++ b/rules/symfony-code-quality/tests/Rector/Class_/EventListenerToEventSubscriberRector/config/listener_services.xml
@@ -21,7 +21,7 @@
         </service>
 
         <service id="fifth_listener" class="Rector\SymfonyCodeQuality\Tests\Rector\Class_\EventListenerToEventSubscriberRector\Fixture\MultipleMethodsWithNonKernel">
-            <tag name="another_listener" event="unkown_event" method="unknownMethod"/>
+            <tag name="another_listener" event="unknown_event" method="unknownMethod"/>
             <tag name="kernel.event_listener" event="single_event" method="singles"/>
         </service>
 

--- a/rules/symfony-code-quality/tests/Rector/Class_/EventListenerToEventSubscriberRector/config/listener_services.xml
+++ b/rules/symfony-code-quality/tests/Rector/Class_/EventListenerToEventSubscriberRector/config/listener_services.xml
@@ -15,6 +15,16 @@
             <tag name="kernel.event_listener" event="multi_event" method="meToo"/>
         </service>
 
+        <service id="fourth_listener" class="Rector\SymfonyCodeQuality\Tests\Rector\Class_\EventListenerToEventSubscriberRector\Fixture\MultipleMethodsCalledOnce">
+            <tag name="kernel.event_listener" event="single_event" method="singles"/>
+            <tag name="kernel.event_listener" event="single_second_event" method="second"/>
+        </service>
+
+        <service id="fifth_listener" class="Rector\SymfonyCodeQuality\Tests\Rector\Class_\EventListenerToEventSubscriberRector\Fixture\MultipleMethodsWithNonKernel">
+            <tag name="another_listener" event="unkown_event" method="unknownMethod"/>
+            <tag name="kernel.event_listener" event="single_event" method="singles"/>
+        </service>
+
         <service id="event_dispatcher" class="Symfony\Component\EventDispatcher\EventDispatcher"/>
     </services>
 </container>

--- a/rules/symfony-code-quality/tests/Rector/Class_/EventListenerToEventSubscriberRector/config/listener_services.xml
+++ b/rules/symfony-code-quality/tests/Rector/Class_/EventListenerToEventSubscriberRector/config/listener_services.xml
@@ -15,7 +15,7 @@
             <tag name="kernel.event_listener" event="multi_event" method="meToo"/>
         </service>
 
-        <service id="fourth_listener" class="Rector\SymfonyCodeQuality\Tests\Rector\Class_\EventListenerToEventSubscriberRector\Fixture\MultipleMethodsCalledOnce">
+        <service id="fourth_listener" class="Rector\SymfonyCodeQuality\Tests\Rector\Class_\EventListenerToEventSubscriberRector\Fixture\MultipleListenersCalledOnce">
             <tag name="kernel.event_listener" event="single_event" method="singles"/>
             <tag name="kernel.event_listener" event="single_second_event" method="second"/>
         </service>


### PR DESCRIPTION
 Fixes #4899 