### PR TITLE
Add failing test fixture for SimplifyUselessVariableRector

### DIFF
--- a/rules/code-quality/tests/Rector/Return_/SimplifyUselessVariableRector/Fixture/demo_file.php.inc
+++ b/rules/code-quality/tests/Rector/Return_/SimplifyUselessVariableRector/Fixture/demo_file.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\CodeQuality\Tests\Rector\Return_\SimplifyUselessVariableRector\Fixture;
+
+final class DemoFile
+{
+    public function run(bool $argument)
+    {
+        $sql = 'begin';
+        if ($argument) {
+            $sql .= ' add something';
+        }
+        $sql .= 'end';
+
+        return $sql;
+    }
+}
+?>


### PR DESCRIPTION
# Failing Test for SimplifyUselessVariableRector

Based on https://getrector.org/demo/692bfec6-24af-4f45-a6d6-ededa13d116a

It should understand that the variable is appended a couple of times.... this doesn't improve the code at all.