### PR TITLE
Add failing test fixture for ExplicitBoolCompareRector

### DIFF
--- a/rules/code-quality/tests/Rector/If_/ExplicitBoolCompareRector/Fixture/UnknownPropertyType.php.inc
+++ b/rules/code-quality/tests/Rector/If_/ExplicitBoolCompareRector/Fixture/UnknownPropertyType.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\CodeQuality\Tests\Rector\If_\ExplicitBoolCompareRector\Fixture;
 
-final class DemoFile
+final class UnknownPropertyType
 {
     public function run(\stdClass $data)
     {

--- a/rules/code-quality/tests/Rector/If_/ExplicitBoolCompareRector/Fixture/demo_file.php.inc
+++ b/rules/code-quality/tests/Rector/If_/ExplicitBoolCompareRector/Fixture/demo_file.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\CodeQuality\Tests\Rector\If_\ExplicitBoolCompareRector\Fixture;
+
+final class DemoFile
+{
+    public function run(\stdClass $data)
+    {
+        if ($data->SomeProperty) {
+        }
+    }
+}
+?>


### PR DESCRIPTION
# Failing Test for ExplicitBoolCompareRector

Based on https://getrector.org/demo/3cb57eee-954d-4f12-9d0f-7ce703672f60

As in this case rector has no idea what is inside the variable, this case should be skipped.