### PR TITLE
Add failing test fixture for StringifyStrNeedlesRector

### DIFF
--- a/rules/php73/src/NodeTypeAnalyzer/NodeTypeAnalyzer.php
+++ b/rules/php73/src/NodeTypeAnalyzer/NodeTypeAnalyzer.php
@@ -9,6 +9,7 @@ use PHPStan\Type\Accessory\AccessoryNumericStringType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 
 final class NodeTypeAnalyzer
@@ -39,9 +40,9 @@ final class NodeTypeAnalyzer
             return true;
         }
 
-        if ($type instanceof IntersectionType) {
-            foreach ($type->getTypes() as $intersectionedType) {
-                if (! $this->isStringType($intersectionedType)) {
+        if ($type instanceof IntersectionType || $type instanceof UnionType) {
+            foreach ($type->getTypes() as $innerType) {
+                if (! $this->isStringType($innerType)) {
                     return false;
                 }
             }

--- a/rules/php73/tests/Rector/FuncCall/StringifyStrNeedlesRector/Fixture/skip_default_constants.php.inc
+++ b/rules/php73/tests/Rector/FuncCall/StringifyStrNeedlesRector/Fixture/skip_default_constants.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Php73\Tests\Rector\FuncCall\StringifyStrNeedlesRector\Fixture;
+
+final class SkipDefaultConstants
+{
+    public function run()
+    {
+        return strstr("test", PHP_EOL);
+    }
+}
+?>


### PR DESCRIPTION
# Failing Test for StringifyStrNeedlesRector

Based on https://getrector.org/demo/d2da9632-23c3-4f71-b800-219c8871639c

It should understand that `PHP_EOL` is a constant that is always a `string`. Therefore, no need to cast it to string.