### PR TITLE
[Process] Add --no-diffs for better huge CI debug

### DIFF
--- a/.github/workflows/build_php71.yaml
+++ b/.github/workflows/build_php71.yaml
@@ -29,6 +29,7 @@ jobs:
             -   uses: montudor/action-zip@v0.1.1
                 with:
                     args: zip -X -r build/rector-php71.zip . -x *.git* .* "*/\.*" build** ci** stubs** tests** "**/tests**"
+
             -   uses: actions/upload-artifact@v2
                 with:
                     name: rector-downgraded-code

--- a/.github/workflows/scripts/downgrade_packages.sh
+++ b/.github/workflows/scripts/downgrade_packages.sh
@@ -204,7 +204,7 @@ then
     config=ci/downgrade/rector-downgrade-rector
     config="${config}-${rector_config}.php"
     note "Running rector_config ${rector_config} for main package ${rootPackage} on path(s) ${path_to_downgrade}"
-    bin/rector process $path_to_downgrade --config=$config --ansi
+    bin/rector process $path_to_downgrade --config=$config --ansi --no-diffs
 
     #Downgrade all the dependencies then
     packages_to_downgrade=$(join_by " " ${dependency_packages[@]})
@@ -212,7 +212,7 @@ then
     config=ci/downgrade/rector-downgrade-dependency
     config="${config}-${rector_config}.php"
     note "Running rector_config ${rector_config} for dependency packages ${packages_to_downgrade} on paths ${paths_to_downgrade}"
-    bin/rector process $paths_to_downgrade --config=$config --ansi
+    bin/rector process $paths_to_downgrade --config=$config --ansi --no-diffs
 
     # Success
     exit 0

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "nette/utils": "^3.2",
         "nikic/php-parser": "^4.10.4",
         "phpstan/phpdoc-parser": "^0.4.9",
-        "phpstan/phpstan": "^0.12.64, <0.12.70",
+        "phpstan/phpstan": "^0.12.69, <0.12.70",
         "phpstan/phpstan-phpunit": "^0.12.17",
         "psr/simple-cache": "^1.0",
         "sebastian/diff": "^4.0",

--- a/packages/changes-reporting/src/Output/ConsoleOutputFormatter.php
+++ b/packages/changes-reporting/src/Output/ConsoleOutputFormatter.php
@@ -212,19 +212,16 @@ final class ConsoleOutputFormatter implements OutputFormatterInterface
     {
         $changeCount = $errorAndDiffCollector->getFileDiffsCount()
             + $errorAndDiffCollector->getRemovedAndAddedFilesCount();
-        $message = 'Rector is done!';
 
         if ($changeCount === 0) {
-            return $message;
+            return 'Rector is done!';
         }
 
-        $message .= sprintf(
-            ' %d file%s %s.',
+        return sprintf(
+            'Rector changed %d file%s %s.',
             $changeCount,
             $changeCount > 1 ? 's' : '',
             $this->configuration->isDryRun() ? 'would have changed (dry-run)' : ($changeCount === 1 ? 'has' : 'have') . ' been changed'
         );
-
-        return $message;
     }
 }

--- a/packages/changes-reporting/src/Output/ConsoleOutputFormatter.php
+++ b/packages/changes-reporting/src/Output/ConsoleOutputFormatter.php
@@ -66,7 +66,10 @@ final class ConsoleOutputFormatter implements OutputFormatterInterface
             $this->symfonyStyle->error($message);
         }
 
-        $this->reportFileDiffs($errorAndDiffCollector->getFileDiffs());
+        if ($this->configuration->shouldShowDiffs()) {
+            $this->reportFileDiffs($errorAndDiffCollector->getFileDiffs());
+        }
+
         $this->reportErrors($errorAndDiffCollector->getErrors());
         $this->reportRemovedFilesAndNodes($errorAndDiffCollector);
 
@@ -74,18 +77,7 @@ final class ConsoleOutputFormatter implements OutputFormatterInterface
             return;
         }
 
-        $changeCount = $errorAndDiffCollector->getFileDiffsCount()
-                     + $errorAndDiffCollector->getRemovedAndAddedFilesCount();
-        $message = 'Rector is done!';
-        if ($changeCount > 0) {
-            $message .= sprintf(
-                ' %d file%s %s.',
-                $changeCount,
-                $changeCount > 1 ? 's' : '',
-                $this->configuration->isDryRun() ? 'would have changed (dry-run)' : ($changeCount === 1 ? 'has' : 'have') . ' been changed'
-            );
-        }
-
+        $message = $this->createSuccessMessage($errorAndDiffCollector);
         $this->symfonyStyle->success($message);
     }
 
