### PR TITLE
 [Downgrade PHP 7.4] Skip DowngradeNumericLiteralSeparatorRector on value contains + char

### DIFF
--- a/rules/downgrade-php74/src/Rector/LNumber/DowngradeNumericLiteralSeparatorRector.php
+++ b/rules/downgrade-php74/src/Rector/LNumber/DowngradeNumericLiteralSeparatorRector.php
@@ -68,7 +68,9 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($node->value === PHP_FLOAT_MAX) {
+        $numberNode      = clone $node;
+        $numberNodeValue = (string) $numberNode->value;
+        if (strpos($numberNodeValue, '+') !== false) {
             return null;
         }
 

--- a/rules/downgrade-php74/src/Rector/LNumber/DowngradeNumericLiteralSeparatorRector.php
+++ b/rules/downgrade-php74/src/Rector/LNumber/DowngradeNumericLiteralSeparatorRector.php
@@ -68,9 +68,9 @@ CODE_SAMPLE
             return null;
         }
 
-        $numberNode      = clone $node;
+        $numberNode = clone $node;
         $numberNodeValue = (string) $numberNode->value;
-        if (strpos($numberNodeValue, '+') !== false) {
+        if (Strings::contains($numberNodeValue, '+')) {
             return null;
         }
 

--- a/rules/downgrade-php74/src/Rector/LNumber/DowngradeNumericLiteralSeparatorRector.php
+++ b/rules/downgrade-php74/src/Rector/LNumber/DowngradeNumericLiteralSeparatorRector.php
@@ -68,6 +68,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node->value === PHP_FLOAT_MAX) {
+            return null;
+        }
+
         $node->value = (string) $node->value;
 
         /**

--- a/rules/downgrade-php74/tests/Rector/LNumber/DowngradeNumericLiteralSeparatorRector/Fixture/skip_float_max.php.inc
+++ b/rules/downgrade-php74/tests/Rector/LNumber/DowngradeNumericLiteralSeparatorRector/Fixture/skip_float_max.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\DowngradePhp74\Tests\Rector\LNumber\DowngradeNumericLiteralSeparatorRector\Fixture;
+
+class SkipFloatMax
+{
+    public function run()
+    {
+        $php_float_max = 1.7976931348623157E+308;
+    }
+}
+
+?>

--- a/rules/downgrade-php74/tests/Rector/LNumber/DowngradeNumericLiteralSeparatorRector/Fixture/skip_no_change.php.inc
+++ b/rules/downgrade-php74/tests/Rector/LNumber/DowngradeNumericLiteralSeparatorRector/Fixture/skip_no_change.php.inc
@@ -14,6 +14,7 @@ class SkipNoChange
         $binary = 0b11111111;
         $octal = 0123;
         $hex = 0x1A;
+        $one_dot_zero = 1.0;
     }
 }
 


### PR DESCRIPTION
Fixes #4401