### PR TITLE
Don't skip add `\` prefix for function when auto import name enabled

### DIFF
--- a/rules/coding-style/src/Node/NameImporter.php
+++ b/rules/coding-style/src/Node/NameImporter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\CodingStyle\Node;
 
 use Nette\Utils\Strings;
+use PhpParser\Node;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name;
@@ -191,6 +192,13 @@ final class NameImporter
     private function isFunctionOrConstantImportWithSingleName(Name $name): bool
     {
         $parentNode = $name->getAttribute(AttributeKey::PARENT_NODE);
+
+        $fullName = $name->toString();
+        $autoImportNames = $this->parameterProvider->provideParameter(Option::AUTO_IMPORT_NAMES);
+        if ($autoImportNames && ! $parentNode instanceof Node && ! Strings::contains($fullName, '\\') && function_exists($fullName)) {
+            return true;
+        }
+
         if (! $parentNode instanceof ConstFetch && ! $parentNode instanceof FuncCall) {
             return false;
         }
@@ -223,12 +231,6 @@ final class NameImporter
     private function addUseImport(Name $name, FullyQualifiedObjectType $fullyQualifiedObjectType): void
     {
         if ($this->useNodesToAddCollector->hasImport($name, $fullyQualifiedObjectType)) {
-            return;
-        }
-
-        $fullName = $name->toString();
-        $autoImportNames = $this->parameterProvider->provideParameter(Option::AUTO_IMPORT_NAMES);
-        if ($autoImportNames && ! Strings::contains($fullName, '\\') && function_exists($fullName)) {
             return;
         }
 

--- a/rules/performance/tests/Rector/FuncCall/PreslashSimpleFunctionRector/FixtureAutoImport/do_not_auto_import_names.php.inc
+++ b/rules/performance/tests/Rector/FuncCall/PreslashSimpleFunctionRector/FixtureAutoImport/do_not_auto_import_names.php.inc
@@ -23,7 +23,7 @@ class DoNotAutoImportNames
     public function shorten($value)
     {
         new stdClass;
-        return trim($value);
+        return \trim($value);
     }
 }
 


### PR DESCRIPTION
This is a follow-up to #5268, which enabled the `\` prefix to be added again to functions when using auto-import names