### PR TITLE
Another fix weekly code coverage action

### DIFF
--- a/.github/workflows/weekly_code_coverage.yaml
+++ b/.github/workflows/weekly_code_coverage.yaml
@@ -31,7 +31,7 @@ jobs:
                             git checkout .
                             git clean -xfd build
                         env:
-                            COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                            COVERALLS_REPO_TOKEN: ${{ secrets.ACCESS_TOKEN }}
                         branch: 'master'
 
         name: ${{ matrix.actions.name }}


### PR DESCRIPTION
`secrets.GITHUB_TOKEN` should be `secrets.ACCESS_TOKEN` like in other action.