### PR TITLE
[PHP 5.5] Move ClassConstantToSelfClassRector from Php 7.4 to Php 5.5 set

### DIFF
--- a/config/set/php55.php
+++ b/config/set/php55.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Rector\Php55\Rector\Class_\ClassConstantToSelfClassRector;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(StringClassNameToClassConstantRector::class);
+    $services->set(ClassConstantToSelfClassRector::class);
 };

--- a/config/set/php74.php
+++ b/config/set/php74.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Rector\Php74\Rector\Assign\NullCoalescingOperatorRector;
-use Rector\Php74\Rector\Class_\ClassConstantToSelfClassRector;
 use Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector;
 use Rector\Php74\Rector\Double\RealToFloatTypeCastRector;
 use Rector\Php74\Rector\FuncCall\ArrayKeyExistsOnPropertyRector;
@@ -43,8 +42,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(FilterVarToAddSlashesRector::class);
 
     $services->set(ExportToReflectionFunctionRector::class);
-
-    $services->set(ClassConstantToSelfClassRector::class);
 
     $services->set(GetCalledClassToStaticClassRector::class);
 

--- a/rules/php55/src/Rector/Class_/ClassConstantToSelfClassRector.php
+++ b/rules/php55/src/Rector/Class_/ClassConstantToSelfClassRector.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Php74\Rector\Class_;
+namespace Rector\Php55\Rector\Class_;
 
 use PhpParser\Node;
 use PhpParser\Node\Scalar\MagicConst\Class_;
@@ -14,7 +14,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * @see https://wiki.php.net/rfc/deprecations_php_7_4 (not confirmed yet)
  * @see https://3v4l.org/INd7o
- * @see \Rector\Php74\Tests\Rector\Class_\ClassConstantToSelfClassRector\ClassConstantToSelfClassRectorTest
+ * @see \Rector\Php55\Tests\Rector\Class_\ClassConstantToSelfClassRector\ClassConstantToSelfClassRectorTest
  */
 final class ClassConstantToSelfClassRector extends AbstractRector
 {

--- a/rules/php55/tests/Rector/Class_/ClassConstantToSelfClassRector/ClassConstantToSelfClassRectorTest.php
+++ b/rules/php55/tests/Rector/Class_/ClassConstantToSelfClassRector/ClassConstantToSelfClassRectorTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Rector\Php74\Tests\Rector\Class_\ClassConstantToSelfClassRector;
+namespace Rector\Php55\Tests\Rector\Class_\ClassConstantToSelfClassRector;
 
 use Iterator;
-use Rector\Php74\Rector\Class_\ClassConstantToSelfClassRector;
+use Rector\Php55\Rector\Class_\ClassConstantToSelfClassRector;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 use Symplify\SmartFileSystem\SmartFileInfo;
 

--- a/rules/php55/tests/Rector/Class_/ClassConstantToSelfClassRector/Fixture/fixture.php.inc
+++ b/rules/php55/tests/Rector/Class_/ClassConstantToSelfClassRector/Fixture/fixture.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\Php74\Tests\Rector\Class_\ClassConstantToSelfClassRector\Fixture;
+namespace Rector\Php55\Tests\Rector\Class_\ClassConstantToSelfClassRector\Fixture;
 
 class Fixture
 {
@@ -14,7 +14,7 @@ class Fixture
 -----
 <?php
 
-namespace Rector\Php74\Tests\Rector\Class_\ClassConstantToSelfClassRector\Fixture;
+namespace Rector\Php55\Tests\Rector\Class_\ClassConstantToSelfClassRector\Fixture;
 
 class Fixture
 {


### PR DESCRIPTION
 Fixes #5341 