### PR TITLE
Add failing test for importing function names

### DIFF
--- a/rules/performance/tests/Rector/FuncCall/PreslashSimpleFunctionRector/Fixture/auto_import_names.php.inc
+++ b/rules/performance/tests/Rector/FuncCall/PreslashSimpleFunctionRector/Fixture/auto_import_names.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Performance\Tests\Rector\FuncCall\PreslashSimpleFunctionRector\Fixture;
+
+class AutoImportNames
+{
+    public function shorten($value)
+    {
+        return trim($value);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Performance\Tests\Rector\FuncCall\PreslashSimpleFunctionRector\Fixture;
+
+use function trim;
+
+class AutoImportNames
+{
+    public function shorten($value)
+    {
+        return trim($value);
+    }
+}
+
+?>

--- a/rules/performance/tests/Rector/FuncCall/PreslashSimpleFunctionRector/PreslashSimpleFunctionRectorTest.php
+++ b/rules/performance/tests/Rector/FuncCall/PreslashSimpleFunctionRector/PreslashSimpleFunctionRectorTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Rector\Performance\Tests\Rector\FuncCall\PreslashSimpleFunctionRector;
 
 use Iterator;
+use Rector\Core\Configuration\Option;
 use Rector\Performance\Rector\FuncCall\PreslashSimpleFunctionRector;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\Exception\FileNotFoundException;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class PreslashSimpleFunctionRectorTest extends AbstractRectorTestCase
@@ -16,6 +18,12 @@ final class PreslashSimpleFunctionRectorTest extends AbstractRectorTestCase
      */
     public function test(SmartFileInfo $fileInfo): void
     {
+        $filename = sprintf('%s.php.inc', Option::AUTO_IMPORT_NAMES);
+
+        if ($fileInfo->endsWith($filename)) {
+            $this->setParameter(Option::AUTO_IMPORT_NAMES, true);
+        }
+
         $this->doTestFileInfo($fileInfo);
     }
 


### PR DESCRIPTION
When setting `auto_import_names` to true and using the `performance` set, function names are imported as class names, instead of with `use function`

Demo:

https://getrector.org/demo/c22d225a-4828-4f47-9b4b-b21f251ade7a

**Example:**

```php
namespace Test;

class SomeClass
{
    public function shorten($value)
    {
        return trim($value);
    }
}
```

**Expected:**

```diff
namespace Test;

+use function trim;
+
 class SomeClass
 {
     public function shorten($value)
     {
        return trim($value);
     }
 }
```

**Actual:**

```diff
namespace Test;

+ use trim;
+
 class SomeClass
 {
     public function shorten($value)
     {
        return trim($value);
     }
 }
```