### PR TITLE
Add failing test fixture for AddArrayDefaultToArrayPropertyRector – must NOT initialize property as type after intialization is incompatible

### DIFF
--- a/rules/coding-style/tests/Rector/Class_/AddArrayDefaultToArrayPropertyRector/Fixture/array_shape_uninitialied_property.php.inc
+++ b/rules/coding-style/tests/Rector/Class_/AddArrayDefaultToArrayPropertyRector/Fixture/array_shape_uninitialied_property.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\CodingStyle\Tests\Rector\Class_\AddArrayDefaultToArrayPropertyRector\Fixture;
+
+final class ArrayShapeUninitialiedProperty
+{
+    /**
+	 * @var array{
+	 *   price: float,
+	 * }
+	 */
+	public array $array;
+}
+?>


### PR DESCRIPTION
must NOT initialize property as type after intialization is incompatible

# Failing Test for AddArrayDefaultToArrayPropertyRector

Based on https://getrector.org/demo/0d6a92ef-1369-4fc9-a08a-e394937298ae