### PR TITLE
[DeadDocBlock] Rollback other_comment_before_var.php.inc for RemoveNonExistingVarAnnotationRector

### DIFF
--- a/packages/better-php-doc-parser/src/PhpDocInfo/PhpDocInfoFactory.php
+++ b/packages/better-php-doc-parser/src/PhpDocInfo/PhpDocInfoFactory.php
@@ -114,7 +114,7 @@ final class PhpDocInfoFactory
             $tokens = $this->lexer->tokenize($content);
             try {
                 $phpDocNode = $this->parseTokensToPhpDocNode($tokens);
-            } catch (ParserException $e) {
+            } catch (ParserException $parserException) {
                 return $this->createEmpty($node);
             }
 

--- a/packages/better-php-doc-parser/src/PhpDocInfo/PhpDocInfoFactory.php
+++ b/packages/better-php-doc-parser/src/PhpDocInfo/PhpDocInfoFactory.php
@@ -115,7 +115,7 @@ final class PhpDocInfoFactory
             try {
                 $phpDocNode = $this->parseTokensToPhpDocNode($tokens);
             } catch (ParserException $parserException) {
-                return $this->createEmpty($node);
+                return null;
             }
 
             $this->setPositionOfLastToken($phpDocNode);

--- a/packages/better-php-doc-parser/src/PhpDocInfo/PhpDocInfoFactory.php
+++ b/packages/better-php-doc-parser/src/PhpDocInfo/PhpDocInfoFactory.php
@@ -7,6 +7,7 @@ namespace Rector\BetterPhpDocParser\PhpDocInfo;
 use PhpParser\Comment\Doc;
 use PhpParser\Node;
 use PHPStan\PhpDocParser\Lexer\Lexer;
+use PHPStan\PhpDocParser\Parser\ParserException;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
 use PHPStan\PhpDocParser\Parser\TokenIterator;
 use Rector\AttributeAwarePhpDoc\Ast\PhpDoc\AttributeAwarePhpDocNode;
@@ -111,7 +112,12 @@ final class PhpDocInfoFactory
         } else {
             $content = $docComment->getText();
             $tokens = $this->lexer->tokenize($content);
-            $phpDocNode = $this->parseTokensToPhpDocNode($tokens);
+            try {
+                $phpDocNode = $this->parseTokensToPhpDocNode($tokens);
+            } catch (ParserException $e) {
+                return $this->createEmpty($node);
+            }
+
             $this->setPositionOfLastToken($phpDocNode);
         }
 

--- a/rules/dead-doc-block/tests/Rector/Node/RemoveNonExistingVarAnnotationRector/Fixture/other_comment_before_var.php.inc
+++ b/rules/dead-doc-block/tests/Rector/Node/RemoveNonExistingVarAnnotationRector/Fixture/other_comment_before_var.php.inc
@@ -1,0 +1,30 @@
+<?php
+
+namespace Rector\DeadDocBlock\Tests\Rector\Node\RemoveNonExistingVarAnnotationRector\Fixture;
+
+class OtherCommentBeforeVar
+{
+    public function get()
+    {
+        /** @var \stdClass $nonExisting */
+        // Load data also with projekt...
+        $return[] = $this->getReturnData();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\DeadDocBlock\Tests\Rector\Node\RemoveNonExistingVarAnnotationRector\Fixture;
+
+class OtherCommentBeforeVar
+{
+    public function get()
+    {
+        // Load data also with projekt...
+        $return[] = $this->getReturnData();
+    }
+}
+
+?>


### PR DESCRIPTION
It seems removed in the following commit: https://github.com/rectorphp/rector/commit/bbe758ab60e7a5a6cb5762441298c24f42dbe8b8#diff-7d9f31651e0271c499388038db8bdef6af038aec9ed0507e0a9bf7636ab7117e . Rollback it make failing test : 

```bash
There was 1 error:

1) Rector\DeadDocBlock\Tests\Rector\Node\RemoveNonExistingVarAnnotationRector\RemoveNonExistingVarAnnotationRectorTest::test with data set #6 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
PHPStan\PhpDocParser\Parser\ParserException: Unexpected token "//", expected '/**' at offset 0

phar:///Users/samsonasik/www/rector/vendor/phpstan/phpstan/phpstan.phar/vendor/phpstan/phpdoc-parser/src/Parser/TokenIterator.php:132
phar:///Users/samsonasik/www/rector/vendor/phpstan/phpstan/phpstan.phar/vendor/phpstan/phpdoc-parser/src/Parser/TokenIterator.php:59
/Users/samsonasik/www/rector/packages/better-php-doc-parser/src/PhpDocParser/BetterPhpDocParser.php:124
/Users/samsonasik/www/rector/packages/better-php-doc-parser/src/PhpDocInfo/PhpDocInfoFactory.php:138
/Users/samsonasik/www/rector/packages/better-php-doc-parser/src/PhpDocInfo/PhpDocInfoFactory.php:114
/Users/samsonasik/www/rector/packages/better-php-doc-parser/src/PhpDocInfo/PhpDocInfoFactory.php:88
```