### PR TITLE
[EarlyReturn] Rename ChangeAndIfContinueToMultiContinueRector to ChangeOrIfContinueToMultiContinueRector

### DIFF
--- a/config/set/early-return.php
+++ b/config/set/early-return.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\EarlyReturn\Rector\Foreach_\ChangeNestedForeachIfsToEarlyContinueRector;
+use Rector\EarlyReturn\Rector\If_\ChangeAndIfContinueToMultiContinueRector;
 use Rector\EarlyReturn\Rector\If_\ChangeAndIfToEarlyReturnRector;
 use Rector\EarlyReturn\Rector\If_\ChangeIfElseValueAssignToEarlyReturnRector;
 use Rector\EarlyReturn\Rector\If_\ChangeNestedIfsToEarlyReturnRector;
@@ -20,4 +21,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(RemoveAlwaysElseRector::class);
     $services->set(ReturnBinaryAndToEarlyReturnRector::class);
     $services->set(ChangeOrIfReturnToEarlyReturnRector::class);
+    $services->set(ChangeAndIfContinueToMultiContinueRector::class);
 };

--- a/config/set/early-return.php
+++ b/config/set/early-return.php
@@ -3,10 +3,10 @@
 declare(strict_types=1);
 
 use Rector\EarlyReturn\Rector\Foreach_\ChangeNestedForeachIfsToEarlyContinueRector;
-use Rector\EarlyReturn\Rector\If_\ChangeAndIfContinueToMultiContinueRector;
 use Rector\EarlyReturn\Rector\If_\ChangeAndIfToEarlyReturnRector;
 use Rector\EarlyReturn\Rector\If_\ChangeIfElseValueAssignToEarlyReturnRector;
 use Rector\EarlyReturn\Rector\If_\ChangeNestedIfsToEarlyReturnRector;
+use Rector\EarlyReturn\Rector\If_\ChangeOrIfContinueToMultiContinueRector;
 use Rector\EarlyReturn\Rector\If_\ChangeOrIfReturnToEarlyReturnRector;
 use Rector\EarlyReturn\Rector\If_\RemoveAlwaysElseRector;
 use Rector\EarlyReturn\Rector\Return_\ReturnBinaryAndToEarlyReturnRector;
@@ -21,5 +21,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(RemoveAlwaysElseRector::class);
     $services->set(ReturnBinaryAndToEarlyReturnRector::class);
     $services->set(ChangeOrIfReturnToEarlyReturnRector::class);
-    $services->set(ChangeAndIfContinueToMultiContinueRector::class);
+    $services->set(ChangeOrIfContinueToMultiContinueRector::class);
 };

