### PR TITLE
Add failing test fixture for GetClassToInstanceOfRector

### DIFF
--- a/rules/code-quality/tests/Rector/Identical/GetClassToInstanceOfRector/Fixture/static_should_not_be_namespaced.php.inc
+++ b/rules/code-quality/tests/Rector/Identical/GetClassToInstanceOfRector/Fixture/static_should_not_be_namespaced.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\CodeQuality\Tests\Rector\Identical\GetClassToInstanceOfRector\Fixture;
+
+class StaticShouldNotBeNamespaced {
+    public function test() {
+        if (\get_class($other) !== static::class) {}
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\CodeQuality\Tests\Rector\Identical\GetClassToInstanceOfRector\Fixture;
+
+class StaticShouldNotBeNamespaced {
+    public function test() {
+        if (!$other instanceof static) {}
+    }
+}
+?>


### PR DESCRIPTION
# Failing Test for GetClassToInstanceOfRector

Based on https://getrector.org/demo/c605ea4b-824c-4fb6-8357-2b71a87098b6

`\static` generates syntax error.