### PR TITLE
[CodeCoverage] Fixes weekly code coverage by move COVERALLS_REPO_TOKEN on run

### DIFF
--- a/.github/workflows/weekly_code_coverage.yaml
+++ b/.github/workflows/weekly_code_coverage.yaml
@@ -30,8 +30,6 @@ jobs:
                             # clean up
                             git checkout .
                             git clean -xfd build
-                        env:
-                            COVERALLS_REPO_TOKEN: ${{ secrets.ACCESS_TOKEN }}
                         branch: 'master'
 
         name: ${{ matrix.actions.name }}
@@ -54,3 +52,5 @@ jobs:
 
             -
                 run: ${{ matrix.actions.run }}
+                env:
+                    COVERALLS_REPO_TOKEN: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
It previously got error:

```bash
The workflow is not valid. .github/workflows/weekly_code_coverage.yaml (Line: 34, Col: 51): Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.ACCESS_TOKEN
```

at https://github.com/rectorphp/rector/actions/runs/490896171 . This change moved COVERALLS_REPO_TOKEN env definition on `run` part.