--- a/packages/node-type-resolver/src/TypeAnalyzer/ArrayTypeAnalyzer.php
+++ b/packages/node-type-resolver/src/TypeAnalyzer/ArrayTypeAnalyzer.php
@@ -87,10 +87,15 @@ final class ArrayTypeAnalyzer
         }
 
         foreach ($nodeType->getTypes() as $intersectionNodeType) {
-            if ($intersectionNodeType instanceof ArrayType || $intersectionNodeType instanceof HasOffsetType || $intersectionNodeType instanceof NonEmptyArrayType) {
+            if ($intersectionNodeType instanceof ArrayType) {
                 continue;
             }
-
+            if ($intersectionNodeType instanceof HasOffsetType) {
+                continue;
+            }
+            if ($intersectionNodeType instanceof NonEmptyArrayType) {
+                continue;
+            }
             return false;
         }
 

--- a/packages/rector-generator/src/Provider/NodeTypesProvider.php
+++ b/packages/rector-generator/src/Provider/NodeTypesProvider.php
@@ -41,7 +41,10 @@ final class NodeTypesProvider
             $name = str_replace(['.php', '/'], ['', '\\'], $fileInfo->getRelativePathname());
 
             $reflectionClass = new ReflectionClass(self::PHP_PARSER_NAMESPACE . $name);
-            if ($reflectionClass->isAbstract() || $reflectionClass->isInterface()) {
+            if ($reflectionClass->isAbstract()) {
+                continue;
+            }
+            if ($reflectionClass->isInterface()) {
                 continue;
             }
 

--- a/rules/code-quality/src/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector.php
+++ b/rules/code-quality/src/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector.php
@@ -92,8 +92,10 @@ CODE_SAMPLE
             $type = $this->getType($object);
             /** @var Identifier|Variable $name */
             $name = $issetVar->name;
-
-            if ($type === null || ! $name instanceof Identifier) {
+            if ($type === null) {
+                continue;
+            }
+            if (! $name instanceof Identifier) {
                 continue;
             }
 

--- a/rules/code-quality/src/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector.php
+++ b/rules/code-quality/src/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector.php
@@ -120,13 +120,13 @@ CODE_SAMPLE
         return $this->createReturnNodes($newNodes);
     }
 
-    private function isTypeNullOrNameNotIdentifier(?Type $type, Node $name): bool
+    private function isTypeNullOrNameNotIdentifier(?Type $type, Node $node): bool
     {
         if ($type === null) {
             return true;
         }
 
-        return ! $name instanceof Identifier;
+        return ! $node instanceof Identifier;
     }
 
     private function getType(Expr $expr): ?Type

--- a/rules/code-quality/src/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector.php
+++ b/rules/code-quality/src/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector.php
@@ -92,10 +92,7 @@ CODE_SAMPLE
             $type = $this->getType($object);
             /** @var Identifier|Variable $name */
             $name = $issetVar->name;
-            if ($type === null) {
-                continue;
-            }
-            if (! $name instanceof Identifier) {
+            if ($this->isTypeNullOrNameNotIdentifier($type, $name)) {
                 continue;
             }
 
@@ -104,6 +101,7 @@ CODE_SAMPLE
                 continue;
             }
 
+            /** @var Identifier $name */
             $property = $name->toString();
             if ($type instanceof ObjectType) {
                 /** @var string $className */
@@ -120,6 +118,15 @@ CODE_SAMPLE
         }
 
         return $this->createReturnNodes($newNodes);
+    }
+
+    private function isTypeNullOrNameNotIdentifier(?Type $type, Node $name): bool
+    {
+        if ($type === null) {
+            return true;
+        }
+
+        return ! $name instanceof Identifier;
     }
 
     private function getType(Expr $expr): ?Type

--- a/rules/downgrade-php74/src/Rector/ClassMethod/DowngradeCovariantReturnTypeRector.php
+++ b/rules/downgrade-php74/src/Rector/ClassMethod/DowngradeCovariantReturnTypeRector.php
@@ -174,7 +174,10 @@ CODE_SAMPLE
             $parentReflectionMethod = new ReflectionMethod($parentClassLike, $methodName);
             $parentReflectionMethodReturnType = $parentReflectionMethod->getReturnType();
 
-            if ($this->isNotReflectionNamedTypeOrNotEqualsToNodeReturnTypeName($parentReflectionMethodReturnType, $nodeReturnTypeName)) {
+            if ($this->isNotReflectionNamedTypeOrNotEqualsToNodeReturnTypeName(
+                $parentReflectionMethodReturnType,
+                $nodeReturnTypeName
+            )) {
                 continue;
             }
 
@@ -186,13 +189,15 @@ CODE_SAMPLE
         return null;
     }
 
-    private function isNotReflectionNamedTypeOrNotEqualsToNodeReturnTypeName(?ReflectionType $parentReflectionMethodReturnType, ?string $nodeReturnTypeName): bool
-    {
-        if (! $parentReflectionMethodReturnType instanceof ReflectionNamedType) {
+    private function isNotReflectionNamedTypeOrNotEqualsToNodeReturnTypeName(
+        ?ReflectionType $reflectionType,
+        ?string $nodeReturnTypeName
+    ): bool {
+        if (! $reflectionType instanceof ReflectionNamedType) {
             return true;
         }
 
-        return $parentReflectionMethodReturnType->getName() === $nodeReturnTypeName;
+        return $reflectionType->getName() === $nodeReturnTypeName;
     }
 
     private function addDocBlockReturn(ClassMethod $classMethod): void

--- a/rules/downgrade-php74/src/Rector/ClassMethod/DowngradeCovariantReturnTypeRector.php
+++ b/rules/downgrade-php74/src/Rector/ClassMethod/DowngradeCovariantReturnTypeRector.php
@@ -172,7 +172,10 @@ CODE_SAMPLE
 
             $parentReflectionMethod = new ReflectionMethod($parentClassLike, $methodName);
             $parentReflectionMethodReturnType = $parentReflectionMethod->getReturnType();
-            if (! $parentReflectionMethodReturnType instanceof ReflectionNamedType || $parentReflectionMethodReturnType->getName() === $nodeReturnTypeName) {
+            if (! $parentReflectionMethodReturnType instanceof ReflectionNamedType) {
+                continue;
+            }
+            if ($parentReflectionMethodReturnType->getName() === $nodeReturnTypeName) {
                 continue;
             }
             // This is an ancestor class with a different return type

--- a/rules/downgrade-php74/src/Rector/ClassMethod/DowngradeCovariantReturnTypeRector.php
+++ b/rules/downgrade-php74/src/Rector/ClassMethod/DowngradeCovariantReturnTypeRector.php
@@ -18,6 +18,7 @@ use Rector\NodeTypeResolver\ClassExistenceStaticHelper;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use ReflectionMethod;
 use ReflectionNamedType;
+use ReflectionType;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -172,17 +173,26 @@ CODE_SAMPLE
 
             $parentReflectionMethod = new ReflectionMethod($parentClassLike, $methodName);
             $parentReflectionMethodReturnType = $parentReflectionMethod->getReturnType();
-            if (! $parentReflectionMethodReturnType instanceof ReflectionNamedType) {
+
+            if ($this->isNotReflectionNamedTypeOrNotEqualsToNodeReturnTypeName($parentReflectionMethodReturnType, $nodeReturnTypeName)) {
                 continue;
             }
-            if ($parentReflectionMethodReturnType->getName() === $nodeReturnTypeName) {
-                continue;
-            }
+
             // This is an ancestor class with a different return type
+            /** @var ReflectionNamedType $parentReflectionMethodReturnType */
             return $parentReflectionMethodReturnType->getName();
         }
 
         return null;
+    }
+
+    private function isNotReflectionNamedTypeOrNotEqualsToNodeReturnTypeName(?ReflectionType $parentReflectionMethodReturnType, ?string $nodeReturnTypeName): bool
+    {
+        if (! $parentReflectionMethodReturnType instanceof ReflectionNamedType) {
+            return true;
+        }
+
+        return $parentReflectionMethodReturnType->getName() === $nodeReturnTypeName;
     }
 
     private function addDocBlockReturn(ClassMethod $classMethod): void

--- a/rules/early-return/src/Rector/If_/ChangeAndIfContinueToMultiContinueRector.php
+++ b/rules/early-return/src/Rector/If_/ChangeAndIfContinueToMultiContinueRector.php
@@ -100,10 +100,10 @@ CODE_SAMPLE
 
     private function processMultiIfContinue(If_ $if): If_
     {
+        $node = clone $if;
         /** @var Continue_ $continue */
         $continue = $if->stmts[0];
         $ifs = $this->createMultipleIfs($if->cond, $continue, []);
-        $node = $if;
         foreach ($ifs as $key => $if) {
             if ($key === 0) {
                 $this->mirrorComments($if, $node);

--- a/rules/early-return/src/Rector/If_/ChangeOrIfContinueToMultiContinueRector.php
+++ b/rules/early-return/src/Rector/If_/ChangeOrIfContinueToMultiContinueRector.php
@@ -6,7 +6,7 @@ namespace Rector\EarlyReturn\Rector\If_;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\BinaryOp\BooleanAnd;
+use PhpParser\Node\Expr\BinaryOp\BooleanOr;
 use PhpParser\Node\Stmt\Continue_;
 use PhpParser\Node\Stmt\If_;
 use Rector\Core\NodeManipulator\IfManipulator;
@@ -15,9 +15,9 @@ use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
- * @see \Rector\EarlyReturn\Tests\Rector\If_\ChangeAndIfContinueToMultiContinueRector\ChangeAndIfContinueToMultiContinueRectorTest
+ * @see \Rector\EarlyReturn\Tests\Rector\If_\ChangeOrIfContinueToMultiContinueRector\ChangeOrIfContinueToMultiContinueRectorTest
  */
-final class ChangeAndIfContinueToMultiContinueRector extends AbstractRector
+final class ChangeOrIfContinueToMultiContinueRector extends AbstractRector
 {
     /**
      * @var IfManipulator
@@ -39,7 +39,7 @@ class SomeClass
     public function canDrive(Car $newCar)
     {
         foreach ($cars as $car) {
-            if ($car->hasWheels() && $car->hasFuel()) {
+            if ($car->hasWheels() || $car->hasFuel()) {
                 continue;
             }
 
@@ -57,10 +57,10 @@ class SomeClass
     public function canDrive(Car $newCar)
     {
         foreach ($cars as $car) {
-            if (! $car->hasWheels()) {
+            if ($car->hasWheels()) {
                 continue;
             }
-            if (! $car->hasFuel()) {
+            if ($car->hasFuel()) {
                 continue;
             }
 
@@ -91,7 +91,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if (! $node->cond instanceof BooleanAnd) {
+        if (! $node->cond instanceof BooleanOr) {
             return null;
         }
 
@@ -122,25 +122,25 @@ CODE_SAMPLE
      */
     private function createMultipleIfs(Expr $expr, Continue_ $continue, array $ifs): array
     {
-        while ($expr instanceof BooleanAnd) {
-            $ifs = array_merge($ifs, $this->collectLeftBooleanAndToIfs($expr, $continue, $ifs));
-            $ifs[] = $this->ifManipulator->createIfNegation($expr->right, $continue);
+        while ($expr instanceof BooleanOr) {
+            $ifs = array_merge($ifs, $this->collectLeftbooleanOrToIfs($expr, $continue, $ifs));
+            $ifs[] = $this->ifManipulator->createIfExpr($expr->right, $continue);
 
             $expr = $expr->right;
         }
 
-        return $ifs + [$this->ifManipulator->createIfNegation($expr, $continue)];
+        return $ifs + [$this->ifManipulator->createIfExpr($expr, $continue)];
     }
 
     /**
      * @param If_[] $ifs
      * @return If_[]
      */
-    private function collectLeftBooleanAndToIfs(BooleanAnd $booleanAnd, Continue_ $continue, array $ifs): array
+    private function collectLeftbooleanOrToIfs(BooleanOr $booleanOr, Continue_ $continue, array $ifs): array
     {
-        $left = $booleanAnd->left;
-        if (! $left instanceof BooleanAnd) {
-            return [$this->ifManipulator->createIfNegation($left, $continue)];
+        $left = $booleanOr->left;
+        if (! $left instanceof BooleanOr) {
+            return [$this->ifManipulator->createIfExpr($left, $continue)];
         }
 
         return $this->createMultipleIfs($left, $continue, $ifs);

--- a/rules/early-return/tests/Rector/If_/ChangeOrIfContinueToMultiContinueRector/ChangeOrIfContinueToMultiContinueRectorTest.php
+++ b/rules/early-return/tests/Rector/If_/ChangeOrIfContinueToMultiContinueRector/ChangeOrIfContinueToMultiContinueRectorTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Rector\EarlyReturn\Tests\Rector\If_\ChangeAndIfContinueToMultiContinueRector;
+namespace Rector\EarlyReturn\Tests\Rector\If_\ChangeOrIfContinueToMultiContinueRector;
 
 use Iterator;
-use Rector\EarlyReturn\Rector\If_\ChangeAndIfContinueToMultiContinueRector;
+use Rector\EarlyReturn\Rector\If_\ChangeOrIfContinueToMultiContinueRector;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
-final class ChangeAndIfContinueToMultiContinueRectorTest extends AbstractRectorTestCase
+final class ChangeOrIfContinueToMultiContinueRectorTest extends AbstractRectorTestCase
 {
     /**
      * @dataProvider provideData()
@@ -26,6 +26,6 @@ final class ChangeAndIfContinueToMultiContinueRectorTest extends AbstractRectorT
 
     protected function getRectorClass(): string
     {
-        return ChangeAndIfContinueToMultiContinueRector::class;
+        return ChangeOrIfContinueToMultiContinueRector::class;
     }
 }

--- a/rules/early-return/tests/Rector/If_/ChangeOrIfContinueToMultiContinueRector/Fixture/fixture.php.inc
+++ b/rules/early-return/tests/Rector/If_/ChangeOrIfContinueToMultiContinueRector/Fixture/fixture.php.inc
@@ -1,13 +1,13 @@
 <?php
 
-namespace Rector\EarlyReturn\Tests\Rector\If_\ChangeAndIfContinueToMultiContinueRector\Fixture;
+namespace Rector\EarlyReturn\Tests\Rector\If_\ChangeOrIfContinueToMultiContinueRector\Fixture;
 
 class Fixture
 {
     public function canDrive(Car $newCar)
     {
         foreach ($cars as $car) {
-            if ($car->hasWheels() && $car->hasFuel()) {
+            if ($car->hasWheels() || $car->hasFuel()) {
                 continue;
             }
             $car->setWheel($newCar->wheel);
@@ -20,17 +20,17 @@ class Fixture
 -----
 <?php
 
-namespace Rector\EarlyReturn\Tests\Rector\If_\ChangeAndIfContinueToMultiContinueRector\Fixture;
+namespace Rector\EarlyReturn\Tests\Rector\If_\ChangeOrIfContinueToMultiContinueRector\Fixture;
 
 class Fixture
 {
     public function canDrive(Car $newCar)
     {
         foreach ($cars as $car) {
-            if (!$car->hasWheels()) {
+            if ($car->hasWheels()) {
                 continue;
             }
-            if (!$car->hasFuel()) {
+            if ($car->hasFuel()) {
                 continue;
             }
             $car->setWheel($newCar->wheel);

--- a/rules/early-return/tests/Rector/If_/ChangeOrIfContinueToMultiContinueRector/Fixture/has_comment.php.inc
+++ b/rules/early-return/tests/Rector/If_/ChangeOrIfContinueToMultiContinueRector/Fixture/has_comment.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Rector\EarlyReturn\Tests\Rector\If_\ChangeAndIfContinueToMultiContinueRector\Fixture;
+namespace Rector\EarlyReturn\Tests\Rector\If_\ChangeOrIfContinueToMultiContinueRector\Fixture;
 
 class HasComment
 {
@@ -8,7 +8,7 @@ class HasComment
     {
         foreach ($cars as $car) {
             // a comment
-            if ($car->hasWheels() && $car->hasFuel()) {
+            if ($car->hasWheels() || $car->hasFuel()) {
                 continue;
             }
             $car->setWheel($newCar->wheel);
@@ -21,7 +21,7 @@ class HasComment
 -----
 <?php
 
-namespace Rector\EarlyReturn\Tests\Rector\If_\ChangeAndIfContinueToMultiContinueRector\Fixture;
+namespace Rector\EarlyReturn\Tests\Rector\If_\ChangeOrIfContinueToMultiContinueRector\Fixture;
 
 class HasComment
 {
@@ -29,10 +29,10 @@ class HasComment
     {
         foreach ($cars as $car) {
             // a comment
-            if (!$car->hasWheels()) {
+            if ($car->hasWheels()) {
                 continue;
             }
-            if (!$car->hasFuel()) {
+            if ($car->hasFuel()) {
                 continue;
             }
             $car->setWheel($newCar->wheel);

--- a/rules/early-return/tests/Rector/If_/ChangeOrIfContinueToMultiContinueRector/Fixture/identical.php.inc
+++ b/rules/early-return/tests/Rector/If_/ChangeOrIfContinueToMultiContinueRector/Fixture/identical.php.inc
@@ -1,13 +1,13 @@
 <?php
 
-namespace Rector\EarlyReturn\Tests\Rector\If_\ChangeAndIfContinueToMultiContinueRector\Fixture;
+namespace Rector\EarlyReturn\Tests\Rector\If_\ChangeOrIfContinueToMultiContinueRector\Fixture;
 
-class Negated
+class Identical
 {
     public function canDrive(Car $newCar)
     {
         foreach ($cars as $car) {
-            if (! $car->hasWheels() && ! $car->hasFuel() && ! $car->isRunnable()) {
+            if ($car->getWheel() === 4 || $car->getFuel() === 'full') {
                 continue;
             }
             $car->setWheel($newCar->wheel);
@@ -20,20 +20,17 @@ class Negated
 -----
 <?php
 
-namespace Rector\EarlyReturn\Tests\Rector\If_\ChangeAndIfContinueToMultiContinueRector\Fixture;
+namespace Rector\EarlyReturn\Tests\Rector\If_\ChangeOrIfContinueToMultiContinueRector\Fixture;
 
-class Negated
+class Identical
 {
     public function canDrive(Car $newCar)
     {
         foreach ($cars as $car) {
-            if ($car->hasWheels()) {
+            if ($car->getWheel() === 4) {
                 continue;
             }
-            if ($car->hasFuel()) {
-                continue;
-            }
-            if ($car->isRunnable()) {
+            if ($car->getFuel() === 'full') {
                 continue;
             }
             $car->setWheel($newCar->wheel);

--- a/rules/early-return/tests/Rector/If_/ChangeOrIfContinueToMultiContinueRector/Fixture/many_and.php.inc
+++ b/rules/early-return/tests/Rector/If_/ChangeOrIfContinueToMultiContinueRector/Fixture/many_and.php.inc
@@ -1,13 +1,13 @@
 <?php
 
-namespace Rector\EarlyReturn\Tests\Rector\If_\ChangeAndIfContinueToMultiContinueRector\Fixture;
+namespace Rector\EarlyReturn\Tests\Rector\If_\ChangeOrIfContinueToMultiContinueRector\Fixture;
 
 class ManyAnd
 {
     public function canDrive(Car $newCar)
     {
         foreach ($cars as $car) {
-            if ($car->hasWheels() && $car->hasFuel() && $car->isRunnable()) {
+            if ($car->hasWheels() || $car->hasFuel() || $car->isRunnable()) {
                 continue;
             }
             $car->setWheel($newCar->wheel);
@@ -20,20 +20,20 @@ class ManyAnd
 -----
 <?php
 
-namespace Rector\EarlyReturn\Tests\Rector\If_\ChangeAndIfContinueToMultiContinueRector\Fixture;
+namespace Rector\EarlyReturn\Tests\Rector\If_\ChangeOrIfContinueToMultiContinueRector\Fixture;
 
 class ManyAnd
 {
     public function canDrive(Car $newCar)
     {
         foreach ($cars as $car) {
-            if (!$car->hasWheels()) {
+            if ($car->hasWheels()) {
                 continue;
             }
-            if (!$car->hasFuel()) {
+            if ($car->hasFuel()) {
                 continue;
             }
-            if (!$car->isRunnable()) {
+            if ($car->isRunnable()) {
                 continue;
             }
             $car->setWheel($newCar->wheel);

--- a/rules/early-return/tests/Rector/If_/ChangeOrIfContinueToMultiContinueRector/Fixture/negated.php.inc
+++ b/rules/early-return/tests/Rector/If_/ChangeOrIfContinueToMultiContinueRector/Fixture/negated.php.inc
@@ -1,13 +1,13 @@
 <?php
 
-namespace Rector\EarlyReturn\Tests\Rector\If_\ChangeAndIfContinueToMultiContinueRector\Fixture;
+namespace Rector\EarlyReturn\Tests\Rector\If_\ChangeOrIfContinueToMultiContinueRector\Fixture;
 
-class NotIdentical
+class Negated
 {
     public function canDrive(Car $newCar)
     {
         foreach ($cars as $car) {
-            if ($car->getWheel() !== 4 && $car->getFuel() !== 'full') {
+            if (! $car->hasWheels() || ! $car->hasFuel() || ! $car->isRunnable()) {
                 continue;
             }
             $car->setWheel($newCar->wheel);
@@ -20,17 +20,20 @@ class NotIdentical
 -----
 <?php
 
-namespace Rector\EarlyReturn\Tests\Rector\If_\ChangeAndIfContinueToMultiContinueRector\Fixture;
+namespace Rector\EarlyReturn\Tests\Rector\If_\ChangeOrIfContinueToMultiContinueRector\Fixture;
 
-class NotIdentical
+class Negated
 {
     public function canDrive(Car $newCar)
     {
         foreach ($cars as $car) {
-            if ($car->getWheel() === 4) {
+            if (! $car->hasWheels()) {
                 continue;
             }
-            if ($car->getFuel() === 'full') {
+            if (! $car->hasFuel()) {
+                continue;
+            }
+            if (! $car->isRunnable()) {
                 continue;
             }
             $car->setWheel($newCar->wheel);

--- a/rules/early-return/tests/Rector/If_/ChangeOrIfContinueToMultiContinueRector/Fixture/not_identical.php.inc
+++ b/rules/early-return/tests/Rector/If_/ChangeOrIfContinueToMultiContinueRector/Fixture/not_identical.php.inc
@@ -1,13 +1,13 @@
 <?php
 
-namespace Rector\EarlyReturn\Tests\Rector\If_\ChangeAndIfContinueToMultiContinueRector\Fixture;
+namespace Rector\EarlyReturn\Tests\Rector\If_\ChangeOrIfContinueToMultiContinueRector\Fixture;
 
-class Identical
+class NotIdentical
 {
     public function canDrive(Car $newCar)
     {
         foreach ($cars as $car) {
-            if ($car->getWheel() === 4 && $car->getFuel() === 'full') {
+            if ($car->getWheel() !== 4 || $car->getFuel() !== 'full') {
                 continue;
             }
             $car->setWheel($newCar->wheel);
@@ -20,9 +20,9 @@ class Identical
 -----
 <?php
 
-namespace Rector\EarlyReturn\Tests\Rector\If_\ChangeAndIfContinueToMultiContinueRector\Fixture;
+namespace Rector\EarlyReturn\Tests\Rector\If_\ChangeOrIfContinueToMultiContinueRector\Fixture;
 
-class Identical
+class NotIdentical
 {
     public function canDrive(Car $newCar)
     {

--- a/rules/early-return/tests/Rector/If_/ChangeOrIfContinueToMultiContinueRector/Fixture/skip_and.php.inc
+++ b/rules/early-return/tests/Rector/If_/ChangeOrIfContinueToMultiContinueRector/Fixture/skip_and.php.inc
@@ -1,14 +1,13 @@
 <?php
 
-namespace Rector\EarlyReturn\Tests\Rector\If_\ChangeAndIfContinueToMultiContinueRector\Fixture;
+namespace Rector\EarlyReturn\Tests\Rector\If_\ChangeOrIfContinueToMultiContinueRector\Fixture;
 
-class SkipMultiStmts
+class SkipAnd
 {
     public function canDrive(Car $newCar)
     {
         foreach ($cars as $car) {
             if ($car->hasWheels() && $car->hasFuel()) {
-                executeSideEffect();
                 continue;
             }
 

--- a/rules/early-return/tests/Rector/If_/ChangeOrIfContinueToMultiContinueRector/Fixture/skip_multi_stmts.php.inc
+++ b/rules/early-return/tests/Rector/If_/ChangeOrIfContinueToMultiContinueRector/Fixture/skip_multi_stmts.php.inc
@@ -1,13 +1,14 @@
 <?php
 
-namespace Rector\EarlyReturn\Tests\Rector\If_\ChangeAndIfContinueToMultiContinueRector\Fixture;
+namespace Rector\EarlyReturn\Tests\Rector\If_\ChangeOrIfContinueToMultiContinueRector\Fixture;
 
-class SkipNotAnd
+class SkipMultiStmts
 {
     public function canDrive(Car $newCar)
     {
         foreach ($cars as $car) {
             if ($car->hasWheels() || $car->hasFuel()) {
+                executeSideEffect();
                 continue;
             }
 

--- a/rules/early-return/tests/Rector/If_/ChangeOrIfContinueToMultiContinueRector/Fixture/skip_not_continue.php.inc
+++ b/rules/early-return/tests/Rector/If_/ChangeOrIfContinueToMultiContinueRector/Fixture/skip_not_continue.php.inc
@@ -1,13 +1,13 @@
 <?php
 
-namespace Rector\EarlyReturn\Tests\Rector\If_\ChangeAndIfContinueToMultiContinueRector\Fixture;
+namespace Rector\EarlyReturn\Tests\Rector\If_\ChangeOrIfContinueToMultiContinueRector\Fixture;
 
 class SkipNotContinue
 {
     public function canDrive(Car $newCar)
     {
         foreach ($cars as $car) {
-            if ($car->hasWheels() && $car->hasFuel()) {
+            if ($car->hasWheels() || $car->hasFuel()) {
                 break;
             }
 

--- a/rules/generic/src/Rector/FuncCall/SwapFuncCallArgumentsRector.php
+++ b/rules/generic/src/Rector/FuncCall/SwapFuncCallArgumentsRector.php
@@ -78,10 +78,12 @@ CODE_SAMPLE
 
             $newArguments = [];
             foreach ($functionArgumentSwap->getOrder() as $oldPosition => $newPosition) {
-                if (! isset($node->args[$oldPosition]) || ! isset($node->args[$newPosition])) {
+                if (! isset($node->args[$oldPosition])) {
                     continue;
                 }
-
+                if (! isset($node->args[$newPosition])) {
+                    continue;
+                }
                 $newArguments[$newPosition] = $node->args[$oldPosition];
             }
 

--- a/rules/mysql-to-mysqli/src/Rector/Assign/MysqlAssignToMysqliRector.php
+++ b/rules/mysql-to-mysqli/src/Rector/Assign/MysqlAssignToMysqliRector.php
@@ -177,7 +177,10 @@ CODE_SAMPLE
         foreach (self::FIELD_TO_FIELD_DIRECT as $funcName => $property) {
             if ($this->isName($funcCall, $funcName)) {
                 $parentNode = $funcCall->getAttribute(AttributeKey::PARENT_NODE);
-                if ($parentNode instanceof PropertyFetch || $parentNode instanceof StaticPropertyFetch) {
+                if ($parentNode instanceof PropertyFetch) {
+                    continue;
+                }
+                if ($parentNode instanceof StaticPropertyFetch) {
                     continue;
                 }
 

--- a/rules/naming/src/Rector/ClassMethod/RenameVariableToMatchNewTypeRector.php
+++ b/rules/naming/src/Rector/ClassMethod/RenameVariableToMatchNewTypeRector.php
@@ -96,7 +96,10 @@ CODE_SAMPLE
 
             /** @var Variable $variable */
             $variable = $assign->var;
-            if ($expectedName === null || $this->isName($variable, $expectedName)) {
+            if ($expectedName === null) {
+                continue;
+            }
+            if ($this->isName($variable, $expectedName)) {
                 continue;
             }
 

--- a/rules/symfony3/src/Rector/MethodCall/ChangeStringCollectionOptionToConstantRector.php
+++ b/rules/symfony3/src/Rector/MethodCall/ChangeStringCollectionOptionToConstantRector.php
@@ -96,6 +96,11 @@ CODE_SAMPLE
             return null;
         }
 
+        return $this->processChangeToConstant($optionsArray, $node);
+    }
+
+    private function processChangeToConstant(Array_ $optionsArray, MethodCall $node): ?Node
+    {
         foreach ($optionsArray->items as $optionsArrayItem) {
             if ($optionsArrayItem === null) {
                 continue;

--- a/rules/symfony3/src/Rector/MethodCall/ChangeStringCollectionOptionToConstantRector.php
+++ b/rules/symfony3/src/Rector/MethodCall/ChangeStringCollectionOptionToConstantRector.php
@@ -99,7 +99,7 @@ CODE_SAMPLE
         return $this->processChangeToConstant($optionsArray, $node);
     }
 
-    private function processChangeToConstant(Array_ $optionsArray, MethodCall $node): ?Node
+    private function processChangeToConstant(Array_ $optionsArray, MethodCall $methodCall): ?Node
     {
         foreach ($optionsArray->items as $optionsArrayItem) {
             if ($optionsArrayItem === null) {
@@ -126,6 +126,6 @@ CODE_SAMPLE
             $optionsArrayItem->value = $this->nodeFactory->createClassConstReference($formClass);
         }
 
-        return $node;
+        return $methodCall;
     }
 }

--- a/rules/symfony3/src/Rector/MethodCall/ChangeStringCollectionOptionToConstantRector.php
+++ b/rules/symfony3/src/Rector/MethodCall/ChangeStringCollectionOptionToConstantRector.php
@@ -97,10 +97,12 @@ CODE_SAMPLE
         }
 
         foreach ($optionsArray->items as $optionsArrayItem) {
-            if ($optionsArrayItem === null || $optionsArrayItem->key === null) {
+            if ($optionsArrayItem === null) {
                 continue;
             }
-
+            if ($optionsArrayItem->key === null) {
+                continue;
+            }
             if (! $this->valueResolver->isValues($optionsArrayItem->key, ['type', 'entry_type'])) {
                 continue;
             }

--- a/rules/type-declaration/src/TypeInferer/PropertyTypeInferer.php
+++ b/rules/type-declaration/src/TypeInferer/PropertyTypeInferer.php
@@ -66,7 +66,10 @@ final class PropertyTypeInferer extends AbstractPriorityAwareTypeInferer
 
         foreach ($this->propertyTypeInferers as $propertyTypeInferer) {
             $type = $propertyTypeInferer->inferProperty($property);
-            if ($type instanceof VoidType || $type instanceof MixedType) {
+            if ($type instanceof VoidType) {
+                continue;
+            }
+            if ($type instanceof MixedType) {
                 continue;
             }
 

--- a/src/NodeManipulator/IfManipulator.php
+++ b/src/NodeManipulator/IfManipulator.php
@@ -353,6 +353,16 @@ final class IfManipulator
         );
     }
 
+    public function createIfExpr(Expr $expr, Stmt $stmt): If_
+    {
+        return new If_(
+            $expr,
+            [
+                'stmts' => [$stmt],
+            ]
+        );
+    }
+
     private function matchComparedAndReturnedNode(NotIdentical $notIdentical, Return_ $return): ?Expr
     {
         if ($this->betterStandardPrinter->areNodesEqual(

--- a/src/PhpParser/Node/Value/ClassResolver.php
+++ b/src/PhpParser/Node/Value/ClassResolver.php
@@ -95,7 +95,10 @@ final class ClassResolver
         foreach ($params as $param) {
             $paramVar = $param->var;
             $methodCallVar = $methodCall->var;
-            if (! $paramVar instanceof Variable || ! $methodCallVar instanceof Variable) {
+            if (! $paramVar instanceof Variable) {
+                continue;
+            }
+            if (! $methodCallVar instanceof Variable) {
                 continue;
             }
             if ($paramVar->name === $methodCallVar->name) {


### PR DESCRIPTION
@TomasVotruba based on https://github.com/rectorphp/rector/pull/5480#discussion_r573181752  I think the rule is invalid, summary:

**It will only works for `BooleanOr`, refs :**

https://3v4l.org/UZ2rD vs https://3v4l.org/MFf4O
https://3v4l.org/ZlWch vs https://3v4l.org/L8XB8

**While in `BooleanAnd`, that's invalid:**

https://3v4l.org/Ip0J6 vs https://3v4l.org/MFf4O
https://3v4l.org/5IIDX vs https://3v4l.org/gRqe5

This PR change name to `ChangeOrIfContinueToMultiContinueRector` instead.

Closes https://github.com/rectorphp/rector/pull/5480