### PR TITLE
Fix fatal error auto-loading file for already existing class by invalid class-name

### DIFF
--- a/rules/renaming/tests/Rector/FileWithoutNamespace/PseudoNamespaceToNamespaceRector/PseudoNamespaceToNamespaceRectorTest.php
+++ b/rules/renaming/tests/Rector/FileWithoutNamespace/PseudoNamespaceToNamespaceRector/PseudoNamespaceToNamespaceRectorTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Rector\Renaming\Tests\Rector\FileWithoutNamespace\PseudoNamespaceToNamespaceRector;
 
 use Iterator;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
 use Rector\Generic\ValueObject\PseudoNamespaceToNamespace;
 use Rector\Renaming\Rector\FileWithoutNamespace\PseudoNamespaceToNamespaceRector;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
@@ -17,7 +19,11 @@ final class PseudoNamespaceToNamespaceRectorTest extends AbstractRectorTestCase
      */
     public function test(SmartFileInfo $fileInfo): void
     {
+        $autoloadClassNameAssertion = $this->getAutoloadClassNameAssertion();
+
         $this->doTestFileInfo($fileInfo);
+
+        $autoloadClassNameAssertion->assert($fileInfo);
     }
 
     public function provideData(): Iterator
@@ -41,5 +47,66 @@ final class PseudoNamespaceToNamespaceRectorTest extends AbstractRectorTestCase
                 ],
             ],
         ];
+    }
+
+    /** @noinspection PhpMissingReturnTypeInspection */
+    // @phpstan-ignore-next-line
+    private function getAutoloadClassNameAssertion()
+    {
+        return new class ($this) { // @phpstan-ignore-line
+            // ref: https://www.php.net/manual/en/language.oop5.basic.php
+            private const CLASS_NAME = '/^
+                # valid PHP class-name (incl. optional leading \\ name-space separator)
+                \\\\?
+                [a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*
+                (?: \\\\ [a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]* )*
+                $/Dx';
+
+            /**
+             * @var TestCase
+             */
+            private $testCase;
+
+            /**
+             * @var string[]
+             */
+            private $sequence = [];
+
+            /**
+             * @param TestCase $testCase
+             * @noinspection InterfacesAsConstructorDependenciesInspection
+             */
+            public function __construct(TestCase $testCase)
+            {
+                $this->testCase = $testCase;
+                \spl_autoload_register($this, true ,true);
+            }
+
+            public function __invoke(string $className): void
+            {
+                $this->sequence[] = $className;
+            }
+
+            /**
+             * @param SmartFileInfo $fileInfo
+             * @throws ExpectationFailedException
+             */
+            public function assert(SmartFileInfo $fileInfo): void
+            {
+                foreach ($this->sequence as $className) {
+                    $this->testCase::assertMatchesRegularExpression(
+                        self::CLASS_NAME,
+                        $className,
+                        $fileInfo->getBasename() . ' class-name validity'
+                    );
+                }
+                $this->sequence = [];
+            }
+
+            public function __destruct()
+            {
+                \spl_autoload_unregister($this);
+            }
+        };
     }
 }

--- a/rules/type-declaration/src/PHPStan/Type/ObjectTypeSpecifier.php
+++ b/rules/type-declaration/src/PHPStan/Type/ObjectTypeSpecifier.php
@@ -128,7 +128,7 @@ final class ObjectTypeSpecifier
             return null;
         }
 
-        $namespacedObject = $namespaceName . '\\' . $objectType->getClassName();
+        $namespacedObject = $namespaceName . '\\' . ltrim($objectType->getClassName(), '\\');
 
         if (ClassExistenceStaticHelper::doesClassLikeExist($namespacedObject)) {
             return new FullyQualifiedObjectType($namespacedObject);


### PR DESCRIPTION
... filing fix for #5024

- [x] Regression test for invalid class-names
- [x] Give Phpstan a helping hand on anonymous class in test-suite
- [x] Add the fix (ltrim)

Using invalid class-names, specifically with two consecutive backslashes, while performing `class_exist()` checks, triggers auto-loading for the invalid class-name which then may result in the re-inclusion of existing files (due to the mapping of the class-name to a file-system-path) which then may trigger a fatal error if such a file contains the class-definition of an already defined
class.

          load class: Name\Space\DoubleTrouble
    file-system path: ../Name/Space/DoubleTrouble.php

    class_exists(Name\Space\\DoubleTrouble)
                           ^^
       file-system path: ../Name/Space//DoubleTrouble.php
                                      ^^
    already loaded file: ../Name/Space/DoubleTrouble.php

This fatal error brings rector to halt.

To stabilize class_exist() while auto-loading is active (it is always active w/ rector), prevent invalid class-names, specifically containing two or more consecutive backslashes.

Fix is to prevent consecutive backslashes when putting the name-space and the class-name together by dropping all leading backslashes from the class-name.

