### PR TITLE
Make example of ReplaceStringWithClassConstantRector more correct

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -14133,7 +14133,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(ReplaceStringWithClassConstantRector::class)
         ->call('configure', [[
             ReplaceStringWithClassConstantRector::REPLACE_STRING_WITH_CLASS_CONSTANT => ValueObjectInliner::inline([
-                new ReplaceStringWithClassConstant('SomeClass', 'call', 'Placeholder', 1),
+                new ReplaceStringWithClassConstant('SomeClass', 'call', 0, 'Placeholder'),
             ]),
         ]]);
 };

--- a/rules/privatization/src/Rector/MethodCall/ReplaceStringWithClassConstantRector.php
+++ b/rules/privatization/src/Rector/MethodCall/ReplaceStringWithClassConstantRector.php
@@ -66,7 +66,7 @@ CODE_SAMPLE
 ,
                 [
                     self::REPLACE_STRING_WITH_CLASS_CONSTANT => [
-                        new ReplaceStringWithClassConstant('SomeClass', 'call', 1, 'Placeholder'),
+                        new ReplaceStringWithClassConstant('SomeClass', 'call', 0, 'Placeholder'),
                     ],
                 ]
             ),


### PR DESCRIPTION
- `argument position` and `class with constants` are swapped
- `argument position` starts with zero (0), so `1` is the second argument