### PR TITLE
Add failing test fixture for JsonThrowOnErrorRector

### DIFF
--- a/rules/php73/tests/Rector/FuncCall/JsonThrowOnErrorRector/Fixture/ternary_perator.php.inc
+++ b/rules/php73/tests/Rector/FuncCall/JsonThrowOnErrorRector/Fixture/ternary_perator.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Php73\Tests\Rector\FuncCall\JsonThrowOnErrorRector\Fixture;
+
+final class TernaryOperator
+{
+    public function run() : array
+    {
+        $campaigns = json_decode($input['campaigns'] ?? '', true) ?: [];
+        
+        return $campaigns;
+    }
+}
+?>


### PR DESCRIPTION
# Failing Test for JsonThrowOnErrorRector

Based on https://getrector.org/demo/c94533f5-3e58-4ffd-a813-3fc257248a70

See #5462 

When the Ternary Operator `?:` is used, it should not rewrite the code as it prevents the fallback from being used.

## Idea

Maybe it should add a try / catch and set the fallback?

```php
<?php

namespace Rector\Php73\Tests\Rector\FuncCall\JsonThrowOnErrorRector\Fixture;

final class TernaryOperator
{
    public function run() : array
    {
        try {
            $campaigns = json_decode($input['campaigns'] ?? '', true, 512, JSON_THROW_ON_ERROR) ?: [];
        } catch (\JsonException $exception) {
            $campaigns = [];
        }
        
        return $campaigns;
    }
}
?>
```