### PR TITLE
[PhpDocInfo Decouple] Use php doc info from factories, not from attribute

### DIFF
--- a/packages/better-php-doc-parser/src/PhpDocInfo/PhpDocInfo.php
+++ b/packages/better-php-doc-parser/src/PhpDocInfo/PhpDocInfo.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\BetterPhpDocParser\PhpDocInfo;
 
 use PhpParser\Node;
-use PhpParser\Node\Param;
 use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocChildNode;

--- a/packages/better-php-doc-parser/src/PhpDocManipulator/VarAnnotationManipulator.php
+++ b/packages/better-php-doc-parser/src/PhpDocManipulator/VarAnnotationManipulator.php
@@ -70,15 +70,9 @@ final class VarAnnotationManipulator
     {
         $currentStmt = $node->getAttribute(AttributeKey::CURRENT_STATEMENT);
         if ($currentStmt instanceof Expression) {
-            /** @var PhpDocInfo|null $phpDocInfo */
-            $phpDocInfo = $currentStmt->getAttribute(AttributeKey::PHP_DOC_INFO);
+            $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($currentStmt);
         } else {
-            /** @var PhpDocInfo|null $phpDocInfo */
-            $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
-        }
-
-        if ($phpDocInfo === null) {
-            $phpDocInfo = $this->phpDocInfoFactory->createEmpty($node);
+            $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
         }
 
         $phpDocInfo->makeSingleLined();

--- a/packages/node-type-resolver/src/PhpDoc/NodeAnalyzer/DocBlockManipulator.php
+++ b/packages/node-type-resolver/src/PhpDoc/NodeAnalyzer/DocBlockManipulator.php
@@ -180,7 +180,6 @@ final class DocBlockManipulator
 
         if ($node->getComments() !== []) {
             $commentsContent = implode(PHP_EOL, $node->getComments());
-
             if ($this->removeSpacesAndAsterisks($commentsContent) === $this->removeSpacesAndAsterisks($phpDoc)) {
                 return false;
             }
@@ -203,12 +202,16 @@ final class DocBlockManipulator
     {
         $startComments = '';
         foreach ($node->getComments() as $comment) {
-            // skip non-simple comments
-            if (! Strings::startsWith($comment->getText(), '//')) {
+            // skip simple comments
+            if (Strings::startsWith($comment->getText(), '//')) {
                 continue;
             }
 
-            $startComments .= $comment->getText();
+            if (Strings::startsWith($comment->getText(), '#')) {
+                continue;
+            }
+
+            $startComments .= $comment->getText() . PHP_EOL;
         }
 
         if ($startComments === '') {

--- a/packages/phpstan-static-type-mapper/src/TypeMapper/UnionTypeMapper.php
+++ b/packages/phpstan-static-type-mapper/src/TypeMapper/UnionTypeMapper.php
@@ -113,9 +113,7 @@ final class UnionTypeMapper implements TypeMapperInterface
 
         if ($this->boolUnionTypeAnalyzer->isNullableBoolUnionType(
             $type
-        ) && ! $this->phpVersionProvider->isAtLeastPhpVersion(
-            PhpVersionFeature::UNION_TYPES
-        )) {
+        ) && ! $this->phpVersionProvider->isAtLeastPhpVersion(PhpVersionFeature::UNION_TYPES)) {
             return new NullableType(new Name('bool'));
         }
 

--- a/packages/rector-generator/src/NodeFactory/ConfigurationNodeFactory.php
+++ b/packages/rector-generator/src/NodeFactory/ConfigurationNodeFactory.php
@@ -118,7 +118,7 @@ final class ConfigurationNodeFactory
 
         $classMethod->stmts = $assigns;
 
-        $phpDocInfo = $this->phpDocInfoFactory->createEmpty($classMethod);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
 
         $identifierTypeNode = new IdentifierTypeNode('mixed[]');
         $paramTagValueNode = new ParamTagValueNode($identifierTypeNode, false, '$configuration', '');

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -547,3 +547,4 @@ parameters:
             path: src/Console/Command/AbstractCommand.php
 
         - '#Content of method "configure\(\)" is duplicated with method "configure\(\)" in "Rector\\Composer\\Rector\\AddPackageToRequireRector" class\. Use unique content or abstract service instead#'
+        - '#Content of method "getFunctionLikePhpDocInfo\(\)" is duplicated with method "getFunctionLikePhpDocInfo\(\)" in "Rector\\TypeDeclaration\\TypeInferer\\ParamTypeInferer\\PHPUnitDataProviderParamTypeInferer" class\. Use unique content or abstract service instead#'

--- a/rules/code-quality-strict/src/Rector/ClassMethod/ParamTypeToAssertTypeRector.php
+++ b/rules/code-quality-strict/src/Rector/ClassMethod/ParamTypeToAssertTypeRector.php
@@ -12,7 +12,6 @@ use PhpParser\Node\Stmt\Expression;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\CodeQualityStrict\NodeFactory\ClassConstFetchFactory;
 use Rector\CodeQualityStrict\TypeAnalyzer\SubTypeAnalyzer;
 use Rector\Core\Rector\AbstractRector;
@@ -86,11 +85,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        /** @var PhpDocInfo|null $phpDocInfo */
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
-        if ($phpDocInfo === null) {
-            return null;
-        }
 
         /** @var Type[] $docParamTypes */
         $docParamTypes = $phpDocInfo->getParamTypesByName();

--- a/rules/code-quality-strict/src/Rector/ClassMethod/ParamTypeToAssertTypeRector.php
+++ b/rules/code-quality-strict/src/Rector/ClassMethod/ParamTypeToAssertTypeRector.php
@@ -16,7 +16,6 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\CodeQualityStrict\NodeFactory\ClassConstFetchFactory;
 use Rector\CodeQualityStrict\TypeAnalyzer\SubTypeAnalyzer;
 use Rector\Core\Rector\AbstractRector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -88,7 +87,7 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
         if ($phpDocInfo === null) {
             return null;
         }

--- a/rules/code-quality-strict/src/Rector/Stmt/VarInlineAnnotationToAssertRector.php
+++ b/rules/code-quality-strict/src/Rector/Stmt/VarInlineAnnotationToAssertRector.php
@@ -88,10 +88,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
-        if ($phpDocInfo === null) {
-            return null;
-        }
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
 
         $docVariableName = $this->getVarDocVariableName($phpDocInfo);
         if ($docVariableName === null) {

--- a/rules/code-quality/src/Rector/Return_/SimplifyUselessVariableRector.php
+++ b/rules/code-quality/src/Rector/Return_/SimplifyUselessVariableRector.php
@@ -12,7 +12,6 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Return_;
 use PHPStan\Type\MixedType;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\PhpParser\Node\AssignAndBinaryMap;
 use Rector\Core\Rector\AbstractRector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -147,11 +146,7 @@ CODE_SAMPLE
 
     private function isReturnWithVarAnnotation(Return_ $return): bool
     {
-        $phpDocInfo = $return->getAttribute(AttributeKey::PHP_DOC_INFO);
-        if (! $phpDocInfo instanceof PhpDocInfo) {
-            return false;
-        }
-
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($return);
         return ! $phpDocInfo->getVarType() instanceof MixedType;
     }
 

--- a/rules/coding-style/src/Rector/ClassMethod/ReturnArrayClassMethodToYieldRector.php
+++ b/rules/coding-style/src/Rector/ClassMethod/ReturnArrayClassMethodToYieldRector.php
@@ -12,7 +12,6 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Return_;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
 use Rector\BetterPhpDocParser\Comment\CommentsMerger;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\CodingStyle\ValueObject\ReturnArrayClassMethodToYield;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Exception\ShouldNotHappenException;
@@ -196,12 +195,7 @@ CODE_SAMPLE
 
     private function removeReturnTag(ClassMethod $classMethod): void
     {
-        /** @var PhpDocInfo|null $phpDocInfo */
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
-        if ($phpDocInfo === null) {
-            return;
-        }
-
         $phpDocInfo->removeByType(ReturnTagValueNode::class);
     }
 }

--- a/rules/coding-style/src/Rector/ClassMethod/ReturnArrayClassMethodToYieldRector.php
+++ b/rules/coding-style/src/Rector/ClassMethod/ReturnArrayClassMethodToYieldRector.php
@@ -197,7 +197,7 @@ CODE_SAMPLE
     private function removeReturnTag(ClassMethod $classMethod): void
     {
         /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $classMethod->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
         if ($phpDocInfo === null) {
             return;
         }

--- a/rules/coding-style/src/Rector/Class_/AddArrayDefaultToArrayPropertyRector.php
+++ b/rules/coding-style/src/Rector/Class_/AddArrayDefaultToArrayPropertyRector.php
@@ -16,7 +16,6 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\PropertyProperty;
 use PHPStan\Type\Type;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\CodingStyle\TypeAnalyzer\IterableTypeAnalyzer;
 use Rector\Core\PhpParser\Node\Manipulator\PropertyFetchManipulator;
 use Rector\Core\Rector\AbstractRector;
@@ -135,9 +134,9 @@ CODE_SAMPLE
             }
 
             $varType = $this->resolveVarType($node);
-            if ($varType === null) {
-                return null;
-            }
+//            if ($varType === null) {
+//                return null;
+//            }
 
             if (! $this->iterableTypeAnalyzer->detect($varType)) {
                 return null;
@@ -244,18 +243,13 @@ CODE_SAMPLE
         });
     }
 
-    private function resolveVarType(PropertyProperty $propertyProperty): ?Type
+    private function resolveVarType(PropertyProperty $propertyProperty): Type
     {
         /** @var Property $property */
         $property = $propertyProperty->getAttribute(AttributeKey::PARENT_NODE);
 
-        // we need docblock
-        $propertyPhpDocInfo = $property->getAttribute(AttributeKey::PHP_DOC_INFO);
-        if (! $propertyPhpDocInfo instanceof PhpDocInfo) {
-            return null;
-        }
-
-        return $propertyPhpDocInfo->getVarType();
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
+        return $phpDocInfo->getVarType();
     }
 
     /**

--- a/rules/coding-style/src/Rector/Class_/AddArrayDefaultToArrayPropertyRector.php
+++ b/rules/coding-style/src/Rector/Class_/AddArrayDefaultToArrayPropertyRector.php
@@ -134,10 +134,6 @@ CODE_SAMPLE
             }
 
             $varType = $this->resolveVarType($node);
-//            if ($varType === null) {
-//                return null;
-//            }
-
             if (! $this->iterableTypeAnalyzer->detect($varType)) {
                 return null;
             }

--- a/rules/coding-style/src/Rector/Property/AddFalseDefaultToBoolPropertyRector.php
+++ b/rules/coding-style/src/Rector/Property/AddFalseDefaultToBoolPropertyRector.php
@@ -7,9 +7,7 @@ namespace Rector\CodingStyle\Rector\Property;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\Type\BooleanType;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\Rector\AbstractRector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -81,12 +79,7 @@ CODE_SAMPLE
 
     private function isBoolDocType(Property $property): bool
     {
-        /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $property->getAttribute(AttributeKey::PHP_DOC_INFO);
-        if ($phpDocInfo === null) {
-            return false;
-        }
-
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
         return $phpDocInfo->getVarType() instanceof BooleanType;
     }
 }

--- a/rules/coding-style/src/Rector/Throw_/AnnotateThrowablesRector.php
+++ b/rules/coding-style/src/Rector/Throw_/AnnotateThrowablesRector.php
@@ -12,14 +12,12 @@ use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Throw_;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\CodingStyle\DocBlock\ThrowsFactory;
 use Rector\CodingStyle\NodeAnalyzer\ThrowAnalyzer;
 use Rector\Core\PhpParser\Node\Value\ClassResolver;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\Reflection\ClassMethodReflectionHelper;
 use Rector\Core\Reflection\FunctionAnnotationResolver;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use ReflectionFunction;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -172,7 +170,8 @@ CODE_SAMPLE
             return;
         }
 
-        $phpDocInfo = $callee->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($callee);
+
         foreach ($this->throwablesToAnnotate as $throwableToAnnotate) {
             $docComment = $this->throwsFactory->crateDocTagNodeFromClass($throwableToAnnotate);
             $phpDocInfo->addPhpDocTagNode($docComment);
@@ -230,12 +229,7 @@ CODE_SAMPLE
             return [];
         }
 
-        /** @var PhpDocInfo|null $callePhpDocInfo */
-        $callePhpDocInfo = $callee->getAttribute(AttributeKey::PHP_DOC_INFO);
-        if ($callePhpDocInfo === null) {
-            return [];
-        }
-
+        $callePhpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($callee);
         return $callePhpDocInfo->getThrowsClassNames();
     }
 

--- a/rules/dead-code/src/Rector/ClassMethod/RemoveDelegatingParentCallRector.php
+++ b/rules/dead-code/src/Rector/ClassMethod/RemoveDelegatingParentCallRector.php
@@ -11,7 +11,6 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Return_;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\Rector\AbstractRector;
 use Rector\DeadCode\Comparator\CurrentAndParentClassMethodComparator;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -148,12 +147,7 @@ CODE_SAMPLE
 
     private function hasRequiredAnnotation(ClassMethod $classMethod): bool
     {
-        /** @var PhpDocInfo|null $phpDocInfo */
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
-        if ($phpDocInfo === null) {
-            return false;
-        }
-
         return $phpDocInfo->hasByName(TagName::REQUIRED);
     }
 }

