### PR TITLE
Do not prefix Symplify\SymfonyPhpConfig

### DIFF
--- a/utils/compiler/src/PhpScoper/StaticEasyPrefixer.php
+++ b/utils/compiler/src/PhpScoper/StaticEasyPrefixer.php
@@ -32,6 +32,9 @@ final class StaticEasyPrefixer
         // this is public API of a Rector rule
         'Symplify\RuleDocGenerator\*',
 
+        // for configuring sets with ValueObjectInliner
+        'Symplify\SymfonyPhpConfig\*',
+
         // doctrine annotations to autocomplete
         'Doctrine\ORM\Mapping\*',
     ];


### PR DESCRIPTION
I found another problematic namespace in prefixed version: `Symplify\SymfonyPhpConfig`

Used in configuring of sets:
```
$services->set(AddReturnTypeDeclarationRector::class)
        ->call('configure', [[
            AddReturnTypeDeclarationRector::METHOD_RETURN_TYPES => ValueObjectInliner::inline([
                ...
            ])
    ]]);
```