### PR TITLE
Support string tags for Symfony ServiceMapProvider

### DIFF
--- a/rules/symfony/src/ServiceMapProvider.php
+++ b/rules/symfony/src/ServiceMapProvider.php
@@ -234,6 +234,12 @@ final class ServiceMapProvider
     {
         $tagValueObjects = [];
         foreach ($tagsData as $key => $tag) {
+
+            if (is_string($tag)) {
+                $tagValueObjects[$key] = new Tag($tag);
+                continue;
+            }
+
             $data = $tag;
             $name = $data['name'] ?? '';
 


### PR DESCRIPTION
For some services (E.G Workflow definitions), the tag has a string value instead of an array with the attributes. This causes the error `Cannot unset string offsets` when running Rector.

An example of such a tag is

```xml
<tag name="application" type="state_machine">workflow.definition</tag>
```

When the xml element gets converted, the `$tag` variable just contains the string `workflow.definition`. So this PR helps to cater for these scenarios and not cause an error