@@ -214,5 +206,25 @@ final class ConsoleOutputFormatter implements OutputFormatterInterface
     private function colorTextToRed(string $text): string
     {
         return '<fg=red>' . $text . '</fg=red>';
+    }
+
+    private function createSuccessMessage(ErrorAndDiffCollector $errorAndDiffCollector): string
+    {
+        $changeCount = $errorAndDiffCollector->getFileDiffsCount()
+            + $errorAndDiffCollector->getRemovedAndAddedFilesCount();
+        $message = 'Rector is done!';
+
+        if ($changeCount === 0) {
+            return $message;
+        }
+
+        $message .= sprintf(
+            ' %d file%s %s.',
+            $changeCount,
+            $changeCount > 1 ? 's' : '',
+            $this->configuration->isDryRun() ? 'would have changed (dry-run)' : ($changeCount === 1 ? 'has' : 'have') . ' been changed'
+        );
+
+        return $message;
     }
 }

--- a/rector.php
+++ b/rector.php
@@ -48,7 +48,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         SetList::NETTE_UTILS_CODE_QUALITY,
         SetList::PRIVATIZATION,
         SetList::NAMING,
-        SetList::ORDER,
         SetList::DEFLUENT,
         SetList::TYPE_DECLARATION,
         SetList::PHPUNIT_CODE_QUALITY,

--- a/rules/type-declaration/src/TypeInferer/PropertyTypeInferer/ConstructorPropertyTypeInferer.php
+++ b/rules/type-declaration/src/TypeInferer/PropertyTypeInferer/ConstructorPropertyTypeInferer.php
@@ -16,8 +16,6 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Property;
 use PhpParser\NodeTraverser;
 use PHPStan\Type\ArrayType;
-use PHPStan\Type\Constant\ConstantIntegerType;
-use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\Type;

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -85,6 +85,11 @@ final class Configuration
      */
     private $configFileInfo;
 
+    /**
+     * @var bool
+     */
+    private $showDiffs = true;
+
     public function __construct(ParameterProvider $parameterProvider)
     {
         $this->isCacheEnabled = (bool) $parameterProvider->provideParameter(Option::ENABLE_CACHE);
@@ -102,6 +107,7 @@ final class Configuration
         $this->shouldClearCache = (bool) $input->getOption(Option::OPTION_CLEAR_CACHE);
         $this->mustMatchGitDiff = (bool) $input->getOption(Option::MATCH_GIT_DIFF);
         $this->showProgressBar = $this->canShowProgressBar($input);
+        $this->showDiffs = ! (bool) $input->getOption(Option::OPTION_NO_DIFFS);
         $this->isCacheDebug = (bool) $input->getOption(Option::CACHE_DEBUG);
 
         /** @var string|null $outputFileOption */
@@ -265,6 +271,11 @@ final class Configuration
             return true;
         }
         return $this->outputFormat === CheckstyleOutputFormatter::NAME;
+    }
+
+    public function shouldShowDiffs(): bool
+    {
+        return $this->showDiffs;
     }
 
     private function canShowProgressBar(InputInterface $input): bool

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -152,4 +152,9 @@ final class Option
      * @var string
      */
     public const TYPES_TO_REMOVE_STATIC_FROM = 'types_to_remove_static_from';
+
+    /**
+     * @var string
+     */
+    public const OPTION_NO_DIFFS = 'no-diffs';
 }

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -180,6 +180,13 @@ final class ProcessCommand extends AbstractCommand
         );
 
         $this->addOption(
+            Option::OPTION_NO_DIFFS,
+            null,
+            InputOption::VALUE_NONE,
+            'Hide diffs of changed files. Useful e.g. for nicer CI output.'
+        );
+
+        $this->addOption(
             Option::OPTION_OUTPUT_FILE,
             null,
             InputOption::VALUE_REQUIRED,


### PR DESCRIPTION
Huge diffs like https://github.com/rectorphp/rector/runs/1793965107 are impossible to debug,
because there is 10 km of diffs bellow.

This should help to display only failing errors