### PR TITLE
InferParamFromClassMethodReturnRector: Don't fail with empty array

### DIFF
--- a/rules/restoration/src/Type/ConstantReturnToParamTypeConverter.php
+++ b/rules/restoration/src/Type/ConstantReturnToParamTypeConverter.php
@@ -33,7 +33,7 @@ final class ConstantReturnToParamTypeConverter
         return $this->unwrapConstantTypeToObjectType($type);
     }
 
-    private function unwrapConstantTypeToObjectType(Type $type): Type
+    private function unwrapConstantTypeToObjectType(Type $type): ?Type
     {
         if ($type instanceof ConstantArrayType) {
             return $this->unwrapConstantTypeToObjectType($type->getItemType());
@@ -44,11 +44,14 @@ final class ConstantReturnToParamTypeConverter
         if ($type instanceof UnionType) {
             $types = [];
             foreach ($type->getTypes() as $unionedType) {
-                $types[] = $this->unwrapConstantTypeToObjectType($unionedType);
+                $type = $this->unwrapConstantTypeToObjectType($unionedType);
+                if ($type !== null) {
+                    $types[] = $type;
+                }
             }
             return $this->typeFactory->createMixedPassedOrUnionType($types);
         }
 
-        throw new NotImplementedYetException();
+        return null;
     }
 }

--- a/rules/restoration/tests/Rector/ClassMethod/InferParamFromClassMethodReturnRector/Fixture/skip_empty_array.php.inc
+++ b/rules/restoration/tests/Rector/ClassMethod/InferParamFromClassMethodReturnRector/Fixture/skip_empty_array.php.inc
@@ -12,9 +12,6 @@ class SkipEmptyArray extends SomeType
         return [];
     }
 
-    /**
-     * @param String_ $node
-     */
     public function process(\PhpParser\Node $node)
     {
     }

--- a/rules/restoration/tests/Rector/ClassMethod/InferParamFromClassMethodReturnRector/Fixture/skip_empty_array.php.inc
+++ b/rules/restoration/tests/Rector/ClassMethod/InferParamFromClassMethodReturnRector/Fixture/skip_empty_array.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Restoration\Tests\Rector\ClassMethod\InferParamFromClassMethodReturnRector\Fixture;
+
+use PhpParser\Node\Scalar\String_;
+use Rector\Restoration\Tests\Rector\ClassMethod\InferParamFromClassMethodReturnRector\Source\SomeType;
+
+class SkipEmptyArray extends SomeType
+{
+    public function getNodeTypes(): array
+    {
+        return [];
+    }
+
+    /**
+     * @param String_ $node
+     */
+    public function process(\PhpParser\Node $node)
+    {
+    }
+}


### PR DESCRIPTION
When inferring param from class method return, an empty array should be fine. In the current situation it throws a `ShouldNotHappenException`. This PR returns `null` instead, which solves the issue.