### PR TITLE
 [Solid] Skip MoveVariableDeclarationNearReferenceRector when next statement has static call

### DIFF
--- a/rules/solid/src/Rector/Variable/MoveVariableDeclarationNearReferenceRector.php
+++ b/rules/solid/src/Rector/Variable/MoveVariableDeclarationNearReferenceRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Do_;
@@ -209,6 +210,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($this->hasStaticCall($next)) {
+            return null;
+        }
+
         $countFound = $this->getCountFound($next, $node);
         if ($countFound === 0 || $countFound >= 2) {
             return null;
@@ -221,6 +226,13 @@ CODE_SAMPLE
         }
 
         return $this->getSameVarNameInNexts($next, $node);
+    }
+
+    private function hasStaticCall(Node $node): bool
+    {
+        return (bool) $this->betterNodeFinder->findFirst($node, function (Node $n): bool {
+            return $n instanceof StaticCall;
+        });
     }
 
     private function isInsideLoopStmts(Node $node): bool

--- a/rules/solid/src/Rector/Variable/MoveVariableDeclarationNearReferenceRector.php
+++ b/rules/solid/src/Rector/Variable/MoveVariableDeclarationNearReferenceRector.php
@@ -228,13 +228,6 @@ CODE_SAMPLE
         return $this->getSameVarNameInNexts($next, $node);
     }
 
-    private function hasStaticCall(Node $node): bool
-    {
-        return (bool) $this->betterNodeFinder->findFirst($node, function (Node $n): bool {
-            return $n instanceof StaticCall;
-        });
-    }
-
     private function isInsideLoopStmts(Node $node): bool
     {
         $parent = $node->getAttribute(AttributeKey::PARENT_NODE);
@@ -258,6 +251,13 @@ CODE_SAMPLE
         }
 
         return $node;
+    }
+
+    private function hasStaticCall(Node $node): bool
+    {
+        return (bool) $this->betterNodeFinder->findFirst($node, function (Node $n): bool {
+            return $n instanceof StaticCall;
+        });
     }
 
     private function getCountFound(Node $node, Variable $variable): int

--- a/rules/solid/tests/Rector/Variable/MoveVariableDeclarationNearReferenceRector/Fixture/skip_usage_in_static_call.php.inc
+++ b/rules/solid/tests/Rector/Variable/MoveVariableDeclarationNearReferenceRector/Fixture/skip_usage_in_static_call.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\SOLID\Tests\Rector\Variable\MoveVariableDeclarationNearReferenceRector\Fixture;
+
+class SkipUsageInStaticCall
+{
+    function myMethod()
+    {
+        $crawler = $kernelBrowser->request('GET', '/');
+        self::assertResponseIsSuccessful();
+        self::assertStringContainsString('Hello World', $crawler->filter('h1, h2, h3')->text());
+    }
+}
+?>


### PR DESCRIPTION
ref https://github.com/rectorphp/rector/issues/4913#issuecomment-747698193