### PR TITLE
Keep colon when it's used in Doctrine tag's original content.

### DIFF
--- a/packages/better-php-doc-parser/src/ValueObjectFactory/TagValueNodeConfigurationFactory.php
+++ b/packages/better-php-doc-parser/src/ValueObjectFactory/TagValueNodeConfigurationFactory.php
@@ -42,6 +42,12 @@ final class TagValueNodeConfigurationFactory
      */
     public const CLOSING_BRACKET_REGEX = '#\)$#';
 
+    /**
+     * @var string
+     * @see https://regex101.com/r/0KlSQv/1
+     */
+    public const ARRAY_COLON_SEPARATOR_REGEX = '#{([^{}]+)[:]([^{}]+)}#';
+
     public function createFromOriginalContent(
         ?string $originalContent,
         PhpDocTagValueNode $phpDocTagValueNode
@@ -70,7 +76,7 @@ final class TagValueNodeConfigurationFactory
 
         $isSilentKeyExplicit = (bool) Strings::contains($originalContent, sprintf('%s=', $silentKey));
 
-        $arrayEqualSign = $this->resolveArrayEqualSignByPhpNodeClass($phpDocTagValueNode);
+        $arrayEqualSign = $this->resolveArraySeparatorSign($originalContent, $phpDocTagValueNode);
 
         return new TagValueNodeConfiguration(
             $originalContent,
@@ -108,6 +114,16 @@ final class TagValueNodeConfigurationFactory
         $quotedArrayPattern = sprintf('#%s=\{"(.*)"\}|\{"(.*)"\}#', $escapedKey);
 
         return (bool) Strings::match($originalContent, $quotedArrayPattern);
+    }
+
+    private function resolveArraySeparatorSign(string $originalContent, PhpDocTagValueNode $phpDocTagValueNode): string
+    {
+        $hasArrayColonSeparator = (bool) Strings::match($originalContent, self::ARRAY_COLON_SEPARATOR_REGEX);
+
+        if ($hasArrayColonSeparator) {
+            return ':';
+        }
+        return $this->resolveArrayEqualSignByPhpNodeClass($phpDocTagValueNode);
     }
 
     /**

--- a/packages/better-php-doc-parser/tests/ValueObjectFactory/TagValueNodeConfigurationFactoryTest.php
+++ b/packages/better-php-doc-parser/tests/ValueObjectFactory/TagValueNodeConfigurationFactoryTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Rector\BetterPhpDocParser\Tests\ValueObjectFactory;
 
 use PHPUnit\Framework\TestCase;
+use Rector\BetterPhpDocParser\ValueObject\PhpDocNode\Doctrine\Property_\ColumnTagValueNode;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocNode\Symfony\SymfonyRouteTagValueNode;
 use Rector\BetterPhpDocParser\ValueObjectFactory\TagValueNodeConfigurationFactory;
+use Iterator;
 
 final class TagValueNodeConfigurationFactoryTest extends TestCase
 {
@@ -28,5 +30,23 @@ final class TagValueNodeConfigurationFactoryTest extends TestCase
         );
 
         $this->assertSame('=', $tagValueNodeConfiguration->getArrayEqualSign());
+    }
+
+    /**
+     * @dataProvider provideData()
+     */
+    public function testArrayColonIsNotChangedToEqual(string $originalContent): void
+    {
+        $tagValueNodeConfiguration = $this->tagValueNodeConfigurationFactory->createFromOriginalContent(
+            $originalContent,
+            new ColumnTagValueNode([])
+        );
+
+        $this->assertSame(':', $tagValueNodeConfiguration->getArrayEqualSign());
+    }
+
+    public function provideData(): Iterator
+    {
+        yield ['(type="integer", nullable=true, options={"default":0})'];
     }
 }


### PR DESCRIPTION
Rector changes use of colon array separator to equal by default.

Example tag `(options={"key":"value"})` is changed to `(options={"key"="value"})`.

This change enables Rector to first check if a colon is used before changing it to equal.

See related issue at https://github.com/rectorphp/rector/issues/3225