### PR TITLE
Add failing test fixture for AddArrayReturnDocTypeRector - array shape is replaced by structural type

### DIFF
--- a/rules/type-declaration/tests/Rector/ClassMethod/AddArrayReturnDocTypeRector/Fixture/b.php.inc
+++ b/rules/type-declaration/tests/Rector/ClassMethod/AddArrayReturnDocTypeRector/Fixture/b.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\TypeDeclaration\Tests\Rector\ClassMethod\AddArrayReturnDocTypeRector\Fixture;
+
+final class B
+{
+	/** @return array{a: string, b: int, c: float}[] */
+	public function X(): array
+	{
+		return [
+            [
+				'a' => 'string',
+            	'b' => 1,
+            	'c' => 1.0,
+        	]
+        ];
+    }
+}
+?>


### PR DESCRIPTION
# Failing Test for AddArrayReturnDocTypeRector

Based on https://getrector.org/demo/4afc86f8-de78-4f13-bed4-3644f1b16d6d

`AddArrayReturnDocTypeRector` replaces array shape with less specific structural type.

BTW: current assigned type `int[][]|float[][]|string[][]` is wrong, as it does NOT allow to pass int|float|string for each value. It allows only int-only array, or float-only array, etc. Correct (still less specific type) would be `array<string, int|float|string>[]` or `(int|float|string)[][]`