### PR TITLE
[Doctrine] Skip ServiceEntityRepositoryParentCallToDIRector on non __construct method

### DIFF
--- a/rules/doctrine/src/Rector/ClassMethod/ServiceEntityRepositoryParentCallToDIRector.php
+++ b/rules/doctrine/src/Rector/ClassMethod/ServiceEntityRepositoryParentCallToDIRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\Rector\AbstractRector;
+use Rector\Core\ValueObject\MethodName;
 use Rector\Doctrine\NodeFactory\RepositoryNodeFactory;
 use Rector\Doctrine\Type\RepositoryTypeFactory;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -142,6 +143,10 @@ CODE_SAMPLE
 
     private function shouldSkipClassMethod(ClassMethod $classMethod): bool
     {
+        if (! $this->isName($classMethod, MethodName::CONSTRUCT)) {
+            return true;
+        }
+
         /** @var string|null $parentClassName */
         $parentClassName = $classMethod->getAttribute(AttributeKey::PARENT_CLASS_NAME);
         if ($parentClassName === null) {

--- a/rules/doctrine/tests/Rector/ClassMethod/ServiceEntityRepositoryParentCallToDIRector/Fixture/do_not_change_other_methods.php.inc
+++ b/rules/doctrine/tests/Rector/ClassMethod/ServiceEntityRepositoryParentCallToDIRector/Fixture/do_not_change_other_methods.php.inc
@@ -7,7 +7,7 @@ use Doctrine\Persistence\ManagerRegistry;
 use Ramsey\Uuid\UuidInterface;
 use Rector\Doctrine\Tests\Rector\ClassMethod\ServiceEntityRepositoryParentCallToDIRector\Source\Project;
 
-final class OtherProjectRepository extends ServiceEntityRepository
+final class DoNotChangeOtherMethods extends ServiceEntityRepository
 {
     public function __construct(ManagerRegistry $registry)
     {
@@ -30,7 +30,7 @@ use Doctrine\Persistence\ManagerRegistry;
 use Ramsey\Uuid\UuidInterface;
 use Rector\Doctrine\Tests\Rector\ClassMethod\ServiceEntityRepositoryParentCallToDIRector\Source\Project;
 
-final class OtherProjectRepository extends ServiceEntityRepository
+final class DoNotChangeOtherMethods extends ServiceEntityRepository
 {
     /**
      * @var \Doctrine\ORM\EntityRepository<\Rector\Doctrine\Tests\Rector\ClassMethod\ServiceEntityRepositoryParentCallToDIRector\Source\Project>

--- a/rules/doctrine/tests/Rector/ClassMethod/ServiceEntityRepositoryParentCallToDIRector/Fixture/dont_change_other_methods.php.inc
+++ b/rules/doctrine/tests/Rector/ClassMethod/ServiceEntityRepositoryParentCallToDIRector/Fixture/dont_change_other_methods.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\ClassMethod\ServiceEntityRepositoryParentCallToDIRector\Fixture;
+
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Ramsey\Uuid\UuidInterface;
+use Rector\Doctrine\Tests\Rector\ClassMethod\ServiceEntityRepositoryParentCallToDIRector\Source\Project;
+
+final class OtherProjectRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Project::class);
+    }
+
+    public function findBy(UuidInterface $id): void
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Doctrine\Tests\Rector\ClassMethod\ServiceEntityRepositoryParentCallToDIRector\Fixture;
+
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Ramsey\Uuid\UuidInterface;
+use Rector\Doctrine\Tests\Rector\ClassMethod\ServiceEntityRepositoryParentCallToDIRector\Source\Project;
+
+final class OtherProjectRepository extends ServiceEntityRepository
+{
+    /**
+     * @var \Doctrine\ORM\EntityRepository<\Rector\Doctrine\Tests\Rector\ClassMethod\ServiceEntityRepositoryParentCallToDIRector\Source\Project>
+     */
+    private \Doctrine\ORM\EntityRepository $repository;
+    public function __construct(private \Doctrine\ORM\EntityManagerInterface $entityManager)
+    {
+        $this->repository = $entityManager->getRepository(Project::class);
+    }
+
+    public function findBy(UuidInterface $id): void
+    {
+    }
+}
+
+?>


### PR DESCRIPTION
Closes #5332 Fixes #5323