### PR TITLE
 [PHP 7.0]  Skip StaticCallOnNonStaticToInstanceCallRector on dynamic static call

### DIFF
--- a/rules/php70/src/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector.php
+++ b/rules/php70/src/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector.php
@@ -167,6 +167,10 @@ CODE_SAMPLE
 
     private function isInstantiable(string $className): bool
     {
+        if (! class_exists($className)) {
+            return false;
+        }
+
         $reflectionClass = new ReflectionClass($className);
         $classConstructorReflection = $reflectionClass->getConstructor();
 

--- a/rules/php70/tests/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector/Fixture/skip_dynamic_static_call.php.inc
+++ b/rules/php70/tests/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector/Fixture/skip_dynamic_static_call.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Php70\Tests\Rector\StaticCall\StaticCallOnNonStaticToInstanceCallRector\Fixture;
+
+class SkipDynamicStaticCall
+{
+    public function getMethod(): object
+    {
+    }
+
+    public function run()
+    {
+        $store = $this->getMethod();
+        $store::foo();
+    }
+}


### PR DESCRIPTION
Fixes #4954