### PR TITLE
NodeFactory: Allow passing a Cast node to createArrayItems

### DIFF
--- a/src/PhpParser/Node/NodeFactory.php
+++ b/src/PhpParser/Node/NodeFactory.php
@@ -14,6 +14,7 @@ use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\BinaryOp\Concat;
+use PhpParser\Node\Expr\Cast;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\ConstFetch;
@@ -553,6 +554,7 @@ final class NodeFactory
             || $item instanceof FuncCall
             || $item instanceof Concat
             || $item instanceof Scalar
+            || $item instanceof Cast
         ) {
             $arrayItem = new ArrayItem($item);
         } elseif ($item instanceof Identifier) {


### PR DESCRIPTION
Allows passing a Cast node to NodeFactory::createArrayItems. Not much to say here.