--- a/rules/dead-code/src/Rector/ClassMethod/RemoveDelegatingParentCallRector.php
+++ b/rules/dead-code/src/Rector/ClassMethod/RemoveDelegatingParentCallRector.php
@@ -149,7 +149,7 @@ CODE_SAMPLE
     private function hasRequiredAnnotation(ClassMethod $classMethod): bool
     {
         /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $classMethod->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
         if ($phpDocInfo === null) {
             return false;
         }

--- a/rules/dead-code/src/Rector/ClassMethod/RemoveUnusedParameterRector.php
+++ b/rules/dead-code/src/Rector/ClassMethod/RemoveUnusedParameterRector.php
@@ -181,7 +181,7 @@ CODE_SAMPLE
     private function clearPhpDocInfo(ClassMethod $classMethod, array $unusedParameters): void
     {
         /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $classMethod->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
         if ($phpDocInfo === null) {
             return;
         }

--- a/rules/dead-code/src/Rector/ClassMethod/RemoveUnusedParameterRector.php
+++ b/rules/dead-code/src/Rector/ClassMethod/RemoveUnusedParameterRector.php
@@ -8,7 +8,6 @@ use PhpParser\Node;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Caching\Contract\Rector\ZeroCacheRectorInterface;
 use Rector\Core\PhpParser\Node\Manipulator\ClassManipulator;
 use Rector\Core\Rector\AbstractRector;
@@ -180,11 +179,7 @@ CODE_SAMPLE
      */
     private function clearPhpDocInfo(ClassMethod $classMethod, array $unusedParameters): void
     {
-        /** @var PhpDocInfo|null $phpDocInfo */
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
-        if ($phpDocInfo === null) {
-            return;
-        }
 
         foreach ($unusedParameters as $unusedParameter) {
             $parameterName = $this->getName($unusedParameter->var);

--- a/rules/dead-code/src/Rector/Expression/RemoveDeadStmtRector.php
+++ b/rules/dead-code/src/Rector/Expression/RemoveDeadStmtRector.php
@@ -7,7 +7,6 @@ namespace Rector\DeadCode\Rector\Expression;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Nop;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\Rector\AbstractRector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -65,8 +64,7 @@ CODE_SAMPLE
 
     private function removeNodeAndKeepComments(Expression $expression): ?Node
     {
-        /** @var PhpDocInfo $phpDocInfo */
-        $phpDocInfo = $expression->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($expression);
 
         if ($expression->getComments() !== []) {
             $nop = new Nop();

--- a/rules/dead-doc-block/src/Rector/ClassMethod/RemoveUselessParamTagRector.php
+++ b/rules/dead-doc-block/src/Rector/ClassMethod/RemoveUselessParamTagRector.php
@@ -9,7 +9,6 @@ use PhpParser\Node\Stmt\ClassMethod;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\Rector\AbstractRector;
 use Rector\DeadDocBlock\DeadParamTagValueNodeAnalyzer;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -76,7 +75,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
         if (! $phpDocInfo instanceof PhpDocInfo) {
             return null;
         }

--- a/rules/dead-doc-block/src/Rector/ClassMethod/RemoveUselessReturnTagRector.php
+++ b/rules/dead-doc-block/src/Rector/ClassMethod/RemoveUselessReturnTagRector.php
@@ -9,7 +9,6 @@ use PhpParser\Node\Stmt\ClassMethod;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\Rector\AbstractRector;
 use Rector\DeadDocBlock\DeadReturnTagValueNodeAnalyzer;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -76,7 +75,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
         if (! $phpDocInfo instanceof PhpDocInfo) {
             return null;
         }

--- a/rules/dead-doc-block/src/Rector/Node/RemoveNonExistingVarAnnotationRector.php
+++ b/rules/dead-doc-block/src/Rector/Node/RemoveNonExistingVarAnnotationRector.php
@@ -22,7 +22,6 @@ use PhpParser\Node\Stmt\While_;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\Rector\AbstractRector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -97,7 +96,7 @@ CODE_SAMPLE
         }
 
         /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
         if ($phpDocInfo === null) {
             return null;
         }

--- a/rules/dead-doc-block/src/Rector/Node/RemoveNonExistingVarAnnotationRector.php
+++ b/rules/dead-doc-block/src/Rector/Node/RemoveNonExistingVarAnnotationRector.php
@@ -20,7 +20,6 @@ use PhpParser\Node\Stmt\Switch_;
 use PhpParser\Node\Stmt\Throw_;
 use PhpParser\Node\Stmt\While_;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -95,11 +94,7 @@ CODE_SAMPLE
             return null;
         }
 
-        /** @var PhpDocInfo|null $phpDocInfo */
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
-        if ($phpDocInfo === null) {
-            return null;
-        }
 
         $attributeAwareVarTagValueNode = $phpDocInfo->getVarTagValueNode();
         if ($attributeAwareVarTagValueNode === null) {

--- a/rules/doctrine-code-quality/src/NodeAnalyzer/ColumnDatetimePropertyAnalyzer.php
+++ b/rules/doctrine-code-quality/src/NodeAnalyzer/ColumnDatetimePropertyAnalyzer.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\DoctrineCodeQuality\NodeAnalyzer;
 
 use PhpParser\Node\Stmt\Property;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocNode\Doctrine\Property_\ColumnTagValueNode;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 
@@ -13,11 +12,7 @@ final class ColumnDatetimePropertyAnalyzer
 {
     public function matchDateTimeColumnTagValueNodeInProperty(Property $property): ?ColumnTagValueNode
     {
-        /** @var PhpDocInfo|null $phpDocInfo */
         $phpDocInfo = $property->getAttribute(AttributeKey::PHP_DOC_INFO);
-        if ($phpDocInfo === null) {
-            return null;
-        }
 
         $columnTagValueNode = $phpDocInfo->getByType(ColumnTagValueNode::class);
         if ($columnTagValueNode === null) {

--- a/rules/doctrine-code-quality/src/NodeAnalyzer/DoctrinePropertyAnalyzer.php
+++ b/rules/doctrine-code-quality/src/NodeAnalyzer/DoctrinePropertyAnalyzer.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\DoctrineCodeQuality\NodeAnalyzer;
 
 use PhpParser\Node\Stmt\Property;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocNode\Doctrine\Property_\ColumnTagValueNode;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocNode\Doctrine\Property_\GeneratedValueTagValueNode;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocNode\Doctrine\Property_\JoinColumnTagValueNode;
@@ -19,77 +18,49 @@ final class DoctrinePropertyAnalyzer
 {
     public function matchDoctrineColumnTagValueNode(Property $property): ?ColumnTagValueNode
     {
-        /** @var PhpDocInfo|null $phpDocInfo */
         $phpDocInfo = $property->getAttribute(AttributeKey::PHP_DOC_INFO);
-        if ($phpDocInfo === null) {
-            return null;
-        }
 
         return $phpDocInfo->getByType(ColumnTagValueNode::class);
     }
 
     public function matchDoctrineOneToManyTagValueNode(Property $property): ?OneToManyTagValueNode
     {
-        /** @var PhpDocInfo|null $phpDocInfo */
         $phpDocInfo = $property->getAttribute(AttributeKey::PHP_DOC_INFO);
-        if ($phpDocInfo === null) {
-            return null;
-        }
 
         return $phpDocInfo->getByType(OneToManyTagValueNode::class);
     }
 
     public function matchDoctrineOneToOneTagValueNode(Property $property): ?OneToOneTagValueNode
     {
-        /** @var PhpDocInfo|null $phpDocInfo */
         $phpDocInfo = $property->getAttribute(AttributeKey::PHP_DOC_INFO);
-        if ($phpDocInfo === null) {
-            return null;
-        }
 
         return $phpDocInfo->getByType(OneToOneTagValueNode::class);
     }
 
     public function matchDoctrineManyToManyTagValueNode(Property $property): ?ManyToManyTagValueNode
     {
-        /** @var PhpDocInfo|null $phpDocInfo */
         $phpDocInfo = $property->getAttribute(AttributeKey::PHP_DOC_INFO);
-        if ($phpDocInfo === null) {
-            return null;
-        }
 
         return $phpDocInfo->getByType(ManyToManyTagValueNode::class);
     }
 
     public function matchDoctrineManyToOneTagValueNode(Property $property): ?ManyToOneTagValueNode
     {
-        /** @var PhpDocInfo|null $phpDocInfo */
         $phpDocInfo = $property->getAttribute(AttributeKey::PHP_DOC_INFO);
-        if ($phpDocInfo === null) {
-            return null;
-        }
 
         return $phpDocInfo->getByType(ManyToOneTagValueNode::class);
     }
 
     public function matchDoctrineJoinColumnTagValueNode(Property $property): ?JoinColumnTagValueNode
     {
-        /** @var PhpDocInfo|null $phpDocInfo */
         $phpDocInfo = $property->getAttribute(AttributeKey::PHP_DOC_INFO);
-        if ($phpDocInfo === null) {
-            return null;
-        }
 
         return $phpDocInfo->getByType(JoinColumnTagValueNode::class);
     }
 
     public function matchDoctrineGeneratedValueTagValueNode(Property $property): ?GeneratedValueTagValueNode
     {
-        /** @var PhpDocInfo|null $phpDocInfo */
         $phpDocInfo = $property->getAttribute(AttributeKey::PHP_DOC_INFO);
-        if ($phpDocInfo === null) {
-            return null;
-        }
 
         return $phpDocInfo->getByType(GeneratedValueTagValueNode::class);
     }

--- a/rules/doctrine-code-quality/src/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector.php
+++ b/rules/doctrine-code-quality/src/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector.php
@@ -11,7 +11,6 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocNode\Doctrine\Property_\ManyToOneTagValueNode;
 use Rector\Core\Rector\AbstractRector;
 use Rector\DoctrineCodeQuality\NodeAnalyzer\SetterClassMethodAnalyzer;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -109,7 +108,7 @@ CODE_SAMPLE
         }
 
         /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $property->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
         if ($phpDocInfo === null) {
             return null;
         }

--- a/rules/doctrine-code-quality/src/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector.php
+++ b/rules/doctrine-code-quality/src/Rector/ClassMethod/MakeEntitySetterNullabilityInSyncWithPropertyRector.php
@@ -7,7 +7,6 @@ namespace Rector\DoctrineCodeQuality\Rector\ClassMethod;
 use PhpParser\Node;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt\ClassMethod;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocNode\Doctrine\Property_\ManyToOneTagValueNode;
 use Rector\Core\Rector\AbstractRector;
 use Rector\DoctrineCodeQuality\NodeAnalyzer\SetterClassMethodAnalyzer;
@@ -107,11 +106,7 @@ CODE_SAMPLE
             return null;
         }
 
-        /** @var PhpDocInfo|null $phpDocInfo */
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
-        if ($phpDocInfo === null) {
-            return null;
-        }
 
         $manyToOneTagValueNode = $phpDocInfo->getByType(ManyToOneTagValueNode::class);
         if ($manyToOneTagValueNode === null) {

--- a/rules/doctrine-code-quality/src/Rector/Property/ChangeBigIntEntityPropertyToIntTypeRector.php
+++ b/rules/doctrine-code-quality/src/Rector/Property/ChangeBigIntEntityPropertyToIntTypeRector.php
@@ -10,7 +10,6 @@ use PHPStan\Type\BooleanType;
 use PHPStan\Type\FloatType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\StringType;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\Rector\AbstractRector;
 use Rector\DoctrineCodeQuality\NodeAnalyzer\DoctrinePropertyAnalyzer;
 use Rector\NodeTypeResolver\PhpDoc\NodeAnalyzer\DocBlockClassRenamer;
@@ -108,11 +107,7 @@ CODE_SAMPLE
             return null;
         }
 
-        /** @var PhpDocInfo|null $phpDocInfo */
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
-        if ($phpDocInfo === null) {
-            return null;
-        }
 
         $attributeAwareVarTagValueNode = $phpDocInfo->getVarTagValueNode();
         if ($attributeAwareVarTagValueNode === null) {

--- a/rules/doctrine-code-quality/src/Rector/Property/ChangeBigIntEntityPropertyToIntTypeRector.php
+++ b/rules/doctrine-code-quality/src/Rector/Property/ChangeBigIntEntityPropertyToIntTypeRector.php
@@ -13,7 +13,6 @@ use PHPStan\Type\StringType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\Rector\AbstractRector;
 use Rector\DoctrineCodeQuality\NodeAnalyzer\DoctrinePropertyAnalyzer;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PhpDoc\NodeAnalyzer\DocBlockClassRenamer;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -110,7 +109,7 @@ CODE_SAMPLE
         }
 
         /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
         if ($phpDocInfo === null) {
             return null;
         }

--- a/rules/doctrine-code-quality/src/Rector/Property/ImproveDoctrineCollectionDocTypeInEntityRector.php
+++ b/rules/doctrine-code-quality/src/Rector/Property/ImproveDoctrineCollectionDocTypeInEntityRector.php
@@ -138,7 +138,7 @@ CODE_SAMPLE
 
         // @todo make an own local property on enter node?
         /** @var PhpDocInfo $phpDocInfo */
-        $phpDocInfo = $property->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
 
         $attributeAwareVarTagValueNode = $this->collectionVarTagValueNodeResolver->resolve($property);
         if ($attributeAwareVarTagValueNode !== null) {
@@ -186,7 +186,7 @@ CODE_SAMPLE
         }
 
         /** @var PhpDocInfo $phpDocInfo */
-        $phpDocInfo = $classMethod->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
 
         $param = $classMethod->params[0];
         $parameterName = $this->getName($param);
@@ -198,7 +198,7 @@ CODE_SAMPLE
 
     private function hasNodeTagValueNode(Property $property, string $tagValueNodeClass): bool
     {
-        $phpDocInfo = $property->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
         if (! $phpDocInfo instanceof PhpDocInfo) {
             return false;
         }

--- a/rules/doctrine-code-quality/src/Rector/Property/ImproveDoctrineCollectionDocTypeInEntityRector.php
+++ b/rules/doctrine-code-quality/src/Rector/Property/ImproveDoctrineCollectionDocTypeInEntityRector.php
@@ -199,10 +199,6 @@ CODE_SAMPLE
     private function hasNodeTagValueNode(Property $property, string $tagValueNodeClass): bool
     {
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
-        if (! $phpDocInfo instanceof PhpDocInfo) {
-            return false;
-        }
-
         return $phpDocInfo->hasByType($tagValueNodeClass);
     }
 

--- a/rules/doctrine-gedmo-to-knplabs/src/Rector/Class_/LoggableBehaviorRector.php
+++ b/rules/doctrine-gedmo-to-knplabs/src/Rector/Class_/LoggableBehaviorRector.php
@@ -11,7 +11,6 @@ use Rector\BetterPhpDocParser\ValueObject\PhpDocNode\Gedmo\LoggableTagValueNode;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocNode\Gedmo\VersionedTagValueNode;
 use Rector\Core\PhpParser\Node\Manipulator\ClassInsertManipulator;
 use Rector\Core\Rector\AbstractRector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -116,10 +115,8 @@ CODE_SAMPLE
     private function removeVersionedTagFromProperties(Class_ $class): void
     {
         foreach ($class->getProperties() as $property) {
-            $propertyPhpDocInfo = $property->getAttribute(AttributeKey::PHP_DOC_INFO);
-            if ($propertyPhpDocInfo === null) {
-                continue;
-            }
+            $propertyPhpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
+
             $hasTypeVersionedTagValueNode = $propertyPhpDocInfo->hasByType(VersionedTagValueNode::class);
 
             if (! $hasTypeVersionedTagValueNode) {

--- a/rules/doctrine-gedmo-to-knplabs/src/Rector/Class_/LoggableBehaviorRector.php
+++ b/rules/doctrine-gedmo-to-knplabs/src/Rector/Class_/LoggableBehaviorRector.php
@@ -94,10 +94,7 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         // change the node
-        $classPhpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
-        if ($classPhpDocInfo === null) {
-            return null;
-        }
+        $classPhpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
         $hasTypeLoggableTagValueNode = $classPhpDocInfo->hasByType(LoggableTagValueNode::class);
 
         if (! $hasTypeLoggableTagValueNode) {

--- a/rules/doctrine-gedmo-to-knplabs/src/Rector/Class_/SluggableBehaviorRector.php
+++ b/rules/doctrine-gedmo-to-knplabs/src/Rector/Class_/SluggableBehaviorRector.php
@@ -16,7 +16,6 @@ use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocNode\Gedmo\SlugTagValueNode;
 use Rector\Core\PhpParser\Node\Manipulator\ClassInsertManipulator;
 use Rector\Core\Rector\AbstractRector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -112,10 +111,7 @@ CODE_SAMPLE
         $matchedProperty = null;
 
         foreach ($node->getProperties() as $property) {
-            $propertyPhpDocInfo = $property->getAttribute(AttributeKey::PHP_DOC_INFO);
-            if ($propertyPhpDocInfo === null) {
-                continue;
-            }
+            $propertyPhpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
 
             /** @var SlugTagValueNode|null $slugTagValueNode */
             $slugTagValueNode = $propertyPhpDocInfo->getByType(SlugTagValueNode::class);

--- a/rules/doctrine-gedmo-to-knplabs/src/Rector/Class_/SoftDeletableBehaviorRector.php
+++ b/rules/doctrine-gedmo-to-knplabs/src/Rector/Class_/SoftDeletableBehaviorRector.php
@@ -10,7 +10,6 @@ use PhpParser\Node\Stmt\Class_;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocNode\Gedmo\SoftDeleteableTagValueNode;
 use Rector\Core\PhpParser\Node\Manipulator\ClassInsertManipulator;
 use Rector\Core\Rector\AbstractRector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -90,10 +89,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $classPhpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
-        if ($classPhpDocInfo === null) {
-            return null;
-        }
+        $classPhpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
         $hasTypeSoftDeleteableTagValueNode = $classPhpDocInfo->hasByType(SoftDeleteableTagValueNode::class);
 
         if (! $hasTypeSoftDeleteableTagValueNode) {

--- a/rules/doctrine-gedmo-to-knplabs/src/Rector/Class_/TranslationBehaviorRector.php
+++ b/rules/doctrine-gedmo-to-knplabs/src/Rector/Class_/TranslationBehaviorRector.php
@@ -198,10 +198,7 @@ CODE_SAMPLE
         $removedPropertyNameToPhpDocInfo = [];
 
         foreach ($class->getProperties() as $property) {
-            $propertyPhpDocInfo = $property->getAttribute(AttributeKey::PHP_DOC_INFO);
-            if ($propertyPhpDocInfo === null) {
-                continue;
-            }
+            $propertyPhpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
             $hasTypeLocaleTagValueNode = $propertyPhpDocInfo->hasByType(LocaleTagValueNode::class);
 
             if ($hasTypeLocaleTagValueNode) {

--- a/rules/doctrine-gedmo-to-knplabs/src/Rector/Class_/TreeBehaviorRector.php
+++ b/rules/doctrine-gedmo-to-knplabs/src/Rector/Class_/TreeBehaviorRector.php
@@ -140,10 +140,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $classPhpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
-        if ($classPhpDocInfo === null) {
-            return null;
-        }
+        $classPhpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
         $hasTypeTreeTagValueNode = $classPhpDocInfo->hasByType(TreeTagValueNode::class);
 
         if (! $hasTypeTreeTagValueNode) {

--- a/rules/doctrine-gedmo-to-knplabs/src/Rector/Class_/TreeBehaviorRector.php
+++ b/rules/doctrine-gedmo-to-knplabs/src/Rector/Class_/TreeBehaviorRector.php
@@ -16,7 +16,6 @@ use Rector\BetterPhpDocParser\ValueObject\PhpDocNode\Gedmo\TreeRootTagValueNode;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocNode\Gedmo\TreeTagValueNode;
 use Rector\Core\PhpParser\Node\Manipulator\ClassInsertManipulator;
 use Rector\Core\Rector\AbstractRector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -158,10 +157,7 @@ CODE_SAMPLE
         $removedPropertyNames = [];
 
         foreach ($node->getProperties() as $property) {
-            $propertyPhpDocInfo = $property->getAttribute(AttributeKey::PHP_DOC_INFO);
-            if ($propertyPhpDocInfo === null) {
-                continue;
-            }
+            $propertyPhpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
 
             if (! $this->shouldRemoveProperty($propertyPhpDocInfo)) {
                 continue;

--- a/rules/doctrine/src/Rector/Class_/AddUuidMirrorForRelationPropertyRector.php
+++ b/rules/doctrine/src/Rector/Class_/AddUuidMirrorForRelationPropertyRector.php
@@ -178,7 +178,7 @@ CODE_SAMPLE
         }
 
         /** @var PhpDocInfo|null $propertyPhpDocInfo */
-        $propertyPhpDocInfo = $property->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $propertyPhpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
         if ($propertyPhpDocInfo === null) {
             return true;
         }
@@ -231,7 +231,7 @@ CODE_SAMPLE
     private function mirrorPhpDocInfoToUuid(Property $property): void
     {
         /** @var PhpDocInfo $propertyPhpDocInfo */
-        $propertyPhpDocInfo = $property->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $propertyPhpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
 
         $newPropertyPhpDocInfo = clone $propertyPhpDocInfo;
 

--- a/rules/doctrine/src/Rector/Class_/AlwaysInitializeUuidInEntityRector.php
+++ b/rules/doctrine/src/Rector/Class_/AlwaysInitializeUuidInEntityRector.php
@@ -14,7 +14,6 @@ use Rector\Core\PhpParser\Node\Manipulator\ClassDependencyManipulator;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\MethodName;
 use Rector\Doctrine\NodeFactory\EntityUuidNodeFactory;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -127,10 +126,7 @@ CODE_SAMPLE
     private function resolveUuidPropertyFromClass(Class_ $class): ?Property
     {
         foreach ($class->getProperties() as $property) {
-            $propertyPhpDoc = $property->getAttribute(AttributeKey::PHP_DOC_INFO);
-            if ($propertyPhpDoc === null) {
-                continue;
-            }
+            $propertyPhpDoc = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
 
             $varType = $propertyPhpDoc->getVarType();
             if (! $varType instanceof ObjectType) {

--- a/rules/doctrine/src/Rector/Class_/RemoveRepositoryFromEntityAnnotationRector.php
+++ b/rules/doctrine/src/Rector/Class_/RemoveRepositoryFromEntityAnnotationRector.php
@@ -63,13 +63,13 @@ CODE_SAMPLE
     {
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
 
-        /** @var EntityTagValueNode|null $doctrineEntityTag */
-        $doctrineEntityTag = $phpDocInfo->getByType(EntityTagValueNode::class);
-        if ($doctrineEntityTag === null) {
+        /** @var EntityTagValueNode|null $entityTagValueNode */
+        $entityTagValueNode = $phpDocInfo->getByType(EntityTagValueNode::class);
+        if ($entityTagValueNode === null) {
             return null;
         }
 
-        $doctrineEntityTag->removeRepositoryClass();
+        $entityTagValueNode->removeRepositoryClass();
 
         return $node;
     }

--- a/rules/doctrine/src/Rector/Class_/RemoveRepositoryFromEntityAnnotationRector.php
+++ b/rules/doctrine/src/Rector/Class_/RemoveRepositoryFromEntityAnnotationRector.php
@@ -8,7 +8,6 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocNode\Doctrine\Class_\EntityTagValueNode;
 use Rector\Core\Rector\AbstractRector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -62,10 +61,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
-        if ($phpDocInfo === null) {
-            return null;
-        }
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
 
         /** @var EntityTagValueNode|null $doctrineEntityTag */
         $doctrineEntityTag = $phpDocInfo->getByType(EntityTagValueNode::class);

--- a/rules/doctrine/src/Rector/Property/AddUuidAnnotationsToIdPropertyRector.php
+++ b/rules/doctrine/src/Rector/Property/AddUuidAnnotationsToIdPropertyRector.php
@@ -13,7 +13,6 @@ use Rector\BetterPhpDocParser\ValueObject\PhpDocNode\Doctrine\Property_\ColumnTa
 use Rector\BetterPhpDocParser\ValueObject\PhpDocNode\Doctrine\Property_\GeneratedValueTagValueNode;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocNode\JMS\SerializerTypeTagValueNode;
 use Rector\Core\Rector\AbstractRector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -101,7 +100,7 @@ CODE_SAMPLE
         }
 
         /** @var PhpDocInfo $phpDocInfo */
-        $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
 
         $fullyQualifiedObjectType = new FullyQualifiedObjectType(UuidInterface::class);
 

--- a/rules/generic/src/Rector/ClassLike/RemoveAnnotationRector.php
+++ b/rules/generic/src/Rector/ClassLike/RemoveAnnotationRector.php
@@ -9,7 +9,6 @@ use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt\ClassConst;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Property;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
@@ -74,11 +73,7 @@ CODE_SAMPLE
             return null;
         }
 
-        /** @var PhpDocInfo|null $phpDocInfo */
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
-        if ($phpDocInfo === null) {
-            return null;
-        }
 
         $hasChanged = false;
         foreach ($this->annotationsToRemove as $annotationToRemove) {

--- a/rules/generic/src/Rector/ClassLike/RemoveAnnotationRector.php
+++ b/rules/generic/src/Rector/ClassLike/RemoveAnnotationRector.php
@@ -12,7 +12,6 @@ use PhpParser\Node\Stmt\Property;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 use Webmozart\Assert\Assert;
@@ -76,7 +75,7 @@ CODE_SAMPLE
         }
 
         /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
         if ($phpDocInfo === null) {
             return null;
         }

--- a/rules/generic/src/Rector/ClassMethod/ChangeContractMethodSingleToManyRector.php
+++ b/rules/generic/src/Rector/ClassMethod/ChangeContractMethodSingleToManyRector.php
@@ -138,7 +138,7 @@ CODE_SAMPLE
         $arrayType = new ArrayType(new MixedType(), $staticType);
 
         /** @var PhpDocInfo $phpDocInfo */
-        $phpDocInfo = $classMethod->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
         $this->phpDocTypeChanger->changeReturnType($phpDocInfo, $arrayType);
     }
 

--- a/rules/generic/src/Rector/Property/AnnotatedPropertyInjectToConstructorInjectionRector.php
+++ b/rules/generic/src/Rector/Property/AnnotatedPropertyInjectToConstructorInjectionRector.php
@@ -96,7 +96,7 @@ CODE_SAMPLE
         }
 
         /** @var PhpDocInfo $phpDocInfo */
-        $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
         $phpDocInfo->removeByName(self::INJECT_ANNOTATION);
 
         if ($this->propertyUsageAnalyzer->isPropertyFetchedInChildClass($node)) {

--- a/rules/generic/src/Rector/Property/AnnotatedPropertyInjectToConstructorInjectionRector.php
+++ b/rules/generic/src/Rector/Property/AnnotatedPropertyInjectToConstructorInjectionRector.php
@@ -117,12 +117,7 @@ CODE_SAMPLE
 
     private function shouldSkipProperty(Property $property): bool
     {
-        /** @var PhpDocInfo|null $phpDocInfo */
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
-        if ($phpDocInfo === null) {
-            return true;
-        }
-
         if (! $phpDocInfo->hasByName(self::INJECT_ANNOTATION)) {
             return true;
         }

--- a/rules/generic/src/Rector/Property/AnnotatedPropertyInjectToConstructorInjectionRector.php
+++ b/rules/generic/src/Rector/Property/AnnotatedPropertyInjectToConstructorInjectionRector.php
@@ -118,7 +118,7 @@ CODE_SAMPLE
     private function shouldSkipProperty(Property $property): bool
     {
         /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $property->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
         if ($phpDocInfo === null) {
             return true;
         }

--- a/rules/generic/src/Rector/Property/InjectAnnotationClassRector.php
+++ b/rules/generic/src/Rector/Property/InjectAnnotationClassRector.php
@@ -142,7 +142,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
         if (! $phpDocInfo instanceof PhpDocInfo) {
             return null;
         }

--- a/rules/generic/src/Rector/Property/InjectAnnotationClassRector.php
+++ b/rules/generic/src/Rector/Property/InjectAnnotationClassRector.php
@@ -210,7 +210,7 @@ CODE_SAMPLE
 
         if ($phpDocTagValueNode instanceof PHPDIInjectTagValueNode) {
             /** @var PhpDocInfo $phpDocInfo */
-            $phpDocInfo = $property->getAttribute(AttributeKey::PHP_DOC_INFO);
+            $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
 
             return $phpDocInfo->getVarType();
         }
@@ -227,7 +227,7 @@ CODE_SAMPLE
         $propertyName = $this->getName($property);
 
         /** @var PhpDocInfo $phpDocInfo */
-        $phpDocInfo = $property->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
 
         $this->phpDocTypeChanger->changeVarType($phpDocInfo, $type);
         $phpDocInfo->removeByType($tagClass);
@@ -269,7 +269,7 @@ CODE_SAMPLE
 
         // 3. service is in @var annotation
         /** @var PhpDocInfo $phpDocInfo */
-        $phpDocInfo = $property->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
 
         $varType = $phpDocInfo->getVarType();
         if (! $varType instanceof MixedType) {

--- a/rules/jms/src/Rector/ClassMethod/RemoveJmsInjectParamsAnnotationRector.php
+++ b/rules/jms/src/Rector/ClassMethod/RemoveJmsInjectParamsAnnotationRector.php
@@ -6,11 +6,9 @@ namespace Rector\JMS\Rector\ClassMethod;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocNode\JMS\JMSInjectParamsTagValueNode;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\MethodName;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -77,12 +75,7 @@ CODE_SAMPLE
             return null;
         }
 
-        /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
-        if ($phpDocInfo === null) {
-            return null;
-        }
-
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
         $phpDocInfo->removeByType(JMSInjectParamsTagValueNode::class);
 
         return $node;

--- a/rules/jms/src/Rector/Class_/RemoveJmsInjectServiceAnnotationRector.php
+++ b/rules/jms/src/Rector/Class_/RemoveJmsInjectServiceAnnotationRector.php
@@ -7,10 +7,8 @@ namespace Rector\JMS\Rector\Class_;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocNode\JMS\JMSServiceValueNode;
 use Rector\Core\Rector\AbstractRector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -63,8 +61,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        /** @var PhpDocInfo $phpDocInfo */
-        $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
         if (! $phpDocInfo->hasByType(JMSServiceValueNode::class)) {
             return null;
         }

--- a/rules/nette-code-quality/src/Rector/Assign/MakeGetComponentAssignAnnotatedRector.php
+++ b/rules/nette-code-quality/src/Rector/Assign/MakeGetComponentAssignAnnotatedRector.php
@@ -214,6 +214,10 @@ CODE_SAMPLE
             throw new ShouldNotHappenException();
         }
 
+        if (! $arrayDimFetch->dim instanceof String_) {
+            return new MixedType();
+        }
+
         return $this->resolveTypeFromShortControlNameAndVariable($arrayDimFetch->dim, $scope, $arrayDimFetch->var);
     }
 

--- a/rules/nette-code-quality/src/Rector/Class_/MoveInjectToExistingConstructorRector.php
+++ b/rules/nette-code-quality/src/Rector/Class_/MoveInjectToExistingConstructorRector.php
@@ -152,12 +152,7 @@ CODE_SAMPLE
             return false;
         }
 
-        /** @var PhpDocInfo|null $phpDocInfo */
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
-        if ($phpDocInfo === null) {
-            return false;
-        }
-
         return (bool) $phpDocInfo->getTagsByName('inject');
     }
 }

--- a/rules/nette-code-quality/src/Rector/Class_/MoveInjectToExistingConstructorRector.php
+++ b/rules/nette-code-quality/src/Rector/Class_/MoveInjectToExistingConstructorRector.php
@@ -12,7 +12,6 @@ use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\MethodName;
 use Rector\Core\ValueObject\PhpVersionFeature;
 use Rector\FamilyTree\NodeAnalyzer\PropertyUsageAnalyzer;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -134,7 +133,7 @@ CODE_SAMPLE
     private function removeInjectAnnotation(Property $property): void
     {
         /** @var PhpDocInfo $phpDocInfo */
-        $phpDocInfo = $property->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
         $phpDocInfo->removeByName('inject');
     }
 
@@ -154,7 +153,7 @@ CODE_SAMPLE
         }
 
         /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $property->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
         if ($phpDocInfo === null) {
             return false;
         }

--- a/rules/nette-to-symfony/src/Rector/ClassMethod/RouterListToControllerAnnotationsRector.php
+++ b/rules/nette-to-symfony/src/Rector/ClassMethod/RouterListToControllerAnnotationsRector.php
@@ -18,7 +18,6 @@ use Rector\Core\Util\StaticRectorStrings;
 use Rector\NetteToSymfony\Route\RouteInfoFactory;
 use Rector\NetteToSymfony\Routing\ExplicitRouteAnnotationDecorator;
 use Rector\NetteToSymfony\ValueObject\RouteInfo;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\TypeDeclaration\TypeInferer\ReturnTypeInferer;
 use ReflectionMethod;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -319,11 +318,7 @@ CODE_SAMPLE
         }
 
         // already has Route tag
-        $phpDocInfo = $classMethod->getAttribute(AttributeKey::PHP_DOC_INFO);
-        if ($phpDocInfo === null) {
-            return false;
-        }
-
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
         return $phpDocInfo->hasByType(SymfonyRouteTagValueNode::class);
     }
 

--- a/rules/order/src/Rector/Class_/OrderClassConstantsByIntegerValueRector.php
+++ b/rules/order/src/Rector/Class_/OrderClassConstantsByIntegerValueRector.php
@@ -111,8 +111,8 @@ CODE_SAMPLE
     }
 
     /**
-     * @param array<int,ClassConst> $numericClassConstsByKey
-     * @return array<int,string>
+     * @param array<int, ClassConst> $numericClassConstsByKey
+     * @return array<int, string>
      */
     private function resolveClassConstConstByUniqueValue(array $numericClassConstsByKey): array
     {

--- a/rules/order/tests/StmtOrderTest.php
+++ b/rules/order/tests/StmtOrderTest.php
@@ -75,9 +75,9 @@ final class StmtOrderTest extends AbstractKernelTestCase
 
     /**
      * @dataProvider dataProvider
-     * @param array<int,string> $desiredStmtOrder
-     * @param array<int,string> $currentStmtOrder
-     * @param array<int,int> $expected
+     * @param array<int, string> $desiredStmtOrder
+     * @param array<int, string> $currentStmtOrder
+     * @param array<int, int> $expected
      */
     public function testCreateOldToNewKeys(array $desiredStmtOrder, array $currentStmtOrder, array $expected): void
     {

--- a/rules/php80/src/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
+++ b/rules/php80/src/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
@@ -139,7 +139,7 @@ CODE_SAMPLE
 
     private function decorateParamWithPropertyPhpDocInfo(Property $property, Param $param): void
     {
-        $propertyPhpDocInfo = $property->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $propertyPhpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
         if (! $propertyPhpDocInfo instanceof PhpDocInfo) {
             return;
         }
@@ -157,7 +157,7 @@ CODE_SAMPLE
 
     private function removeClassMethodParam(ClassMethod $classMethod, string $paramName): void
     {
-        $phpDocInfo = $classMethod->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
         if (! $phpDocInfo instanceof PhpDocInfo) {
             return;
         }

--- a/rules/php80/src/Rector/FunctionLike/UnionTypesRector.php
+++ b/rules/php80/src/Rector/FunctionLike/UnionTypesRector.php
@@ -16,7 +16,6 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\Rector\AbstractRector;
 use Rector\DeadDocBlock\TagRemover\ParamTagRemover;
 use Rector\DeadDocBlock\TagRemover\ReturnTagRemover;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -86,10 +85,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
-        if ($phpDocInfo === null) {
-            return null;
-        }
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
 
         $this->refactorParamTypes($node, $phpDocInfo);
         $this->refactorReturnType($node, $phpDocInfo);

--- a/rules/phpunit/src/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector.php
+++ b/rules/phpunit/src/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector.php
@@ -12,7 +12,6 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\Rector\AbstractPHPUnitRector;
 use Rector\Core\Reflection\ClassMethodReflectionFactory;
 use Rector\FileSystemRector\Parser\FileInfoParser;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PhpDoc\NodeAnalyzer\DocBlockManipulator;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -163,7 +162,7 @@ CODE_SAMPLE
     private function addDoesNotPerformAssertions(ClassMethod $classMethod): void
     {
         /** @var PhpDocInfo $phpDocInfo */
-        $phpDocInfo = $classMethod->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
         $phpDocInfo->addBareTag('@' . self::DOES_NOT_PERFORM_ASSERTION_TAG);
     }
 

--- a/rules/phpunit/src/Rector/ClassMethod/ExceptionAnnotationRector.php
+++ b/rules/phpunit/src/Rector/ClassMethod/ExceptionAnnotationRector.php
@@ -6,7 +6,6 @@ namespace Rector\PHPUnit\Rector\ClassMethod;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\Rector\AbstractPHPUnitRector;
 use Rector\PHPUnit\NodeFactory\ExpectExceptionMethodCallFactory;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -89,12 +88,7 @@ CODE_SAMPLE
             return null;
         }
 
-        /** @var PhpDocInfo|null $phpDocInfo */
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
-        if ($phpDocInfo === null) {
-            return null;
-        }
-
         foreach (self::ANNOTATION_TO_METHOD as $annotationName => $methodName) {
             if (! $phpDocInfo->hasByName($annotationName)) {
                 continue;

--- a/rules/phpunit/src/Rector/ClassMethod/ExceptionAnnotationRector.php
+++ b/rules/phpunit/src/Rector/ClassMethod/ExceptionAnnotationRector.php
@@ -8,7 +8,6 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\Rector\AbstractPHPUnitRector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PHPUnit\NodeFactory\ExpectExceptionMethodCallFactory;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -91,7 +90,7 @@ CODE_SAMPLE
         }
 
         /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
         if ($phpDocInfo === null) {
             return null;
         }

--- a/rules/phpunit/src/Rector/Class_/AddSeeTestAnnotationRector.php
+++ b/rules/phpunit/src/Rector/Class_/AddSeeTestAnnotationRector.php
@@ -92,7 +92,7 @@ CODE_SAMPLE
         }
 
         /** @var PhpDocInfo $phpDocInfo */
-        $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
 
         $seeTagNode = $this->createSeePhpDocTagNode($testCaseClassName);
         $phpDocInfo->addPhpDocTagNode($seeTagNode);

--- a/rules/phpunit/src/Rector/Class_/AddSeeTestAnnotationRector.php
+++ b/rules/phpunit/src/Rector/Class_/AddSeeTestAnnotationRector.php
@@ -12,7 +12,6 @@ use Rector\AttributeAwarePhpDoc\Ast\PhpDoc\AttributeAwareGenericTagValueNode;
 use Rector\AttributeAwarePhpDoc\Ast\PhpDoc\AttributeAwarePhpDocTagNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\Rector\AbstractRector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PHPUnit\TestClassResolver\TestClassResolver;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -109,12 +108,7 @@ CODE_SAMPLE
             return true;
         }
 
-        /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $class->getAttribute(AttributeKey::PHP_DOC_INFO);
-        if ($phpDocInfo === null) {
-            return true;
-        }
-
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($class);
         $seeTags = $phpDocInfo->getTagsByName('see');
 
         // is the @see annotation already added

--- a/rules/phpunit/src/Rector/Class_/ArrayArgumentInTestToDataProviderRector.php
+++ b/rules/phpunit/src/Rector/Class_/ArrayArgumentInTestToDataProviderRector.php
@@ -224,7 +224,7 @@ CODE_SAMPLE
         $dataProviderTagNode = $this->createDataProviderTagNode($dataProviderMethodName);
 
         /** @var PhpDocInfo $phpDocInfo */
-        $phpDocInfo = $classMethod->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
         $phpDocInfo->addPhpDocTagNode($dataProviderTagNode);
     }
 
@@ -271,7 +271,7 @@ CODE_SAMPLE
         $classMethod->params = $this->createParams($paramAndArgs);
 
         /** @var PhpDocInfo $phpDocInfo */
-        $phpDocInfo = $classMethod->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
 
         foreach ($paramAndArgs as $paramAndArg) {
             $staticType = $paramAndArg->getType();

--- a/rules/phpunit/src/Rector/Class_/RemoveDataProviderTestPrefixRector.php
+++ b/rules/phpunit/src/Rector/Class_/RemoveDataProviderTestPrefixRector.php
@@ -11,7 +11,6 @@ use PhpParser\Node\Stmt\Class_;
 use Rector\AttributeAwarePhpDoc\Ast\PhpDoc\DataProviderTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\Rector\AbstractPHPUnitRector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -102,7 +101,7 @@ CODE_SAMPLE
     {
         foreach ($class->getMethods() as $classMethod) {
             /** @var PhpDocInfo|null $phpDocInfo */
-            $phpDocInfo = $classMethod->getAttribute(AttributeKey::PHP_DOC_INFO);
+            $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
             if ($phpDocInfo === null) {
                 continue;
             }

--- a/rules/phpunit/src/Rector/Class_/RemoveDataProviderTestPrefixRector.php
+++ b/rules/phpunit/src/Rector/Class_/RemoveDataProviderTestPrefixRector.php
@@ -9,7 +9,6 @@ use PhpParser\Node;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\Class_;
 use Rector\AttributeAwarePhpDoc\Ast\PhpDoc\DataProviderTagValueNode;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\Rector\AbstractPHPUnitRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -100,11 +99,7 @@ CODE_SAMPLE
     private function renameDataProviderAnnotationsAndCollectRenamedMethods(Class_ $class): void
     {
         foreach ($class->getMethods() as $classMethod) {
-            /** @var PhpDocInfo|null $phpDocInfo */
             $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
-            if ($phpDocInfo === null) {
-                continue;
-            }
 
             /** @var DataProviderTagValueNode[] $dataProviderTagValueNodes */
             $dataProviderTagValueNodes = $phpDocInfo->findAllByType(DataProviderTagValueNode::class);

--- a/rules/phpunit/src/Rector/Class_/SelfContainerGetMethodCallFromTestToInjectPropertyRector.php
+++ b/rules/phpunit/src/Rector/Class_/SelfContainerGetMethodCallFromTestToInjectPropertyRector.php
@@ -7,10 +7,8 @@ namespace Rector\PHPUnit\Rector\Class_;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Property;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\PhpParser\Node\Manipulator\ClassManipulator;
 use Rector\Core\Rector\AbstractPHPUnitRector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PHPUnit\Collector\FormerVariablesByMethodCollector;
 use Rector\PHPUnit\Manipulator\OnContainerGetCallManipulator;
 use Rector\SymfonyPHPUnit\Node\KernelTestCaseNodeFactory;
@@ -160,10 +158,9 @@ CODE_SAMPLE
         return $node;
     }
 
-    private function addInjectAnnotationToProperty(Property $privateProperty): void
+    private function addInjectAnnotationToProperty(Property $property): void
     {
-        /** @var PhpDocInfo $phpDocInfo */
-        $phpDocInfo = $privateProperty->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
         $phpDocInfo->addBareTag('@inject');
     }
 

--- a/rules/privatization/src/Rector/ClassConst/PrivatizeLocalClassConstantRector.php
+++ b/rules/privatization/src/Rector/ClassConst/PrivatizeLocalClassConstantRector.php
@@ -6,7 +6,6 @@ namespace Rector\Privatization\Rector\ClassConst;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassConst;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Caching\Contract\Rector\ZeroCacheRectorInterface;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Core\ValueObject\PhpVersionFeature;
@@ -149,9 +148,8 @@ CODE_SAMPLE
             return true;
         }
 
-        /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $classConst->getAttribute(AttributeKey::PHP_DOC_INFO);
-        if ($phpDocInfo !== null && $phpDocInfo->hasByName('api')) {
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classConst);
+        if ($phpDocInfo->hasByName('api')) {
             return true;
         }
 

--- a/rules/privatization/src/Rector/ClassMethod/PrivatizeLocalOnlyMethodRector.php
+++ b/rules/privatization/src/Rector/ClassMethod/PrivatizeLocalOnlyMethodRector.php
@@ -157,12 +157,7 @@ CODE_SAMPLE
             return true;
         }
 
-        /** @var PhpDocInfo|null $phpDocInfo */
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
-        if ($phpDocInfo === null) {
-            return false;
-        }
-
         return $phpDocInfo->hasByNames([self::API, TagName::REQUIRED]);
     }
 

--- a/rules/privatization/src/Rector/ClassMethod/PrivatizeLocalOnlyMethodRector.php
+++ b/rules/privatization/src/Rector/ClassMethod/PrivatizeLocalOnlyMethodRector.php
@@ -158,7 +158,7 @@ CODE_SAMPLE
         }
 
         /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $classMethod->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
         if ($phpDocInfo === null) {
             return false;
         }
@@ -184,7 +184,7 @@ CODE_SAMPLE
         }
 
         /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $classMethod->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
         if ($phpDocInfo === null) {
             return false;
         }

--- a/rules/privatization/src/Rector/Property/PrivatizeLocalPropertyToPrivatePropertyRector.php
+++ b/rules/privatization/src/Rector/Property/PrivatizeLocalPropertyToPrivatePropertyRector.php
@@ -139,7 +139,7 @@ CODE_SAMPLE
         }
 
         /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $property->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
         if ($phpDocInfo === null) {
             return false;
         }

--- a/rules/removing-static/src/Rector/Class_/StaticTypeToSetterInjectionRector.php
+++ b/rules/removing-static/src/Rector/Class_/StaticTypeToSetterInjectionRector.php
@@ -15,12 +15,10 @@ use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Type\ObjectType;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Naming\Naming\PropertyNaming;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\Astral\ValueObject\NodeBuilder\MethodBuilder;
 use Symplify\Astral\ValueObject\NodeBuilder\ParamBuilder;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
@@ -173,8 +171,7 @@ CODE_SAMPLE
 
             $entityFactoryProperty = $this->nodeFactory->createPrivateProperty($variableName);
 
-            /** @var PhpDocInfo $phpDocInfo */
-            $phpDocInfo = $entityFactoryProperty->getAttribute(AttributeKey::PHP_DOC_INFO);
+            $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($entityFactoryProperty);
             $this->phpDocTypeChanger->changeVarType($phpDocInfo, $objectType);
 
             $class->stmts = array_merge([$entityFactoryProperty, $setEntityFactoryMethod], $class->stmts);

--- a/rules/renaming/src/Rector/ClassMethod/RenameAnnotationRector.php
+++ b/rules/renaming/src/Rector/ClassMethod/RenameAnnotationRector.php
@@ -89,7 +89,7 @@ CODE_SAMPLE
         $classLike = $node->getAttribute(AttributeKey::CLASS_NODE);
 
         /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
         if ($phpDocInfo === null) {
             return null;
         }

--- a/rules/restoration/src/Rector/ClassMethod/InferParamFromClassMethodReturnRector.php
+++ b/rules/restoration/src/Rector/ClassMethod/InferParamFromClassMethodReturnRector.php
@@ -138,7 +138,7 @@ CODE_SAMPLE
             $returnType = $this->returnTypeInferer->inferFunctionLike($returnClassMethod);
 
             /** @var PhpDocInfo|null $currentPhpDocInfo */
-            $currentPhpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
+            $currentPhpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
             if ($currentPhpDocInfo === null) {
                 $currentPhpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
             }

--- a/rules/restoration/src/Rector/Use_/RestoreFullyQualifiedNameRector.php
+++ b/rules/restoration/src/Rector/Use_/RestoreFullyQualifiedNameRector.php
@@ -14,7 +14,6 @@ use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\Type\MixedType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\Rector\AbstractRector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Restoration\NameMatcher\FullyQualifiedNameMatcher;
 use Rector\Restoration\NameMatcher\PhpDocTypeNodeNameMatcher;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -149,7 +148,7 @@ CODE_SAMPLE
     private function refactorReturnTagValueNode(ClassMethod $classMethod): void
     {
         /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $classMethod->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
         if (! $phpDocInfo instanceof PhpDocInfo) {
             return;
         }

--- a/rules/sensio/src/Rector/ClassMethod/RemoveServiceFromSensioRouteRector.php
+++ b/rules/sensio/src/Rector/ClassMethod/RemoveServiceFromSensioRouteRector.php
@@ -10,7 +10,6 @@ use PhpParser\Node\Stmt\ClassMethod;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocNode\Sensio\SensioRouteTagValueNode;
 use Rector\Core\Rector\AbstractRector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -70,7 +69,7 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
         if ($phpDocInfo === null) {
             return null;
         }

--- a/rules/sensio/src/Rector/ClassMethod/ReplaceSensioRouteAnnotationWithSymfonyRector.php
+++ b/rules/sensio/src/Rector/ClassMethod/ReplaceSensioRouteAnnotationWithSymfonyRector.php
@@ -13,7 +13,6 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocNode\Sensio\SensioRouteTagValueNode;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocNode\Symfony\SymfonyRouteTagValueNode;
 use Rector\Core\Rector\AbstractRector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -81,7 +80,7 @@ CODE_SAMPLE
         }
 
         /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
         if ($phpDocInfo === null) {
             return null;
         }

--- a/rules/symfony3/src/Rector/ClassMethod/MergeMethodAnnotationToRouteAnnotationRector.php
+++ b/rules/symfony3/src/Rector/ClassMethod/MergeMethodAnnotationToRouteAnnotationRector.php
@@ -85,7 +85,7 @@ CODE_SAMPLE
         }
 
         /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
         if ($phpDocInfo === null) {
             return null;
         }

--- a/rules/symfony3/src/Rector/ClassMethod/MergeMethodAnnotationToRouteAnnotationRector.php
+++ b/rules/symfony3/src/Rector/ClassMethod/MergeMethodAnnotationToRouteAnnotationRector.php
@@ -6,7 +6,6 @@ namespace Rector\Symfony3\Rector\ClassMethod;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocNode\Sensio\SensioMethodTagValueNode;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocNode\Symfony\SymfonyRouteTagValueNode;
 use Rector\Core\Rector\AbstractRector;
@@ -84,11 +83,7 @@ CODE_SAMPLE
             return null;
         }
 
-        /** @var PhpDocInfo|null $phpDocInfo */
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
-        if ($phpDocInfo === null) {
-            return null;
-        }
 
         /** @var SensioMethodTagValueNode|null $sensioMethodTagValueNode */
         $sensioMethodTagValueNode = $phpDocInfo->getByType(SensioMethodTagValueNode::class);

--- a/rules/type-declaration/src/Rector/ClassMethod/AddArrayReturnDocTypeRector.php
+++ b/rules/type-declaration/src/Rector/ClassMethod/AddArrayReturnDocTypeRector.php
@@ -151,7 +151,7 @@ CODE_SAMPLE
         }
 
         /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
         if ($phpDocInfo === null) {
             return null;
         }

--- a/rules/type-declaration/src/Rector/ClassMethod/AddArrayReturnDocTypeRector.php
+++ b/rules/type-declaration/src/Rector/ClassMethod/AddArrayReturnDocTypeRector.php
@@ -21,7 +21,6 @@ use Rector\AttributeAwarePhpDoc\Ast\Type\AttributeAwareGenericTypeNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 use Rector\Core\Rector\AbstractRector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\TypeDeclaration\OverrideGuard\ClassMethodReturnTypeOverrideGuard;
 use Rector\TypeDeclaration\TypeAnalyzer\AdvancedArrayAnalyzer;
 use Rector\TypeDeclaration\TypeInferer\ReturnTypeInferer;
@@ -186,7 +185,7 @@ CODE_SAMPLE
     private function getNodeReturnPhpDocType(ClassMethod $classMethod): ?Type
     {
         /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $classMethod->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
         return $phpDocInfo !== null ? $phpDocInfo->getReturnType() : null;
     }
 
@@ -252,11 +251,7 @@ CODE_SAMPLE
 
     private function hasArrayShapeNode(ClassMethod $classMethod): bool
     {
-        /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $classMethod->getAttribute(AttributeKey::PHP_DOC_INFO);
-        if (! $phpDocInfo instanceof PhpDocInfo) {
-            return false;
-        }
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
 
         $attributeAwareReturnTagValueNode = $phpDocInfo->getReturnTagValue();
         if (! $attributeAwareReturnTagValueNode instanceof ReturnTagValueNode) {
@@ -280,7 +275,7 @@ CODE_SAMPLE
 
     private function hasInheritDoc(ClassMethod $classMethod): bool
     {
-        $phpDocInfo = $classMethod->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
         if (! $phpDocInfo instanceof PhpDocInfo) {
             return false;
         }

--- a/rules/type-declaration/src/Rector/ClassMethod/AddArrayReturnDocTypeRector.php
+++ b/rules/type-declaration/src/Rector/ClassMethod/AddArrayReturnDocTypeRector.php
@@ -18,7 +18,6 @@ use PHPStan\Type\UnionType;
 use PHPStan\Type\VoidType;
 use Rector\AttributeAwarePhpDoc\Ast\Type\AttributeAwareArrayShapeNode;
 use Rector\AttributeAwarePhpDoc\Ast\Type\AttributeAwareGenericTypeNode;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 use Rector\Core\Rector\AbstractRector;
 use Rector\TypeDeclaration\OverrideGuard\ClassMethodReturnTypeOverrideGuard;
@@ -149,12 +148,7 @@ CODE_SAMPLE
             return null;
         }
 
-        /** @var PhpDocInfo|null $phpDocInfo */
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
-        if ($phpDocInfo === null) {
-            return null;
-        }
-
         $this->phpDocTypeChanger->changeReturnType($phpDocInfo, $inferedType);
 
         return $node;
@@ -182,11 +176,10 @@ CODE_SAMPLE
         return $currentPhpDocReturnType instanceof IterableType;
     }
 
-    private function getNodeReturnPhpDocType(ClassMethod $classMethod): ?Type
+    private function getNodeReturnPhpDocType(ClassMethod $classMethod): Type
     {
-        /** @var PhpDocInfo|null $phpDocInfo */
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
-        return $phpDocInfo !== null ? $phpDocInfo->getReturnType() : null;
+        return $phpDocInfo->getReturnType();
     }
 
     /**
@@ -276,10 +269,6 @@ CODE_SAMPLE
     private function hasInheritDoc(ClassMethod $classMethod): bool
     {
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
-        if (! $phpDocInfo instanceof PhpDocInfo) {
-            return false;
-        }
-
         return $phpDocInfo->hasInheritDoc();
     }
 }

--- a/rules/type-declaration/src/Rector/Identical/FlipTypeControlToUseExclusiveTypeRector.php
+++ b/rules/type-declaration/src/Rector/Identical/FlipTypeControlToUseExclusiveTypeRector.php
@@ -95,10 +95,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $phpDocInfo = $expression->getAttribute(AttributeKey::PHP_DOC_INFO);
-        if (! $phpDocInfo instanceof PhpDocInfo) {
-            return null;
-        }
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($expression);
 
         /** @var AttributeAwareIdentifierTypeNode[] $types */
         $types = $this->getTypes($phpDocInfo);

--- a/rules/type-declaration/src/Rector/Property/CompleteVarDocTypePropertyRector.php
+++ b/rules/type-declaration/src/Rector/Property/CompleteVarDocTypePropertyRector.php
@@ -7,9 +7,7 @@ namespace Rector\TypeDeclaration\Rector\Property;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\Type\MixedType;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
-use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\Rector\AbstractRector;
 use Rector\TypeDeclaration\TypeInferer\PropertyTypeInferer;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -91,12 +89,7 @@ CODE_SAMPLE
             return null;
         }
 
-        /** @var PhpDocInfo|null $phpDocInfo */
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
-        if ($phpDocInfo === null) {
-            throw new ShouldNotHappenException();
-        }
-
         $this->phpDocTypeChanger->changeVarType($phpDocInfo, $propertyType);
 
         return $node;

--- a/rules/type-declaration/src/Rector/Property/CompleteVarDocTypePropertyRector.php
+++ b/rules/type-declaration/src/Rector/Property/CompleteVarDocTypePropertyRector.php
@@ -11,7 +11,6 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\Rector\AbstractRector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\TypeDeclaration\TypeInferer\PropertyTypeInferer;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -93,7 +92,7 @@ CODE_SAMPLE
         }
 
         /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
         if ($phpDocInfo === null) {
             throw new ShouldNotHappenException();
         }

--- a/rules/type-declaration/src/Rector/Property/PropertyTypeDeclarationRector.php
+++ b/rules/type-declaration/src/Rector/Property/PropertyTypeDeclarationRector.php
@@ -7,10 +7,8 @@ namespace Rector\TypeDeclaration\Rector\Property;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\Type\MixedType;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 use Rector\Core\Rector\AbstractRector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\TypeDeclaration\TypeInferer\PropertyTypeInferer;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -93,20 +91,16 @@ CODE_SAMPLE
             return null;
         }
 
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
+
         // is already set
-        /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
-        if ($phpDocInfo !== null && ! $phpDocInfo->getVarType() instanceof MixedType) {
+        if (! $phpDocInfo->getVarType() instanceof MixedType) {
             return null;
         }
 
         $type = $this->propertyTypeInferer->inferProperty($node);
         if ($type instanceof MixedType) {
             return null;
-        }
-
-        if ($phpDocInfo === null) {
-            $phpDocInfo = $this->phpDocInfoFactory->createEmpty($node);
         }
 
         $this->phpDocTypeChanger->changeVarType($phpDocInfo, $type);

--- a/rules/type-declaration/src/TypeInferer/ParamTypeInferer/FunctionLikeDocParamTypeInferer.php
+++ b/rules/type-declaration/src/TypeInferer/ParamTypeInferer/FunctionLikeDocParamTypeInferer.php
@@ -8,7 +8,7 @@ use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Param;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\TypeDeclaration\Contract\TypeInferer\ParamTypeInfererInterface;
@@ -16,9 +16,15 @@ use Rector\TypeDeclaration\TypeInferer\AbstractTypeInferer;
 
 final class FunctionLikeDocParamTypeInferer extends AbstractTypeInferer implements ParamTypeInfererInterface
 {
-    public function __construct(NodeNameResolver $nodeNameResolver)
+    /**
+     * @var PhpDocInfoFactory
+     */
+    private $phpDocInfoFactory;
+
+    public function __construct(NodeNameResolver $nodeNameResolver, PhpDocInfoFactory $phpDocInfoFactory)
     {
         $this->nodeNameResolver = $nodeNameResolver;
+        $this->phpDocInfoFactory = $phpDocInfoFactory;
     }
 
     public function inferParam(Param $param): Type
@@ -28,11 +34,7 @@ final class FunctionLikeDocParamTypeInferer extends AbstractTypeInferer implemen
             return new MixedType();
         }
 
-        /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $functionLike->getAttribute(AttributeKey::PHP_DOC_INFO);
-        if ($phpDocInfo === null) {
-            return new MixedType();
-        }
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($functionLike);
 
         $paramTypesByName = $phpDocInfo->getParamTypesByName();
         if ($paramTypesByName === []) {

--- a/rules/type-declaration/src/TypeInferer/ParamTypeInferer/GetterNodeParamTypeInferer.php
+++ b/rules/type-declaration/src/TypeInferer/ParamTypeInferer/GetterNodeParamTypeInferer.php
@@ -12,7 +12,7 @@ use PhpParser\Node\Stmt\Return_;
 use PhpParser\NodeTraverser;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Core\PhpParser\Node\Manipulator\PropertyFetchAssignManipulator;
 use Rector\Core\PhpParser\Node\Manipulator\PropertyFetchManipulator;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -31,12 +31,19 @@ final class GetterNodeParamTypeInferer extends AbstractTypeInferer implements Pa
      */
     private $propertyFetchAssignManipulator;
 
+    /**
+     * @var PhpDocInfoFactory
+     */
+    private $phpDocInfoFactory;
+
     public function __construct(
         PropertyFetchAssignManipulator $propertyFetchAssignManipulator,
-        PropertyFetchManipulator $propertyFetchManipulator
+        PropertyFetchManipulator $propertyFetchManipulator,
+        PhpDocInfoFactory $phpDocInfoFactory
     ) {
         $this->propertyFetchManipulator = $propertyFetchManipulator;
         $this->propertyFetchAssignManipulator = $propertyFetchAssignManipulator;
+        $this->phpDocInfoFactory = $phpDocInfoFactory;
     }
 
     public function inferParam(Param $param): Type
@@ -86,11 +93,7 @@ final class GetterNodeParamTypeInferer extends AbstractTypeInferer implements Pa
                 return null;
             }
 
-            /** @var PhpDocInfo|null $phpDocInfo */
-            $phpDocInfo = $classMethod->getAttribute(AttributeKey::PHP_DOC_INFO);
-            if ($phpDocInfo === null) {
-                return null;
-            }
+            $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classMethod);
 
             $methodReturnType = $phpDocInfo->getReturnType();
             if ($methodReturnType instanceof MixedType) {

--- a/rules/type-declaration/src/TypeInferer/ParamTypeInferer/PHPUnitDataProviderParamTypeInferer.php
+++ b/rules/type-declaration/src/TypeInferer/ParamTypeInferer/PHPUnitDataProviderParamTypeInferer.php
@@ -15,6 +15,8 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use Rector\AttributeAwarePhpDoc\Ast\PhpDoc\DataProviderTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\NodeTypeResolver;
@@ -38,10 +40,19 @@ final class PHPUnitDataProviderParamTypeInferer implements ParamTypeInfererInter
      */
     private $typeFactory;
 
-    public function __construct(BetterNodeFinder $betterNodeFinder, TypeFactory $typeFactory)
-    {
+    /**
+     * @var PhpDocInfoFactory
+     */
+    private $phpDocInfoFactory;
+
+    public function __construct(
+        BetterNodeFinder $betterNodeFinder,
+        TypeFactory $typeFactory,
+        PhpDocInfoFactory $phpDocInfoFactory
+    ) {
         $this->betterNodeFinder = $betterNodeFinder;
         $this->typeFactory = $typeFactory;
+        $this->phpDocInfoFactory = $phpDocInfoFactory;
     }
 
     /**
@@ -74,9 +85,6 @@ final class PHPUnitDataProviderParamTypeInferer implements ParamTypeInfererInter
     private function resolveDataProviderClassMethod(Param $param): ?ClassMethod
     {
         $phpDocInfo = $this->getFunctionLikePhpDocInfo($param);
-        if ($phpDocInfo === null) {
-            return null;
-        }
 
         /** @var DataProviderTagValueNode|null $attributeAwareDataProviderTagValueNode */
         $attributeAwareDataProviderTagValueNode = $phpDocInfo->getByType(DataProviderTagValueNode::class);
@@ -128,13 +136,13 @@ final class PHPUnitDataProviderParamTypeInferer implements ParamTypeInfererInter
         return $this->typeFactory->createMixedPassedOrUnionType($paramOnPositionTypes);
     }
 
-    private function getFunctionLikePhpDocInfo(Param $param): ?PhpDocInfo
+    private function getFunctionLikePhpDocInfo(Param $param): PhpDocInfo
     {
         $parent = $param->getAttribute(AttributeKey::PARENT_NODE);
         if (! $parent instanceof FunctionLike) {
-            return null;
+            throw new ShouldNotHappenException();
         }
 
-        return $parent->getAttribute(AttributeKey::PHP_DOC_INFO);
+        return $this->phpDocInfoFactory->createFromNodeOrEmpty($parent);
     }
 }

--- a/rules/type-declaration/src/TypeInferer/PropertyTypeInferer.php
+++ b/rules/type-declaration/src/TypeInferer/PropertyTypeInferer.php
@@ -92,37 +92,33 @@ final class PropertyTypeInferer extends AbstractPriorityAwareTypeInferer
             }
         }
 
-        if ($resolvedType === null) {
-            return new MixedType();
-        }
-
         return $resolvedType;
     }
 
-    private function shouldUnionWithDefaultValue(Type $defaultValueType, ?Type $type = null): bool
+    private function shouldUnionWithDefaultValue(Type $defaultValueType, Type $type): bool
     {
         if ($defaultValueType instanceof MixedType) {
             return false;
         }
 
         // skip empty array type (mixed[])
-        if ($defaultValueType instanceof ArrayType && $defaultValueType->getItemType() instanceof NeverType && $type !== null) {
+        if ($defaultValueType instanceof ArrayType && $defaultValueType->getItemType() instanceof NeverType && ! $type instanceof MixedType) {
             return false;
         }
 
-        if ($type === null) {
+        if ($type instanceof MixedType) {
             return true;
         }
 
         return ! $this->doctrineTypeAnalyzer->isDoctrineCollectionWithIterableUnionType($type);
     }
 
-    private function unionWithDefaultValueType(Type $defaultValueType, ?Type $resolvedType): Type
+    private function unionWithDefaultValueType(Type $defaultValueType, Type $resolvedType): Type
     {
         $types = [];
         $types[] = $defaultValueType;
 
-        if ($resolvedType !== null) {
+        if (! $resolvedType instanceof MixedType) {
             $types[] = $resolvedType;
         }
 

--- a/rules/type-declaration/src/TypeInferer/PropertyTypeInferer/DoctrineRelationPropertyTypeInferer.php
+++ b/rules/type-declaration/src/TypeInferer/PropertyTypeInferer/DoctrineRelationPropertyTypeInferer.php
@@ -12,9 +12,8 @@ use PHPStan\Type\Type;
 use Rector\BetterPhpDocParser\Contract\Doctrine\DoctrineRelationTagValueNodeInterface;
 use Rector\BetterPhpDocParser\Contract\Doctrine\ToManyTagNodeInterface;
 use Rector\BetterPhpDocParser\Contract\Doctrine\ToOneTagNodeInterface;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\ValueObject\PhpDocNode\Doctrine\Property_\JoinColumnTagValueNode;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PHPStan\Type\TypeFactory;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 use Rector\TypeDeclaration\Contract\TypeInferer\PropertyTypeInfererInterface;
@@ -31,18 +30,20 @@ final class DoctrineRelationPropertyTypeInferer implements PropertyTypeInfererIn
      */
     private $typeFactory;
 
-    public function __construct(TypeFactory $typeFactory)
+    /**
+     * @var PhpDocInfoFactory
+     */
+    private $phpDocInfoFactory;
+
+    public function __construct(TypeFactory $typeFactory, PhpDocInfoFactory $phpDocInfoFactory)
     {
         $this->typeFactory = $typeFactory;
+        $this->phpDocInfoFactory = $phpDocInfoFactory;
     }
 
     public function inferProperty(Property $property): Type
     {
-        /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $property->getAttribute(AttributeKey::PHP_DOC_INFO);
-        if ($phpDocInfo === null) {
-            return new MixedType();
-        }
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
 
         $relationTagValueNode = $phpDocInfo->getByType(DoctrineRelationTagValueNodeInterface::class);
         if ($relationTagValueNode === null) {

--- a/rules/type-declaration/src/TypeInferer/PropertyTypeInferer/VarDocPropertyTypeInferer.php
+++ b/rules/type-declaration/src/TypeInferer/PropertyTypeInferer/VarDocPropertyTypeInferer.php
@@ -6,24 +6,23 @@ namespace Rector\TypeDeclaration\TypeInferer\PropertyTypeInferer;
 
 use PhpParser\Node\Stmt\Property;
 use PHPStan\Type\Type;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
-use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 
 final class VarDocPropertyTypeInferer
 {
-    public function inferProperty(Property $property): ?Type
+    /**
+     * @var PhpDocInfoFactory
+     */
+    private $phpDocInfoFactory;
+
+    public function __construct(PhpDocInfoFactory $phpDocInfoFactory)
     {
-        /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $property->getAttribute(AttributeKey::PHP_DOC_INFO);
-        if ($phpDocInfo === null) {
-            return null;
-        }
+        $this->phpDocInfoFactory = $phpDocInfoFactory;
+    }
 
-        // is empty
-        if ($phpDocInfo->getPhpDocNode()->children === []) {
-            return null;
-        }
-
+    public function inferProperty(Property $property): Type
+    {
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($property);
         return $phpDocInfo->getVarType();
     }
 }

--- a/rules/type-declaration/src/TypeInferer/ReturnTypeInferer/ReturnTagReturnTypeInferer.php
+++ b/rules/type-declaration/src/TypeInferer/ReturnTypeInferer/ReturnTagReturnTypeInferer.php
@@ -8,26 +8,29 @@ use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
-use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
-use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\TypeDeclaration\Contract\TypeInferer\ReturnTypeInfererInterface;
 use Rector\TypeDeclaration\TypeInferer\AbstractTypeInferer;
 
 final class ReturnTagReturnTypeInferer extends AbstractTypeInferer implements ReturnTypeInfererInterface
 {
     /**
+     * @var PhpDocInfoFactory
+     */
+    private $phpDocInfoFactory;
+
+    public function __construct(PhpDocInfoFactory $phpDocInfoFactory)
+    {
+        $this->phpDocInfoFactory = $phpDocInfoFactory;
+    }
+
+    /**
      * @param ClassMethod|Closure|Function_ $functionLike
      */
     public function inferFunctionLike(FunctionLike $functionLike): Type
     {
-        /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $functionLike->getAttribute(AttributeKey::PHP_DOC_INFO);
-        if ($phpDocInfo === null) {
-            return new MixedType();
-        }
-
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($functionLike);
         return $phpDocInfo->getReturnType();
     }
 

--- a/src/PhpParser/Node/NodeFactory.php
+++ b/src/PhpParser/Node/NodeFactory.php
@@ -644,7 +644,7 @@ final class NodeFactory
         $staticType = $this->staticTypeMapper->mapPhpParserNodePHPStanType($value);
 
         if (! $staticType instanceof MixedType) {
-            $phpDocInfo = $this->phpDocInfoFactory->createEmpty($classConst);
+            $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($classConst);
             $this->phpDocTypeChanger->changeVarType($phpDocInfo, $staticType);
         }
 

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -311,7 +311,7 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
         foreach ($stmts as $key => $ifStmt) {
             if ($key === 0) {
                 // move /* */ doc block from if to first element to keep it
-                $currentPhpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
+                $currentPhpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
                 $ifStmt->setAttribute(AttributeKey::PHP_DOC_INFO, $currentPhpDocInfo);
 
                 // move // comments

--- a/src/Rector/AbstractRector/PhpDocTrait.php
+++ b/src/Rector/AbstractRector/PhpDocTrait.php
@@ -6,11 +6,9 @@ namespace Rector\Core\Rector\AbstractRector;
 
 use PhpParser\Node;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagValueNode;
-use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoManipulator;
 use Rector\BetterPhpDocParser\Printer\PhpDocInfoPrinter;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 
 /**
  * This could be part of @see AbstractRector, but decopuling to trait
@@ -48,11 +46,7 @@ trait PhpDocTrait
 
     protected function hasTagByName(Node $node, string $tagName): bool
     {
-        $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
-        if (! $phpDocInfo instanceof PhpDocInfo) {
-            return false;
-        }
-
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
         return $phpDocInfo->hasByName($tagName);
     }
 
@@ -63,23 +57,13 @@ trait PhpDocTrait
 
     protected function hasPhpDocTagValueNode(Node $node, string $phpDocTagNodeClass): bool
     {
-        /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
-        if ($phpDocInfo === null) {
-            return false;
-        }
-
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
         return $phpDocInfo->hasByType($phpDocTagNodeClass);
     }
 
     protected function removePhpDocTagValueNode(Node $node, string $phpDocTagNodeClass): void
     {
-        /** @var PhpDocInfo|null $phpDocInfo */
-        $phpDocInfo = $node->getAttribute(AttributeKey::PHP_DOC_INFO);
-        if ($phpDocInfo === null) {
-            return;
-        }
-
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
         $phpDocInfo->removeByType($phpDocTagNodeClass);
     }
 }

--- a/tests/Issues/Issue4274_4573/DoNotChangeAnnotationCallback/Fixture/skip_symfony_route_annotation.php.inc
+++ b/tests/Issues/Issue4274_4573/DoNotChangeAnnotationCallback/Fixture/skip_symfony_route_annotation.php.inc
@@ -9,7 +9,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class Controller
 {
     /**
-     * @Route("/route/{view}.{_format}", name="views.test", defaults={"_format": "json"}, methods={"POST"})
+     * @Route("/route/{view}.{_format}", name="views.test", defaults={"_format":"json"}, methods={"POST"})
      */
     public function updateAction()
     {


### PR DESCRIPTION
Follow up to https://github.com/rectorphp/rector/pull/5226