### PR TITLE
Add failing test fixture for RenameMethodRector

### DIFF
--- a/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/Fixture/demo_file.php.inc
+++ b/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/Fixture/demo_file.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture;
+
+final class DemoFile
+{
+    public function notify()
+    {
+        return 5;
+    }
+
+}
+
+final class Caller
+{
+    public static function execute()
+    {
+        $demo = new DemoFile();
+        $demo->notify();
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture;
+
+final class DemoFile
+{
+    public function __invoke()
+    {
+        return 5;
+    }
+
+}
+
+final class Caller
+{
+    public static function execute()
+    {
+        $demo = new DemoFile();
+        $demo->__invoke();
+    }
+}
+?>

--- a/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/config/configured_rule.php
+++ b/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/config/configured_rule.php
@@ -14,6 +14,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         RenameMethodRector::METHOD_CALL_RENAMES => ValueObjectInliner::inline([
             new MethodCallRename(AbstractType::class, 'setDefaultOptions', 'configureOptions'),
             new MethodCallRename(Html::class, 'add', 'addHtml'),
+            new MethodCallRename('Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture\DemoFile', 'notify', '__invoke'),
             new MethodCallRename('*Presenter', 'run', '__invoke'),
             new MethodCallRename(
                 \Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture\SkipSelfMethodRename::class,


### PR DESCRIPTION
# Failing Test for RenameMethodRector

Based on https://getrector.org/demo/85509375-fe03-4f79-b861-fe8a4e7d6990

Why doesn't it rename the method definition?