### PR TITLE
Add failing test fixture for RenameMethodRector: Check visibility when renaming to magic method __invoke

### DIFF
--- a/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/Fixture/rename_class_method.php.inc
+++ b/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/Fixture/rename_class_method.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture;
 
-class NetteToSymfonyPresenter
+class RenameClassMethod
 {
     public function run()
     {
@@ -15,7 +15,7 @@ class NetteToSymfonyPresenter
 
 namespace Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture;
 
-class NetteToSymfonyPresenter
+class RenameClassMethod
 {
     public function __invoke()
     {

--- a/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/Fixture/rename_class_method_and_method_call.php.inc
+++ b/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/Fixture/rename_class_method_and_method_call.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture;
 
-final class DemoFile
+final class RenameClassMethodAndMethodCall
 {
     public function notify()
     {
@@ -15,7 +15,7 @@ final class Caller
 {
     public static function execute()
     {
-        $demo = new DemoFile();
+        $demo = new RenameClassMethodAndMethodCall();
         $demo->notify();
     }
 }
@@ -25,7 +25,7 @@ final class Caller
 
 namespace Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture;
 
-final class DemoFile
+final class RenameClassMethodAndMethodCall
 {
     public function __invoke()
     {
@@ -38,7 +38,7 @@ final class Caller
 {
     public static function execute()
     {
-        $demo = new DemoFile();
+        $demo = new RenameClassMethodAndMethodCall();
         $demo->__invoke();
     }
 }

--- a/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/Fixture/skip_private_method_rename_to_private_invoke.php.inc
+++ b/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/Fixture/skip_private_method_rename_to_private_invoke.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture;
+
+final class SkipPrivateMethodRenameToPrivateInvoke
+{
+    private function notify()
+    {
+        return 5;
+    }
+
+}
+
+?>

--- a/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/Fixture/skip_rename_private_method_to_private_invoke.php.inc
+++ b/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/Fixture/skip_rename_private_method_to_private_invoke.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture;
 
-final class SkipPrivateMethodRenameToPrivateInvoke
+final class SkipRenamePrivateMethodToPrivateInvoke
 {
     private function notify()
     {

--- a/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/config/configured_rule.php
+++ b/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/config/configured_rule.php
@@ -3,6 +3,7 @@
 use Nette\Utils\Html;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture\SkipPrivateMethodRenameToPrivateInvoke;
+use Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture\SkipRenamePrivateMethodToPrivateInvoke;
 use Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Source\AbstractType;
 use Rector\Renaming\ValueObject\MethodCallRename;
 use Rector\Renaming\ValueObject\MethodCallRenameWithArrayKey;
@@ -20,11 +21,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 'notify',
                 '__invoke'
             ),
-            new MethodCallRename(
-                'Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture\SkipPrivateMethodRenameToPrivateInvoke',
-                'notify',
-                '__invoke'
-            ),
+            new MethodCallRename(SkipRenamePrivateMethodToPrivateInvoke::class, 'notify', '__invoke'),
             new MethodCallRename('*Presenter', 'run', '__invoke'),
             new MethodCallRename(
                 \Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture\SkipSelfMethodRename::class,

--- a/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/config/configured_rule.php
+++ b/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/config/configured_rule.php
@@ -2,6 +2,7 @@
 
 use Nette\Utils\Html;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
+use Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture\SkipPrivateMethodRenameToPrivateInvoke;
 use Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Source\AbstractType;
 use Rector\Renaming\ValueObject\MethodCallRename;
 use Rector\Renaming\ValueObject\MethodCallRenameWithArrayKey;
@@ -16,6 +17,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             new MethodCallRename(Html::class, 'add', 'addHtml'),
             new MethodCallRename(
                 'Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture\DemoFile',
+                'notify',
+                '__invoke'
+            ),
+            new MethodCallRename(
+                'Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture\SkipPrivateMethodRenameToPrivateInvoke',
                 'notify',
                 '__invoke'
             ),

--- a/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/config/configured_rule.php
+++ b/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/config/configured_rule.php
@@ -2,6 +2,7 @@
 
 use Nette\Utils\Html;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
+use Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture\RenameClassMethodAndMethodCall;
 use Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture\SkipPrivateMethodRenameToPrivateInvoke;
 use Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture\SkipRenamePrivateMethodToPrivateInvoke;
 use Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Source\AbstractType;
@@ -16,11 +17,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         RenameMethodRector::METHOD_CALL_RENAMES => ValueObjectInliner::inline([
             new MethodCallRename(AbstractType::class, 'setDefaultOptions', 'configureOptions'),
             new MethodCallRename(Html::class, 'add', 'addHtml'),
-            new MethodCallRename(
-                'Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture\DemoFile',
-                'notify',
-                '__invoke'
-            ),
+            new MethodCallRename(RenameClassMethodAndMethodCall::class, 'notify', '__invoke'),
             new MethodCallRename(SkipRenamePrivateMethodToPrivateInvoke::class, 'notify', '__invoke'),
             new MethodCallRename('*RenameClassMethod', 'run', '__invoke'),
             new MethodCallRename(

--- a/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/config/configured_rule.php
+++ b/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/config/configured_rule.php
@@ -22,7 +22,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 '__invoke'
             ),
             new MethodCallRename(SkipRenamePrivateMethodToPrivateInvoke::class, 'notify', '__invoke'),
-            new MethodCallRename('*Presenter', 'run', '__invoke'),
+            new MethodCallRename('*RenameClassMethod', 'run', '__invoke'),
             new MethodCallRename(
                 \Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture\SkipSelfMethodRename::class,
                 'preventPHPStormRefactoring',


### PR DESCRIPTION
# Failing Test for RenameMethodRector

Based on https://getrector.org/demo/38775b0b-7f57-4f18-97ac-b39a71fa6d78

It should detect that the old method is not public and that the new magic method `__invoke` can only be applied when public.