### PR TITLE
Add failing test fixture for AddArrayReturnDocTypeRector – not compatible with generic parameters

### DIFF
--- a/rules/type-declaration/tests/Rector/ClassMethod/AddArrayReturnDocTypeRector/Fixture/base_model.php.inc
+++ b/rules/type-declaration/tests/Rector/ClassMethod/AddArrayReturnDocTypeRector/Fixture/base_model.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\TypeDeclaration\Tests\Rector\ClassMethod\AddArrayReturnDocTypeRector\Fixture;
+
+class BaseModel {}
+
+namespace Rector\TypeDeclaration\Tests\Rector\ClassMethod\AddArrayReturnDocTypeRector\Fixture;
+
+final class DemoFile
+{
+	/**
+	 * @template T of BaseModel
+	 * @param class-string<T> $otherModelClass
+	 * @return T[]
+	 */
+	public static function findMany(
+		BaseModel $me
+	): array {
+        /** @var T[] $rArray */
+		$rArray = []; // get data from somewhere
+		return $rArray;
+    }
+}
+?>

--- a/rules/type-declaration/tests/Rector/ClassMethod/AddArrayReturnDocTypeRector/Fixture/base_model.php.inc
+++ b/rules/type-declaration/tests/Rector/ClassMethod/AddArrayReturnDocTypeRector/Fixture/base_model.php.inc
@@ -14,7 +14,7 @@ final class DemoFile
 	 * @return T[]
 	 */
 	public static function findMany(
-		BaseModel $me
+		string $otherModelClass
 	): array {
         /** @var T[] $rArray */
 		$rArray = []; // get data from somewhere


### PR DESCRIPTION
# Failing Test for AddArrayReturnDocTypeRector

Based on https://getrector.org/demo/d79b7b37-2939-4f8c-99f8-dc1602888273

AddArrayReturnDocTypeRector should keep generic `@return` php doc intact. As current doc block is more specific that what has been inferred.