### PR TITLE
Add failing test fixture for AddDefaultValueForUndefinedVariableRector (relates to #5253)

### DIFF
--- a/rules/php56/tests/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/demo_file.php.inc
+++ b/rules/php56/tests/Rector/FunctionLike/AddDefaultValueForUndefinedVariableRector/Fixture/demo_file.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\Php56\Tests\Rector\FunctionLike\AddDefaultValueForUndefinedVariableRector\Fixture;
+
+final class DemoFile
+{
+    public function run()
+    {
+        $a['a'] = 'b';
+        $a['a'] = 'b';
+        $a['a'] = 'b';
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Php56\Tests\Rector\FunctionLike\AddDefaultValueForUndefinedVariableRector\Fixture;
+
+final class DemoFile
+{
+    public function run()
+    {
+        $a = [];
+        $a['a'] = 'b';
+        $a['a'] = 'b';
+        $a['a'] = 'b';
+    }
+}
+?>


### PR DESCRIPTION
relates to https://github.com/rectorphp/rector/issues/5253#issuecomment-763537452

# Failing Test for AddDefaultValueForUndefinedVariableRector

Based on https://getrector.org/demo/62ab1e88-6035-4fa6-87bb-c600dac418b2