### PR TITLE
[RenameMethodRector] Do not rename methods that are part of an interface

### DIFF
--- a/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/Fixture/skip_when_interface.php.inc
+++ b/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/Fixture/skip_when_interface.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture;
+
+interface SubscriberInterface {
+    public function notify();
+}
+
+final class Subscriber implements SubscriberInterface
+{
+    public function notify()
+    {
+        return 5;
+    }
+}
+
+final class Caller
+{
+    public static function execute()
+    {
+        $demo = new Subscriber();
+        $demo->notify();
+    }
+}
+?>


### PR DESCRIPTION
# Failing Test for RenameMethodRector

Based on https://getrector.org/demo/3df11204-06c7-4fec-b909-e3acdffb23b1

When the class implements an interface, it should __not__ change anything.