### PR TITLE
[CodeQualityStrict] Skip MoveVariableDeclarationNearReferenceRector on assign expr is ArrayDimFetch

### DIFF
--- a/rules/code-quality-strict/src/Rector/Variable/MoveVariableDeclarationNearReferenceRector.php
+++ b/rules/code-quality-strict/src/Rector/Variable/MoveVariableDeclarationNearReferenceRector.php
@@ -123,13 +123,13 @@ CODE_SAMPLE
         return $node;
     }
 
-    private function shouldSkipReAssign(Expression $expression, Assign $expr): bool
+    private function shouldSkipReAssign(Expression $expression, Assign $assign): bool
     {
-        if ($this->hasReAssign($expression, $expr->var)) {
+        if ($this->hasReAssign($expression, $assign->var)) {
             return true;
         }
 
-        return $this->hasReAssign($expression, $expr->expr);
+        return $this->hasReAssign($expression, $assign->expr);
     }
 
     private function isUsedAsArraykeyOrInsideIfCondition(Expression $expression, Variable $variable): bool

--- a/rules/code-quality-strict/src/Rector/Variable/MoveVariableDeclarationNearReferenceRector.php
+++ b/rules/code-quality-strict/src/Rector/Variable/MoveVariableDeclarationNearReferenceRector.php
@@ -94,6 +94,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($parent->expr instanceof ArrayDimFetch) {
+            return null;
+        }
+
         if ($this->hasPropertyInExpr($expression, $parent->expr)) {
             return null;
         }

--- a/rules/code-quality-strict/src/Rector/Variable/MoveVariableDeclarationNearReferenceRector.php
+++ b/rules/code-quality-strict/src/Rector/Variable/MoveVariableDeclarationNearReferenceRector.php
@@ -85,6 +85,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($parent->expr instanceof ArrayDimFetch) {
+            return null;
+        }
+
         $expression = $parent->getAttribute(AttributeKey::PARENT_NODE);
         if (! $expression instanceof Expression) {
             return null;
@@ -94,17 +98,11 @@ CODE_SAMPLE
             return null;
         }
 
-        if ($parent->expr instanceof ArrayDimFetch) {
-            return null;
-        }
-
         if ($this->hasPropertyInExpr($expression, $parent->expr)) {
             return null;
         }
-        if ($this->hasReAssign($expression, $parent->var)) {
-            return null;
-        }
-        if ($this->hasReAssign($expression, $parent->expr)) {
+
+        if ($this->shouldSkipReAssign($expression, $parent)) {
             return null;
         }
 
@@ -123,6 +121,15 @@ CODE_SAMPLE
         $this->removeNode($expression);
 
         return $node;
+    }
+
+    private function shouldSkipReAssign(Expression $expression, Assign $expr): bool
+    {
+        if ($this->hasReAssign($expression, $expr->var)) {
+            return true;
+        }
+
+        return $this->hasReAssign($expression, $expr->expr);
     }
 
     private function isUsedAsArraykeyOrInsideIfCondition(Expression $expression, Variable $variable): bool

--- a/rules/code-quality-strict/tests/Rector/Variable/MoveVariableDeclarationNearReferenceRector/Fixture/skip_assign_expr_array_dim_fetch.php.inc
+++ b/rules/code-quality-strict/tests/Rector/Variable/MoveVariableDeclarationNearReferenceRector/Fixture/skip_assign_expr_array_dim_fetch.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\CodeQualityStrict\Tests\Rector\Variable\MoveVariableDeclarationNearReferenceRector\Fixture;
+
+final class SkipAssignExprArrayDimFetch
+{
+    public function run()
+    {
+        $value = $values[$i];
+        ++$i;
+        return $value;
+    }
+}


### PR DESCRIPTION
Fixes #5200 ref https://github.com/symplify/symplify/pull/2811#discussion_r558815457