### PR TITLE
Fix weekly code coverage github action

### DIFF
--- a/.github/workflows/weekly_code_coverage.yaml
+++ b/.github/workflows/weekly_code_coverage.yaml
@@ -40,8 +40,6 @@ jobs:
         steps:
             -
                 uses: actions/checkout@v2
-                with:
-                    token: ${{ secrets.ACCESS_TOKEN }}
 
             # see https://github.com/shivammathur/setup-php
             -


### PR DESCRIPTION
it got error at https://github.com/rectorphp/rector/actions/runs/474871156

```

The workflow is not valid. .github/workflows/weekly_code_coverage.yaml (Line: 34, Col: 51): Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.GITHUB_TOKEN
```

The `secrets` seems only needed for automatic PR.