### PR TITLE
Ignore special class names when using Option::AUTO_IMPORT_NAMES

### DIFF
--- a/packages/post-rector/src/Rector/NameImportingPostRector.php
+++ b/packages/post-rector/src/Rector/NameImportingPostRector.php
@@ -83,6 +83,10 @@ final class NameImportingPostRector extends AbstractPostRector
 
     private function processNodeName(Name $name): ?Node
     {
+        if ($name->isSpecialClassName()) {
+            return $name;
+        }
+
         $importName = $this->getName($name);
 
         if (! is_callable($importName)) {

--- a/rules/code-quality/tests/Rector/Return_/SimplifyUselessVariableRector/Fixture/special_class_name_with_anonymous_class.php.inc
+++ b/rules/code-quality/tests/Rector/Return_/SimplifyUselessVariableRector/Fixture/special_class_name_with_anonymous_class.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\CodeQuality\Tests\Rector\Return_\SimplifyUselessVariableRector\Fixture;
+
+use Exception;
+
+final class SpecialClassNameWithAnonymousClass
+{
+    public function weird() : void
+    {
+        $exception = new class() extends Exception {
+            public static function create() : self
+            {
+                $exception = new self();
+
+                return $exception;
+            }
+        };
+
+        throw $exception;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\CodeQuality\Tests\Rector\Return_\SimplifyUselessVariableRector\Fixture;
+
+use Exception;
+
+final class SpecialClassNameWithAnonymousClass
+{
+    public function weird() : void
+    {
+        $exception = new class() extends Exception {
+            public static function create() : self
+            {
+                return new self();
+            }
+        };
+
+        throw $exception;
+    }
+}
+?>

--- a/rules/code-quality/tests/Rector/Return_/SimplifyUselessVariableRector/SimplifyUselessVariableRectorTest.php
+++ b/rules/code-quality/tests/Rector/Return_/SimplifyUselessVariableRector/SimplifyUselessVariableRectorTest.php
@@ -6,6 +6,7 @@ namespace Rector\CodeQuality\Tests\Rector\Return_\SimplifyUselessVariableRector;
 
 use Iterator;
 use Rector\CodeQuality\Rector\Return_\SimplifyUselessVariableRector;
+use Rector\Core\Configuration\Option;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
@@ -21,6 +22,8 @@ final class SimplifyUselessVariableRectorTest extends AbstractRectorTestCase
      */
     public function test(SmartFileInfo $fileInfo): void
     {
+        $this->setParameter(Option::AUTO_IMPORT_NAMES, true);
+
         $this->doTestFileInfo($fileInfo);
     }
 


### PR DESCRIPTION
Fixes #5426

This makes sure that special class names like `self, parent, static` are not automatically imported.
