### PR TITLE
Add ext-intl to require section of composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "php": "^7.3|^8.0",
         "ext-json": "*",
         "ext-dom": "*",
+        "ext-intl": "*",
         "composer/xdebug-handler": "^1.4",
         "doctrine/annotations": "^1.11",
         "doctrine/inflector": "^2.0",


### PR DESCRIPTION
Without ext-intl installed rector triggers an error when I try to run `app/console`:

```
[16:53:53] brzv@brzv:~/Github/rector$ bin/rector
PHP Notice:  Nette\Utils\Strings::toAscii(): it is recommended to enable PHP extensions 'intl'. in /home/brzv/Github/rector/vendor/nette/utils/src/Utils/Strings.php on line 152
PHP Stack trace:
PHP   1. {main}() /home/brzv/Github/rector/bin/rector:0
PHP   2. require_once() /home/brzv/Github/rector/bin/rector:4
```