### PR TITLE
[PHP 7.4] Skip TypedPropertyRector on standalone null type

### DIFF
--- a/rules/php74/src/Rector/Property/TypedPropertyRector.php
+++ b/rules/php74/src/Rector/Property/TypedPropertyRector.php
@@ -183,6 +183,9 @@ CODE_SAMPLE
         }
 
         $typeName = $this->getName($node);
+        if ($typeName === 'null') {
+            return true;
+        }
         if ($typeName === null) {
             return false;
         }

--- a/rules/php74/tests/Rector/Property/TypedPropertyRector/Fixture/skip_null_type.php.inc
+++ b/rules/php74/tests/Rector/Property/TypedPropertyRector/Fixture/skip_null_type.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
+
+class SkipNullType
+{
+    /**
+     * @var null|mixed
+     */
+    protected $property;
+
+    function some()
+    {
+	    $this->property = null;
+	}
+}


### PR DESCRIPTION
Fixes #4956