### PR TITLE
Add failing test fixture for AddArrayReturnDocTypeRector – shape arrays inherited from parent

### DIFF
--- a/rules/type-declaration/tests/Rector/ClassMethod/AddArrayReturnDocTypeRector/Fixture/a.php.inc
+++ b/rules/type-declaration/tests/Rector/ClassMethod/AddArrayReturnDocTypeRector/Fixture/a.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+
+namespace Rector\TypeDeclaration\Tests\Rector\ClassMethod\AddArrayReturnDocTypeRector\Fixture;
+
+abstract class A {
+	/** @return array{a: string, b: int, c: float}[] */
+	public function X(): array { return []; }
+}
+
+namespace Rector\TypeDeclaration\Tests\Rector\ClassMethod\AddArrayReturnDocTypeRector\Fixture;
+
+class B extends A
+{
+	public function X(): array { return [ [ 'a' => 'string', 'b' => 1, 'c' => 1.0 ] ]; }
+}
+?>


### PR DESCRIPTION
Follow up from #5016

# Failing Test for AddArrayReturnDocTypeRector

Based on https://getrector.org/demo/27963b19-4d20-4f99-b376-267d21aa828c

Rector should also ignore array shapes which are inherited from parent parent class method.