### PR TITLE
Fixed typo "lenght"

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -1185,7 +1185,7 @@ Change isset on property object to `property_exists()`
 
 ### JoinStringConcatRector
 
-Joins concat of 2 strings, unless the lenght is too long
+Joins concat of 2 strings, unless the length is too long
 
 - class: `Rector\CodeQuality\Rector\Concat\JoinStringConcatRector`
 

--- a/rules/code-quality/src/Rector/Concat/JoinStringConcatRector.php
+++ b/rules/code-quality/src/Rector/Concat/JoinStringConcatRector.php
@@ -31,7 +31,7 @@ final class JoinStringConcatRector extends AbstractRector
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
-            'Joins concat of 2 strings, unless the lenght is too long',
+            'Joins concat of 2 strings, unless the length is too long',
             [
                 new CodeSample(
                     <<<'CODE_SAMPLE'

--- a/rules/code-quality/src/Rector/If_/SimplifyIfElseToTernaryRector.php
+++ b/rules/code-quality/src/Rector/If_/SimplifyIfElseToTernaryRector.php
@@ -23,7 +23,7 @@ final class SimplifyIfElseToTernaryRector extends AbstractRector
     /**
      * @var int
      */
-    private const LINE_LENGHT_LIMIT = 120;
+    private const LINE_LENGTH_LIMIT = 120;
 
     public function getRuleDefinition(): RuleDefinition
     {
@@ -169,6 +169,6 @@ CODE_SAMPLE
 
     private function isNodeTooLong(Assign $assign): bool
     {
-        return Strings::length($this->print($assign)) > self::LINE_LENGHT_LIMIT;
+        return Strings::length($this->print($assign)) > self::LINE_LENGTH_LIMIT;
     }
 }

--- a/stubs/Symfony/Component/Validator/Constraints/Length.php
+++ b/stubs/Symfony/Component/Validator/Constraints/Length.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Symfony\Component\Validator\Constraints;
 
-if (class_exists('Symfony\Component\Validator\Constraints\Lenght')) {
+if (class_exists('Symfony\Component\Validator\Constraints\Length')) {
     return;
 }
 


### PR DESCRIPTION
Hi,

I was reading the docs, and found a typo that I wanted to fix. I did a grep on the entire codebase, and found a few other instances where "lenght" instead of "length" was used. One instance even did a check on `class_exists` on "lenght" where the class was called "length", and thus the `class_exists` call did not work as expected.

So, here is the mr for fixing docs and one small bug :)

Floris