### PR TITLE
[Downgrade PHP 7.4] Skip downgrading contravariant argument for __construct

### DIFF
--- a/rules/downgrade-php74/src/Rector/ClassMethod/DowngradeContravariantArgumentTypeRector.php
+++ b/rules/downgrade-php74/src/Rector/ClassMethod/DowngradeContravariantArgumentTypeRector.php
@@ -85,6 +85,11 @@ CODE_SAMPLE
             return false;
         }
 
+        // Contravariant arguments are supported for __construct
+        if ($this->getName($functionLike) === '__construct') {
+            return false;
+        }
+
         // Check if the type is different from the one declared in some ancestor
         return $this->getDifferentParamTypeFromAncestorClass($param, $functionLike) !== null;
     }

--- a/rules/downgrade-php74/tests/Rector/ClassMethod/DowngradeContravariantArgumentTypeRector/Fixture/skip_overloading_construct.php.inc
+++ b/rules/downgrade-php74/tests/Rector/ClassMethod/DowngradeContravariantArgumentTypeRector/Fixture/skip_overloading_construct.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\DowngradePhp74\Tests\Rector\ClassMethod\DowngradeContravariantArgumentTypeRector\Fixture;
+
+class SkipOverloadingConstructParentType {}
+class SkipOverloadingConstructChildType extends SkipOverloadingConstructParentType {}
+
+class SkipOverloadingConstructA
+{
+    public function __construct(SkipOverloadingConstructChildType $type)
+    {
+        /* … */
+    }
+}
+
+class SkipOverloadingConstructB extends SkipOverloadingConstructA
+{
+    public function __construct(SkipOverloadingConstructParentType $type)
+    {
+        /* … */
+        parent::__construct($type);
+    }
+}
+
+?>


### PR DESCRIPTION
Fixes #5147