### PR TITLE
Allow PrettyVersion 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "composer/xdebug-handler": "^1.4",
         "doctrine/annotations": "^1.11",
         "doctrine/inflector": "^2.0",
-        "jean85/pretty-package-versions": "^1.5.1",
+        "jean85/pretty-package-versions": "^1.5.1|^2.0.1",
         "nette/robot-loader": "^3.2",
         "nette/utils": "^3.2",
         "nikic/php-parser": "^4.10.4",


### PR DESCRIPTION
This simple bump allows for the 2.0 version of this lib, which leverages Composer 2 APIs and drops any sub dependency.

There are basically no BC; for more details, see the [the changelog](https://github.com/Jean85/pretty-package-versions/blob/2.x/CHANGELOG.md).