### PR TITLE
Added missing symfony/process to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
         "symfony/dependency-injection": "^5.1",
         "symfony/finder": "^4.4.8|^5.1",
         "symfony/http-kernel": "^4.4.8|^5.1",
+        "symfony/process": "^4.4.8|^5.1",
         "symplify/astral": "^9.0.34",
         "symplify/autowire-array-parameter": "^9.0.34",
         "symplify/console-color-diff": "^9.0.34",


### PR DESCRIPTION
It was used only as dev dependency so it doesn't appear in build and prefixed-rector. Throws an error:
```
Class 'RectorPrefix20210117\Symfony\Component\Process\Process' not found
```