### PR TITLE
Downgrade nette/application  from v3.1 to v3.0.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "2.17.1",
-        "nette/application": "^3.0",
+        "nette/application": "~3.0.7",
         "nette/di": "^3.0",
         "nette/forms": "^3.0",
         "ocramius/package-versions": "^1.9",


### PR DESCRIPTION
[Package "nette/application"](https://packagist.org/packages/nette/application) released version 3.1 yesterday, and it [broke the CI](https://github.com/rectorphp/rector/pull/4447/checks?check_run_id=1632391997) (check error message below).

So downgraded to previous `v3.0.7` to make the CI work again, then we have time to find out why `v3.1` produces errors and bump it up again.

Errors:

```
There were 5 failures:

1) Rector\NetteToSymfony\Tests\Rector\ClassMethod\RouterListToControllerAnnotationsRector\RouterListToControllerAnnotationsRectorTest::test with data set #0 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
rules/nette-to-symfony/tests/Rector/ClassMethod/RouterListToControllerAnnotationsRector/Fixture/general_method_named_routes.php.inc
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
 
 namespace Rector\NetteToSymfony\Tests\Rector\ClassMethod\RouterListToControllerAnnotationsRector\Fixture;
 
-use Symfony\Component\Routing\Annotation\Route;
+use Nette\Application\Routers\Route;
 use Nette\Application\Routers\RouteList;
 
 final class GeneralMethodNamedRoutesRouterFactory
@@ @@
     public function create(): RouteList
     {
         $routeList = new RouteList();
+        $routeList[] = new Route('<presenter>/<action>', 'Homepage:default');
 
         return $routeList;
     }
@@ @@
 
 final class GeneralMethodNamedRoutesSomePresenter
 {
-    /**
-     * @Route(path="general-method-named-routes-some/first")
-     */
     public function actionFirst()
     {
     }
 
-    /**
-     * @Route(path="general-method-named-routes-some/second")
-     */
     public function actionSecond()
     {
     }

/Users/mac/GitRepos/GitHub/Libraries/rectorphp/rector/packages/testing/src/PHPUnit/AbstractRectorTestCase.php:486
/Users/mac/GitRepos/GitHub/Libraries/rectorphp/rector/packages/testing/src/PHPUnit/AbstractRectorTestCase.php:308
/Users/mac/GitRepos/GitHub/Libraries/rectorphp/rector/rules/nette-to-symfony/tests/Rector/ClassMethod/RouterListToControllerAnnotationsRector/RouterListToControllerAnnotationsRectorTest.php:19

2) Rector\NetteToSymfony\Tests\Rector\ClassMethod\RouterListToControllerAnnotationsRector\RouterListToControllerAnnotationsRectorTest::test with data set #2 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
rules/nette-to-symfony/tests/Rector/ClassMethod/RouterListToControllerAnnotationsRector/Fixture/constant_reference_route_to_annotation.php.inc
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
 
 namespace Rector\NetteToSymfony\Tests\Rector\ClassMethod\RouterListToControllerAnnotationsRector\Fixture;
 
-use Symfony\Component\Routing\Annotation\Route;
+use Nette\Application\Routers\Route;
 use Nette\Application\Routers\RouteList;
 
 final class ConstantReferenceRouterFactory
@@ @@
     {
         $routeList = new RouteList();
 
+        // case of single action controller, usually get() or __invoke() method
+        $routeList[] = Route::get(self::SOME_PATH, ConstantReferenceSomePresenter::class);
+
         return $routeList;
     }
 }
@@ @@
 
 final class ConstantReferenceSomePresenter
 {
-    /**
-     * @Route(path="/some-path", methods={"GET"})
-     */
     public function run()
     {
     }

/Users/mac/GitRepos/GitHub/Libraries/rectorphp/rector/packages/testing/src/PHPUnit/AbstractRectorTestCase.php:486
/Users/mac/GitRepos/GitHub/Libraries/rectorphp/rector/packages/testing/src/PHPUnit/AbstractRectorTestCase.php:308
/Users/mac/GitRepos/GitHub/Libraries/rectorphp/rector/rules/nette-to-symfony/tests/Rector/ClassMethod/RouterListToControllerAnnotationsRector/RouterListToControllerAnnotationsRectorTest.php:19

3) Rector\NetteToSymfony\Tests\Rector\ClassMethod\RouterListToControllerAnnotationsRector\RouterListToControllerAnnotationsRectorTest::test with data set #3 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
rules/nette-to-symfony/tests/Rector/ClassMethod/RouterListToControllerAnnotationsRector/Fixture/method_named_routes.php.inc
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
 
 namespace Rector\NetteToSymfony\Tests\Rector\ClassMethod\RouterListToControllerAnnotationsRector\Fixture;
 
-use Symfony\Component\Routing\Annotation\Route;
+use Nette\Application\Routers\Route;
 use Nette\Application\Routers\RouteList;
 
 final class MethodNamedRoutesRouterFactory
@@ @@
     public function create(): RouteList
     {
         $routeList = new RouteList();
+        $routeList[] = new Route('hi', 'MethodNamedRoutesSome:first');
+        $routeList[] = new Route('hello', 'MethodNamedRoutesSome:second');
+        $routeList[] = new Route('<presenter>/<action>', 'Homepage:default');
 
         return $routeList;
     }
@@ @@
 
 final class MethodNamedRoutesSomePresenter
 {
-    /**
-     * @Route(path="hi")
-     */
     public function actionFirst()
     {
     }
 
-    /**
-     * @Route(path="hello")
-     */
     public function actionSecond()
     {
     }

/Users/mac/GitRepos/GitHub/Libraries/rectorphp/rector/packages/testing/src/PHPUnit/AbstractRectorTestCase.php:486
/Users/mac/GitRepos/GitHub/Libraries/rectorphp/rector/packages/testing/src/PHPUnit/AbstractRectorTestCase.php:308
/Users/mac/GitRepos/GitHub/Libraries/rectorphp/rector/rules/nette-to-symfony/tests/Rector/ClassMethod/RouterListToControllerAnnotationsRector/RouterListToControllerAnnotationsRectorTest.php:19

4) Rector\NetteToSymfony\Tests\Rector\ClassMethod\RouterListToControllerAnnotationsRector\RouterListToControllerAnnotationsRectorTest::test with data set #4 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
rules/nette-to-symfony/tests/Rector/ClassMethod/RouterListToControllerAnnotationsRector/Fixture/with_parameter.php.inc
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
 
 namespace Rector\NetteToSymfony\Tests\Rector\ClassMethod\RouterListToControllerAnnotationsRector\Fixture;
 
-use Symfony\Component\Routing\Annotation\Route;
 use Nette\Application\IPresenter;
 use Nette\Application\IResponse;
+use Nette\Application\Routers\Route;
 use Nette\Application\Routers\RouteList;
 
 final class WithParameterRouterFactory
@@ @@
     {
         $routeList = new RouteList();
 
+        $routeList[] = new Route('some-path/<id>', WithParameterSomePresenter::class);
+
         return $routeList;
     }
 }
@@ @@
 {
     /**
      * @doto
-     * @Route(path="some-path/{id}")
      */
     public function run(\Nette\Application\Request $request): IResponse
     {

/Users/mac/GitRepos/GitHub/Libraries/rectorphp/rector/packages/testing/src/PHPUnit/AbstractRectorTestCase.php:486
/Users/mac/GitRepos/GitHub/Libraries/rectorphp/rector/packages/testing/src/PHPUnit/AbstractRectorTestCase.php:308
/Users/mac/GitRepos/GitHub/Libraries/rectorphp/rector/rules/nette-to-symfony/tests/Rector/ClassMethod/RouterListToControllerAnnotationsRector/RouterListToControllerAnnotationsRectorTest.php:19

5) Rector\NetteToSymfony\Tests\Rector\ClassMethod\RouterListToControllerAnnotationsRector\RouterListToControllerAnnotationsRectorTest::test with data set #5 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
rules/nette-to-symfony/tests/Rector/ClassMethod/RouterListToControllerAnnotationsRector/Fixture/new_route_to_annotation.php.inc
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
 
 namespace Rector\NetteToSymfony\Tests\Rector\ClassMethod\RouterListToControllerAnnotationsRector\Fixture;
 
-use Symfony\Component\Routing\Annotation\Route;
+use Nette\Application\Routers\Route;
 use Nette\Application\Routers\RouteList;
 
 final class NewRouterFactory
@@ @@
     {
         $routeList = new RouteList();
 
+        // case of single action controller, usually get() or __invoke() method
+        $routeList[] = new Route('some-path', NewSomePresenter::class);
+
         return $routeList;
     }
 }
@@ @@
 
 final class NewSomePresenter
 {
-    /**
-     * @Route(path="some-path")
-     */
     public function run()
     {
     }

/Users/mac/GitRepos/GitHub/Libraries/rectorphp/rector/packages/testing/src/PHPUnit/AbstractRectorTestCase.php:486
/Users/mac/GitRepos/GitHub/Libraries/rectorphp/rector/packages/testing/src/PHPUnit/AbstractRectorTestCase.php:308
/Users/mac/GitRepos/GitHub/Libraries/rectorphp/rector/rules/nette-to-symfony/tests/Rector/ClassMethod/RouterListToControllerAnnotationsRector/RouterListToControllerAnnotationsRectorTest.php:19
```