### PR TITLE
[PHPStan] Clean up duplicated ignore error "Class cognitive complexity is \d+, keep it under 40" in phpstan.neon

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -579,14 +579,6 @@ parameters:
         - '#Content of method "mapToPhpParserNode\(\)" is duplicated with method in "Rector\\PHPStanStaticTypeMapper\\TypeMapper\\ClosureTypeMapper" class\. Use unique content or abstract service instead#'
 
         -
-             message: '#Class cognitive complexity is \d+, keep it under 40#'
-             paths:
-                  - src/Rector/AbstractRector.php
-                  - rules/php80/src/Rector/If_/NullsafeOperatorRector.php
-                  - rules/code-quality/src/Rector/For_/ForToForeachRector.php
-                  - rules/coding-style/src/Rector/Use_/RemoveUnusedAliasRector.php
-
-        -
             message: '#Use explicit names over dynamic ones#'
             paths:
                 - utils/compiler/tests/PatchersCallbackTest.php


### PR DESCRIPTION
already defined previously.