### PR TITLE
Fix match without return

### DIFF
--- a/rules/php80/tests/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/without_return.php.inc
+++ b/rules/php80/tests/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/without_return.php.inc
@@ -6,18 +6,19 @@ class WithoutReturn
 {
     public function run($value)
     {
-        $action = fn ($var): void => return;
-        
         switch ($value) {
             case 1:
-                $action($value);
+                $this->x($value);
                 break;
 
             default:
-                $action($value);
+                $this->y($value);
                 break;
         }
     }
+    
+    private function x($value) {}
+    private function y($value) {}
 }
 
 ?>
@@ -30,13 +31,14 @@ class WithReturn
 {
     public function run($value)
     {
-        $action = fn ($var): void => return;
-        
         match ($value) {
-            1 => $action($value),
-            default => $action($value),
+            1 => $this->x($value),
+            default => $this->y($value),
         };
     }
+    
+    private function x($value) {}
+    private function y($value) {}
 }
 
 ?>

--- a/rules/php80/tests/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/without_return.php.inc
+++ b/rules/php80/tests/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/without_return.php.inc
@@ -27,7 +27,7 @@ class WithoutReturn
 
 namespace Rector\Php80\Tests\Rector\Switch_\ChangeSwitchToMatchRector\Fixture;
 
-class WithReturn
+class WithoutReturn
 {
     public function run($value)
     {

--- a/rules/php80/tests/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/without_return.php.inc
+++ b/rules/php80/tests/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/without_return.php.inc
@@ -1,0 +1,42 @@
+<?php
+
+namespace Rector\Php80\Tests\Rector\Switch_\ChangeSwitchToMatchRector\Fixture;
+
+class WithoutReturn
+{
+    public function run($value)
+    {
+        $action = fn ($var): void => return;
+        
+        switch ($value) {
+            case 1:
+                $action($value);
+                break;
+
+            default:
+                $action($value);
+                break;
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Php80\Tests\Rector\Switch_\ChangeSwitchToMatchRector\Fixture;
+
+class WithReturn
+{
+    public function run($value)
+    {
+        $action = fn ($var): void => return;
+        
+        match ($value) {
+            1 => $action($value),
+            default => $action($value),
+        };
+    }
+}
+
+?>


### PR DESCRIPTION
I am getting left with something like:

```php
function x($value)
{
	match $value { // notice missing braces
		1 => y($value);
		default => z($value);
	}
}
```