### PR TITLE
failing test: ClassPropertyAssignToConstructorPromotionRector: Create parameter is not passed as a reference

### DIFF
--- a/rules/php80/tests/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/parameter-is-not-passed-as-reference.php.inc
+++ b/rules/php80/tests/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/parameter-is-not-passed-as-reference.php.inc
@@ -21,7 +21,8 @@ namespace Rector\Php80\Tests\Rector\Class_\ClassPropertyAssignToConstructorPromo
 class X {
         
     function __construct(public string $x) {
-        $this->x = 'preprended-' . $this->x;
+        $this->x = 'preprended-' . $x;
+        $this->x = $x;
     }
     
 }

--- a/rules/php80/tests/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/parameter-is-not-passed-as-reference.php.inc
+++ b/rules/php80/tests/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector/parameter-is-not-passed-as-reference.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\Php80\Tests\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector\Fixture;
+
+class X {
+    
+    public $x;
+    
+    function __construct(string $x) {
+        $x = 'preprended-' . $x;
+        $this->x = $x;
+    }
+    
+}
+?>
+-----
+<?php
+
+namespace Rector\Php80\Tests\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector\Fixture;
+
+class X {
+        
+    function __construct(public string $x) {
+        $this->x = 'preprended-' . $this->x;
+    }
+    
+}
+?>


### PR DESCRIPTION
# The original code

I have tried to migrated [this code](https://3v4l.org/JoUf8):
```php
<?php

class X {
    
    public string $x;
    
    function __construct(string $x) {
        $x = 'preprended-' . $x;
        $this->x = $x;
    }
    
}

$x = new X('input');
echo $x->x; // === "preprended-input"
```

# [Option 1](https://3v4l.org/lW0Hd): Used `$this->x` instead of local variable

As argument passed to constructor is NOT passed as reference, it is not possible to change value of property by assigning into local variable.

```php
<?php

class X {
    
    function __construct(public string $x) {
        $this->x = 'preprended-' . $this->x;
    }
    
}

$x = new X('input');
echo $x->x;
```


# [Option 2](https://3v4l.org/OQOpR): Overriding argument with reference:
```php
<?php

class X {
    
    function __construct(public string $x) {
        $x = & $this->x;
        $x = 'preprended-' . $x;
    }
    
}

$x = new X('input');
echo $x->x;
```


# [this PR] [Option 3](https://3v4l.org/eEeK1): Reassign changed property at the end

```php
<?php

class X {
    
    function __construct(public string $x) {
        $x = 'preprended-' . $x;
        $this->x = $x;
    }
    
}

$x = new X('input');
echo $x->x;
```


# Summary

<del>To me, option 1 looks as the most readable and simplest to implement.</del> I have updated PR to option 3.