### PR TITLE
[CodeQualityStrict] Handle space in variable new name and assign in if cond at MoveOutMethodCallInsideIfConditionRector

### DIFF
--- a/rules/code-quality-strict/src/Rector/If_/MoveOutMethodCallInsideIfConditionRector.php
+++ b/rules/code-quality-strict/src/Rector/If_/MoveOutMethodCallInsideIfConditionRector.php
@@ -125,6 +125,11 @@ CODE_SAMPLE
 
     private function moveOutMethodCall(MethodCall $methodCall, If_ $if): ?If_
     {
+        $hasParentAssign = $this->betterNodeFinder->findParentType($methodCall, Assign::class);
+        if ($hasParentAssign) {
+            return null;
+        }
+
         $variableName = $this->methodCallToVariableNameResolver->resolveVariableName($methodCall);
         if ($variableName === null) {
             return null;

--- a/rules/code-quality-strict/src/Rector/If_/MoveOutMethodCallInsideIfConditionRector.php
+++ b/rules/code-quality-strict/src/Rector/If_/MoveOutMethodCallInsideIfConditionRector.php
@@ -125,7 +125,7 @@ CODE_SAMPLE
 
     private function moveOutMethodCall(MethodCall $methodCall, If_ $if): ?If_
     {
-        $hasParentAssign = $this->betterNodeFinder->findParentType($methodCall, Assign::class);
+        $hasParentAssign = (bool) $this->betterNodeFinder->findParentType($methodCall, Assign::class);
         if ($hasParentAssign) {
             return null;
         }

--- a/rules/code-quality-strict/tests/Rector/If_/MoveOutMethodCallInsideIfConditionRector/Fixture/skip_parent_assign.php.inc
+++ b/rules/code-quality-strict/tests/Rector/If_/MoveOutMethodCallInsideIfConditionRector/Fixture/skip_parent_assign.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\CodeQualityStrict\Tests\Rector\If_\MoveOutMethodCallInsideIfConditionRector\Fixture;
+
+final class SkipParentAssign
+{
+    public $mysqli;
+    public $databaseName;
+
+    public function run()
+    {
+        $this->mysqli->select_db($this->databaseName);
+        if (!$result = $this->mysqli->query('SHOW TABLES')) {
+            throw new DatabaseException('SHOW TABLES FAILED.');
+        }
+    }
+}

--- a/rules/code-quality-strict/tests/Rector/If_/MoveOutMethodCallInsideIfConditionRector/Fixture/variable_has_space.php.inc
+++ b/rules/code-quality-strict/tests/Rector/If_/MoveOutMethodCallInsideIfConditionRector/Fixture/variable_has_space.php.inc
@@ -30,8 +30,8 @@ final class VariableHasSpace
     public function run()
     {
         $this->mysqli->select_db($this->databaseName);
-        $SHOWTABLESMysqliQuery = $this->mysqli->query('SHOW TABLES');
-        if (! $SHOWTABLESMysqliQuery) {
+        $mysqliQuery = $this->mysqli->query('SHOW TABLES');
+        if (! $mysqliQuery) {
             throw new DatabaseException('SHOW TABLES FAILED.');
         }
     }

--- a/rules/code-quality-strict/tests/Rector/If_/MoveOutMethodCallInsideIfConditionRector/Fixture/variable_has_space.php.inc
+++ b/rules/code-quality-strict/tests/Rector/If_/MoveOutMethodCallInsideIfConditionRector/Fixture/variable_has_space.php.inc
@@ -1,0 +1,40 @@
+<?php
+
+namespace Rector\CodeQualityStrict\Tests\Rector\If_\MoveOutMethodCallInsideIfConditionRector\Fixture;
+
+final class VariableHasSpace
+{
+    public $mysqli;
+    public $databaseName;
+
+    public function run()
+    {
+        $this->mysqli->select_db($this->databaseName);
+        if (! $this->mysqli->query('SHOW TABLES')) {
+            throw new DatabaseException('SHOW TABLES FAILED.');
+        }
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\CodeQualityStrict\Tests\Rector\If_\MoveOutMethodCallInsideIfConditionRector\Fixture;
+
+final class VariableHasSpace
+{
+    public $mysqli;
+    public $databaseName;
+
+    public function run()
+    {
+        $this->mysqli->select_db($this->databaseName);
+        $SHOWTABLESMysqliQuery = $this->mysqli->query('SHOW TABLES');
+        if (! $SHOWTABLESMysqliQuery) {
+            throw new DatabaseException('SHOW TABLES FAILED.');
+        }
+    }
+}
+
+?>

--- a/rules/code-quality/src/Naming/MethodCallToVariableNameResolver.php
+++ b/rules/code-quality/src/Naming/MethodCallToVariableNameResolver.php
@@ -28,6 +28,12 @@ final class MethodCallToVariableNameResolver
     private const CONSTANT_REGEX = '#(_)([a-z])#';
 
     /**
+     * @var string
+     * @see https://regex101.com/r/dhAgLI/1
+     */
+    private const SPACE_REGEX = '#\s+#';
+
+    /**
      * @var NodeNameResolver
      */
     private $nodeNameResolver;
@@ -57,7 +63,10 @@ final class MethodCallToVariableNameResolver
             return null;
         }
 
-        return $this->getVariableName($methodCall, $methodCallVarName, $methodCallName);
+        $result = $this->getVariableName($methodCall, $methodCallVarName, $methodCallName);
+        $result = Strings::replace($result, self::SPACE_REGEX);
+
+        return $result;
     }
 
     private function getVariableName(MethodCall $methodCall, string $methodCallVarName, string $methodCallName): string

--- a/rules/code-quality/src/Naming/MethodCallToVariableNameResolver.php
+++ b/rules/code-quality/src/Naming/MethodCallToVariableNameResolver.php
@@ -64,9 +64,11 @@ final class MethodCallToVariableNameResolver
         }
 
         $result = $this->getVariableName($methodCall, $methodCallVarName, $methodCallName);
-        $result = Strings::replace($result, self::SPACE_REGEX);
+        if (! Strings::match($result, self::SPACE_REGEX)) {
+            return $result;
+        }
 
-        return $result;
+        return $this->getFallbackVarName($methodCallVarName, $methodCallName);
     }
 
     private function getVariableName(MethodCall $methodCall, string $methodCallVarName, string $methodCallName): string


### PR DESCRIPTION
Fixes #5506 Fixes 2 issues:

- variable new name in assign inside if cond, skipped
- variable new name as space, fallback to `$methodCallVarName . ucfirst($methodCallName)`