### PR TITLE
UnSpreadOperatorRector: Should kept spread operator on dynamic method calls

### DIFF
--- a/rules/coding-style/tests/Rector/ClassMethod/UnSpreadOperatorRector/Fixture/demo_file.php.inc
+++ b/rules/coding-style/tests/Rector/ClassMethod/UnSpreadOperatorRector/Fixture/demo_file.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\CodingStyle\Tests\Rector\ClassMethod\UnSpreadOperatorRector\Fixture;
+
+final class DemoFile
+{
+    public function run()
+    {
+         $classInstance->{$methodName}(...$this->getParameters());
+    }
+    
+    private function getParameters(): array{}
+}
+?>


### PR DESCRIPTION
# Failing Test for UnSpreadOperatorRector

Based on https://getrector.org/demo/72c7df1d-01a2-4f1b-923f-2c5dedd7b636