### PR TITLE
[DeadCode] Fix RemoveSetterOnlyPropertyAndMethodCallRector for no-read, no-write expression

### DIFF
--- a/packages/read-write/src/ReadNodeAnalyzer/AbstractReadNodeAnalyzer.php
+++ b/packages/read-write/src/ReadNodeAnalyzer/AbstractReadNodeAnalyzer.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Return_;
 use Rector\Core\Exception\NotImplementedYetException;
 use Rector\Core\NodeFinder\NodeUsageFinder;
@@ -55,6 +56,10 @@ abstract class AbstractReadNodeAnalyzer
             }
 
             return $parentParent->var !== $parent;
+        }
+
+        if ($parent instanceof Expression) {
+            return false;
         }
 
         throw new NotImplementedYetException();

--- a/rules/dead-code/tests/Rector/Property/RemoveSetterOnlyPropertyAndMethodCallRector/Fixture/value_call_setter_only.php.inc
+++ b/rules/dead-code/tests/Rector/Property/RemoveSetterOnlyPropertyAndMethodCallRector/Fixture/value_call_setter_only.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rector\DeadCode\Tests\Rector\Property\RemoveSetterOnlyPropertyAndMethodCallRector\Fixture;
+
+final class ValueCallSetterOnly
+{
+    public $data;
+
+    private $execstart;
+
+    public function method(object $data)
+    {
+        $this->data[$data->key] = "data";
+    }
+
+    public function data()
+    {
+        $this->data;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\DeadCode\Tests\Rector\Property\RemoveSetterOnlyPropertyAndMethodCallRector\Fixture;
+
+final class ValueCallSetterOnly
+{
+    public $data;
+
+    public function method(object $data)
+    {
+        $this->data[$data->key] = "data";
+    }
+
+    public function data()
+    {
+        $this->data;
+    }
+}
+
+?>


### PR DESCRIPTION
Closes https://github.com/rectorphp/rector/issues/5234

@olivernybroe This was the problematic snippet:

```php
public function data()
    {
        $this->data;
    }
```

This method does nothing, no set, no return. Now it's evalueated as no-read property use, so it's skipped.

It looks like dead code. What does it do actually?