### PR TITLE
Publish all tags as docker images

### DIFF
--- a/.github/workflows/publish_docker_images.yaml
+++ b/.github/workflows/publish_docker_images.yaml
@@ -7,7 +7,7 @@ on:
 
         # Publish `v1.2.3` tags as releases.
         tags:
-            - v*
+            - *
 
 jobs:
     publish_images:


### PR DESCRIPTION
No tags except latest were published because tags no longer contain leading `v`