### PR TITLE
(fix) RemoveDoubleAssignRector: properly skip if the assigned expression is a call

### DIFF
--- a/rules/dead-code/src/Rector/Assign/RemoveDoubleAssignRector.php
+++ b/rules/dead-code/src/Rector/Assign/RemoveDoubleAssignRector.php
@@ -80,7 +80,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($this->isCall($node->expr)) {
+        if ($this->isCall($previousStatement->expr->expr)) {
             return null;
         }
 

--- a/rules/dead-code/tests/Rector/Assign/RemoveDoubleAssignRector/Fixture/skip_calls.php.inc
+++ b/rules/dead-code/tests/Rector/Assign/RemoveDoubleAssignRector/Fixture/skip_calls.php.inc
@@ -10,6 +10,7 @@ class SkipCalls
         $item = array_pop($items);
         $item = array_pop($items);
         $item = array_pop($items);
+        $item = null;
     }
 
     public function staticCalls()
@@ -17,6 +18,7 @@ class SkipCalls
         $item = StaticClass::dump();
         $item = StaticClass::dump();
         $item = StaticClass::dump();
+        $item = null;
     }
 
     public function nonStaticCalls()
@@ -24,6 +26,8 @@ class SkipCalls
         $nonStaticClass = (new NonStaticClass());
         $item = $nonStaticClass->dump();
         $item = $nonStaticClass->dump();
+        $item = $nonStaticClass->dump();
+        $item = null;
     }
 }
 


### PR DESCRIPTION
RemoveDoubleAssignRector was checking if the _current_ assignment includes a call, rather than the preceding one. This was resulting in wrong removals:

```
$a = echo(''); // was removed before, is skipped now.
$a = 7;
```

