### PR TITLE
[DeadCode] Skip RemoveUnusedPublicMethodRector on __construct

### DIFF
--- a/rules/dead-code/src/Rector/ClassMethod/RemoveUnusedPublicMethodRector.php
+++ b/rules/dead-code/src/Rector/ClassMethod/RemoveUnusedPublicMethodRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\Caching\Contract\Rector\ZeroCacheRectorInterface;
 use Rector\Core\Rector\AbstractRector;
+use Rector\Core\ValueObject\MethodName;
 use Rector\NodeCollector\ValueObject\ArrayCallable;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -90,6 +91,10 @@ CODE_SAMPLE
         }
 
         if (! $node->isPublic()) {
+            return null;
+        }
+
+        if ($this->isName($node, MethodName::CONSTRUCT)) {
             return null;
         }
 

--- a/rules/dead-code/tests/Rector/ClassMethod/RemoveUnusedPublicMethodRector/Fixture/skip-constructor.php.inc
+++ b/rules/dead-code/tests/Rector/ClassMethod/RemoveUnusedPublicMethodRector/Fixture/skip-constructor.php.inc
@@ -1,0 +1,12 @@
+<?php
+namespace Rector\DeadCode\Tests\Rector\ClassMethod\RemoveUnusedPublicMethodRector\Fixture;
+
+final class Fixture
+{
+    public function __construct() 
+    {
+    }
+}
+
+new Fixture();
+?>

--- a/rules/dead-code/tests/Rector/ClassMethod/RemoveUnusedPublicMethodRector/Fixture/skip_constructor.php.inc
+++ b/rules/dead-code/tests/Rector/ClassMethod/RemoveUnusedPublicMethodRector/Fixture/skip_constructor.php.inc
@@ -1,12 +1,12 @@
 <?php
 namespace Rector\DeadCode\Tests\Rector\ClassMethod\RemoveUnusedPublicMethodRector\Fixture;
 
-final class Fixture
+final class SkipConstructor
 {
-    public function __construct() 
+    public function __construct()
     {
     }
 }
 
-new Fixture();
+new SkipConstructor();
 ?>


### PR DESCRIPTION
Close #5257 Fixes #5256 