### PR TITLE
Add failing test fixture for ConsoleExecuteReturnIntRector

### DIFF
--- a/rules/symfony4/tests/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/demo_command.php.inc
+++ b/rules/symfony4/tests/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/demo_command.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+namespace Rector\Symfony4\Tests\Rector\ClassMethod\ConsoleExecuteReturnIntRector\Fixture;
+
+final class DemoCommand extends \Symfony\Component\Console\Command\Command
+{
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        return (int) random_int(0,1);
+    }
+}
+?>
+-----
+<?php
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+namespace Rector\Symfony4\Tests\Rector\ClassMethod\ConsoleExecuteReturnIntRector\Fixture;
+
+final class DemoCommand extends \Symfony\Component\Console\Command\Command
+{
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        return (int) random_int(0,1);
+    }
+}
+?>

--- a/rules/symfony4/tests/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/demo_command.php.inc
+++ b/rules/symfony4/tests/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/demo_command.php.inc
@@ -13,19 +13,3 @@ final class DemoCommand extends \Symfony\Component\Console\Command\Command
     }
 }
 ?>
------
-<?php
-
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
-
-namespace Rector\Symfony4\Tests\Rector\ClassMethod\ConsoleExecuteReturnIntRector\Fixture;
-
-final class DemoCommand extends \Symfony\Component\Console\Command\Command
-{
-    protected function execute(InputInterface $input, OutputInterface $output): int
-    {
-        return (int) random_int(0,1);
-    }
-}
-?>


### PR DESCRIPTION
# Failing Test for ConsoleExecuteReturnIntRector

Based on https://getrector.org/demo/2ce24767-1f3c-4f0c-b74f-bbea4b441678

it should change nothing because the value before return is casted to `int`