### PR TITLE
Demonstrate infinite recursion [DO NOT MERGE]

### DIFF
--- a/tests/Issues/CaptureReturnValueRector.php
+++ b/tests/Issues/CaptureReturnValueRector.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\MethodCall;
+use Rector\Core\Rector\AbstractRector;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class CaptureReturnValueRector extends AbstractRector
+{
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    /**
+     * @var MethodCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $assignReturnValue = new Assign($node->var, $node);
+        if ($node->getAttribute(AttributeKey::PARENT_NODE) instanceof Assign) {
+            /*
+             * This should prevent the infinite loop, but if the Assign node
+             * is the one we've just created, it won't have the parent attribute yet.
+             */
+
+            return null;
+        }
+
+        /*
+         * So we need to do add this, but it would be nice if Rector would do this for us,
+         * maybe by running the node connecting visitor again on the returned node.
+         */
+//        $node->setAttribute(AttributeKey::PARENT_NODE, $assignReturnValue);
+
+        return $assignReturnValue;
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('', []);
+    }
+}

--- a/tests/Issues/CaptureReturnValueRectorTest.php
+++ b/tests/Issues/CaptureReturnValueRectorTest.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Rector\Core\Tests\Issues;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class CaptureReturnValueRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    protected function getRectorClass(): string
+    {
+        return CaptureReturnValueRector::class;
+    }
+}

--- a/tests/Issues/Fixture/example.php.inc
+++ b/tests/Issues/Fixture/example.php.inc
@@ -1,0 +1,9 @@
+<?php
+$dt = new DateTime();
+$dt->modify('+1 day');
+?>
+-----
+<?php
+$dt = new DateTime();
+$dt = $dt->modify('+1 day');
+?>


### PR DESCRIPTION
This PR demonstrates an infinite recursion issue I ran into, which is caused by the lack of relation attributes in newly created nodes. The solution I think, and one that might be useful in other situations too, would be to traverse a by `refactor()` returned node using the `NodeConnectingVisitor`, so it sets the correct attributes.