### PR TITLE
failing test: ClassPropertyAssignToConstructorPromotionRector: should ignore early returns

### DIFF
--- a/rules/php80/tests/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/earlyReturn.php.inc
+++ b/rules/php80/tests/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/earlyReturn.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Php80\Tests\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector\Fixture;
+
+final class DemoFile
+{
+  public int $x = 60;
+    
+	public function __construct(int $x)
+	{
+    if ($x < 0) {
+       return;
+    }
+		$this->x = $x;
+	}
+}
+?>


### PR DESCRIPTION
Currently it promotes variable which is assigned AFTER early return. [Which changes behaviour.](https://getrector.org/demo/2676fbab-e519-4f3a-883d-daf1c92619d6)

(Maybe another) question is what should it do with [excetions](https://getrector.org/demo/fad9ecfe-4307-4f7c-aa98-d39c349cef98). Probably nothing, as class is NOT created when there is an exception thrown in constructor?