### PR TITLE
Fix merging of multiple calls to configure in sets

### DIFF
--- a/src/DependencyInjection/Loader/ConfigurableCallValuesCollectingPhpFileLoader.php
+++ b/src/DependencyInjection/Loader/ConfigurableCallValuesCollectingPhpFileLoader.php
@@ -27,6 +27,20 @@ final class ConfigurableCallValuesCollectingPhpFileLoader extends PhpFileLoader
         parent::__construct($containerBuilder, $fileLocator);
     }
 
+    /**
+     * @param mixed $resource
+     * @param null|string $type
+     */
+    public function load($resource, $type = null): void
+    {
+        // this call collects root values
+        $this->collectConfigureCallsFromJustImportedConfigurableRectorDefinitions();
+
+        parent::load($resource, $type);
+
+        $this->collectConfigureCallsFromJustImportedConfigurableRectorDefinitions();
+    }
+
     public function import(
         $resource,
         $type = null,

--- a/tests/DependencyInjection/ConfigurableRectorImportConfigCallsMergeTest.php
+++ b/tests/DependencyInjection/ConfigurableRectorImportConfigCallsMergeTest.php
@@ -51,17 +51,17 @@ final class ConfigurableRectorImportConfigCallsMergeTest extends AbstractKernelT
         ];
 
         yield [
-            __DIR__ . '/config/main_config_with_own_value.php', [
+            __DIR__ . '/config/main_config_with_override_value.php', [
                 'old_2' => 'new_2',
                 'old_1' => 'new_1',
-                'old_3' => 'new_3',
             ],
         ];
 
         yield [
-            __DIR__ . '/config/main_config_with_override_value.php', [
+            __DIR__ . '/config/main_config_with_own_value.php', [
                 'old_2' => 'new_2',
                 'old_1' => 'new_1',
+                'old_3' => 'new_3',
             ],
         ];
     }

--- a/tests/DependencyInjection/ConfigurableRectorImportConfigCallsMergeTest.php
+++ b/tests/DependencyInjection/ConfigurableRectorImportConfigCallsMergeTest.php
@@ -98,29 +98,29 @@ final class ConfigurableRectorImportConfigCallsMergeTest extends AbstractRectorT
 
         yield [
             __DIR__ . '/config/two_sets.php', [
+                'Twig_SimpleFilter' => 'Twig_Filter',
+                'Twig_SimpleFunction' => 'Twig_Function',
+                'Twig_SimpleTest' => 'Twig_Test',
                 'PHPUnit_Framework_MockObject_Stub' => 'PHPUnit\Framework\MockObject\Stub',
                 'PHPUnit_Framework_MockObject_Stub_Return' => 'PHPUnit\Framework\MockObject\Stub\ReturnStub',
                 'PHPUnit_Framework_MockObject_Matcher_Parameters' => 'PHPUnit\Framework\MockObject\Matcher\Parameters',
                 'PHPUnit_Framework_MockObject_Matcher_Invocation' => 'PHPUnit\Framework\MockObject\Matcher\Invocation',
                 'PHPUnit_Framework_MockObject_MockObject' => 'PHPUnit\Framework\MockObject\MockObject',
                 'PHPUnit_Framework_MockObject_Invocation_Object' => 'PHPUnit\Framework\MockObject\Invocation\ObjectInvocation',
-                'Twig_SimpleFilter' => 'Twig_Filter',
-                'Twig_SimpleFunction' => 'Twig_Function',
-                'Twig_SimpleTest' => 'Twig_Test',
             ],
         ];
 
         yield [
             __DIR__ . '/config/two_sets_with_own_rename.php', [
+                'Twig_SimpleFilter' => 'Twig_Filter',
+                'Twig_SimpleFunction' => 'Twig_Function',
+                'Twig_SimpleTest' => 'Twig_Test',
                 'PHPUnit_Framework_MockObject_Stub' => 'PHPUnit\Framework\MockObject\Stub',
                 'PHPUnit_Framework_MockObject_Stub_Return' => 'PHPUnit\Framework\MockObject\Stub\ReturnStub',
                 'PHPUnit_Framework_MockObject_Matcher_Parameters' => 'PHPUnit\Framework\MockObject\Matcher\Parameters',
                 'PHPUnit_Framework_MockObject_Matcher_Invocation' => 'PHPUnit\Framework\MockObject\Matcher\Invocation',
                 'PHPUnit_Framework_MockObject_MockObject' => 'PHPUnit\Framework\MockObject\MockObject',
                 'PHPUnit_Framework_MockObject_Invocation_Object' => 'PHPUnit\Framework\MockObject\Invocation\ObjectInvocation',
-                'Twig_SimpleFilter' => 'Twig_Filter',
-                'Twig_SimpleFunction' => 'Twig_Function',
-                'Twig_SimpleTest' => 'Twig_Test',
                 'Old' => 'New',
             ],
         ];

--- a/tests/DependencyInjection/ConfigurableRectorImportConfigCallsMergeTest.php
+++ b/tests/DependencyInjection/ConfigurableRectorImportConfigCallsMergeTest.php
@@ -81,5 +81,17 @@ final class ConfigurableRectorImportConfigCallsMergeTest extends AbstractRectorT
                 'PHPUnit_Framework_MockObject_Invocation_Object' => 'PHPUnit\Framework\MockObject\Invocation\ObjectInvocation',
             ],
         ];
+
+        yield [
+            __DIR__ . '/config/one_set_with_own_rename.php', [
+                'PHPUnit_Framework_MockObject_Stub' => 'PHPUnit\Framework\MockObject\Stub',
+                'PHPUnit_Framework_MockObject_Stub_Return' => 'PHPUnit\Framework\MockObject\Stub\ReturnStub',
+                'PHPUnit_Framework_MockObject_Matcher_Parameters' => 'PHPUnit\Framework\MockObject\Matcher\Parameters',
+                'PHPUnit_Framework_MockObject_Matcher_Invocation' => 'PHPUnit\Framework\MockObject\Matcher\Invocation',
+                'PHPUnit_Framework_MockObject_MockObject' => 'PHPUnit\Framework\MockObject\MockObject',
+                'PHPUnit_Framework_MockObject_Invocation_Object' => 'PHPUnit\Framework\MockObject\Invocation\ObjectInvocation',
+                'Old' => 'New',
+            ],
+        ];
     }
 }

--- a/tests/DependencyInjection/ConfigurableRectorImportConfigCallsMergeTest.php
+++ b/tests/DependencyInjection/ConfigurableRectorImportConfigCallsMergeTest.php
@@ -93,5 +93,19 @@ final class ConfigurableRectorImportConfigCallsMergeTest extends AbstractRectorT
                 'Old' => 'New',
             ],
         ];
+
+        yield [
+            __DIR__ . '/config/two_sets.php', [
+                'PHPUnit_Framework_MockObject_Stub' => 'PHPUnit\Framework\MockObject\Stub',
+                'PHPUnit_Framework_MockObject_Stub_Return' => 'PHPUnit\Framework\MockObject\Stub\ReturnStub',
+                'PHPUnit_Framework_MockObject_Matcher_Parameters' => 'PHPUnit\Framework\MockObject\Matcher\Parameters',
+                'PHPUnit_Framework_MockObject_Matcher_Invocation' => 'PHPUnit\Framework\MockObject\Matcher\Invocation',
+                'PHPUnit_Framework_MockObject_MockObject' => 'PHPUnit\Framework\MockObject\MockObject',
+                'PHPUnit_Framework_MockObject_Invocation_Object' => 'PHPUnit\Framework\MockObject\Invocation\ObjectInvocation',
+                'Twig_SimpleFilter' => 'Twig_Filter',
+                'Twig_SimpleFunction' => 'Twig_Function',
+                'Twig_SimpleTest' => 'Twig_Test',
+            ],
+        ];
     }
 }

--- a/tests/DependencyInjection/ConfigurableRectorImportConfigCallsMergeTest.php
+++ b/tests/DependencyInjection/ConfigurableRectorImportConfigCallsMergeTest.php
@@ -107,5 +107,20 @@ final class ConfigurableRectorImportConfigCallsMergeTest extends AbstractRectorT
                 'Twig_SimpleTest' => 'Twig_Test',
             ],
         ];
+
+        yield [
+            __DIR__ . '/config/two_sets_with_own_rename.php', [
+                'PHPUnit_Framework_MockObject_Stub' => 'PHPUnit\Framework\MockObject\Stub',
+                'PHPUnit_Framework_MockObject_Stub_Return' => 'PHPUnit\Framework\MockObject\Stub\ReturnStub',
+                'PHPUnit_Framework_MockObject_Matcher_Parameters' => 'PHPUnit\Framework\MockObject\Matcher\Parameters',
+                'PHPUnit_Framework_MockObject_Matcher_Invocation' => 'PHPUnit\Framework\MockObject\Matcher\Invocation',
+                'PHPUnit_Framework_MockObject_MockObject' => 'PHPUnit\Framework\MockObject\MockObject',
+                'PHPUnit_Framework_MockObject_Invocation_Object' => 'PHPUnit\Framework\MockObject\Invocation\ObjectInvocation',
+                'Twig_SimpleFilter' => 'Twig_Filter',
+                'Twig_SimpleFunction' => 'Twig_Function',
+                'Twig_SimpleTest' => 'Twig_Test',
+                'Old' => 'New',
+            ],
+        ];
     }
 }

--- a/tests/DependencyInjection/ConfigurableRectorImportConfigCallsMergeTest.php
+++ b/tests/DependencyInjection/ConfigurableRectorImportConfigCallsMergeTest.php
@@ -31,31 +31,27 @@ final class ConfigurableRectorImportConfigCallsMergeTest extends AbstractKernelT
      * @dataProvider provideData()
      * @param array<string, string> $expectedConfiguration
      */
-    public function testMainConfigValues(
-        string $config,
-        int $expectedConfigurationCount,
-        array $expectedConfiguration
-    ): void {
+    public function testMainConfigValues(string $config, array $expectedConfiguration): void
+    {
         $this->bootKernelWithConfigs(RectorKernel::class, [$config]);
         $this->renameClassRector = $this->getService(RenameClassRector::class);
 
         $oldToNewClasses = $this->privatesAccessor->getPrivateProperty($this->renameClassRector, 'oldToNewClasses');
 
-        $this->assertCount($expectedConfigurationCount, $oldToNewClasses);
         $this->assertSame($expectedConfiguration, $oldToNewClasses);
     }
 
     public function provideData(): Iterator
     {
         yield [
-            __DIR__ . '/config/main_config_with_only_imports.php', 2, [
+            __DIR__ . '/config/main_config_with_only_imports.php', [
                 'old_2' => 'new_2',
                 'old_1' => 'new_1',
             ],
         ];
 
         yield [
-            __DIR__ . '/config/main_config_with_own_value.php', 3, [
+            __DIR__ . '/config/main_config_with_own_value.php', [
                 'old_2' => 'new_2',
                 'old_1' => 'new_1',
                 'old_3' => 'new_3',
@@ -63,7 +59,7 @@ final class ConfigurableRectorImportConfigCallsMergeTest extends AbstractKernelT
         ];
 
         yield [
-            __DIR__ . '/config/main_config_with_override_value.php', 2, [
+            __DIR__ . '/config/main_config_with_override_value.php', [
                 'old_2' => 'new_2',
                 'old_1' => 'new_1',
             ],

--- a/tests/DependencyInjection/ConfigurableRectorImportConfigCallsMergeTest.php
+++ b/tests/DependencyInjection/ConfigurableRectorImportConfigCallsMergeTest.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Rector\Core\Tests\DependencyInjection;
 
 use Iterator;
+use Rector\Core\Bootstrap\RectorConfigsResolver;
 use Rector\Core\HttpKernel\RectorKernel;
 use Rector\Renaming\Rector\Name\RenameClassRector;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 use Symplify\PackageBuilder\Reflection\PrivatesAccessor;
-use Symplify\PackageBuilder\Testing\AbstractKernelTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
 
-final class ConfigurableRectorImportConfigCallsMergeTest extends AbstractKernelTestCase
+final class ConfigurableRectorImportConfigCallsMergeTest extends AbstractRectorTestCase
 {
     /**
      * @var RenameClassRector
@@ -33,7 +35,11 @@ final class ConfigurableRectorImportConfigCallsMergeTest extends AbstractKernelT
      */
     public function testMainConfigValues(string $config, array $expectedConfiguration): void
     {
-        $this->bootKernelWithConfigs(RectorKernel::class, [$config]);
+        $rectorConfigsResolver = new RectorConfigsResolver();
+
+        $configFileInfos = $rectorConfigsResolver->resolveFromConfigFileInfo(new SmartFileInfo($config));
+
+        $this->bootKernelWithConfigs(RectorKernel::class, $configFileInfos);
         $this->renameClassRector = $this->getService(RenameClassRector::class);
 
         $oldToNewClasses = $this->privatesAccessor->getPrivateProperty($this->renameClassRector, 'oldToNewClasses');
@@ -62,6 +68,17 @@ final class ConfigurableRectorImportConfigCallsMergeTest extends AbstractKernelT
                 'old_2' => 'new_2',
                 'old_1' => 'new_1',
                 'old_3' => 'new_3',
+            ],
+        ];
+
+        yield [
+            __DIR__ . '/config/one_set.php', [
+                'PHPUnit_Framework_MockObject_Stub' => 'PHPUnit\Framework\MockObject\Stub',
+                'PHPUnit_Framework_MockObject_Stub_Return' => 'PHPUnit\Framework\MockObject\Stub\ReturnStub',
+                'PHPUnit_Framework_MockObject_Matcher_Parameters' => 'PHPUnit\Framework\MockObject\Matcher\Parameters',
+                'PHPUnit_Framework_MockObject_Matcher_Invocation' => 'PHPUnit\Framework\MockObject\Matcher\Invocation',
+                'PHPUnit_Framework_MockObject_MockObject' => 'PHPUnit\Framework\MockObject\MockObject',
+                'PHPUnit_Framework_MockObject_Invocation_Object' => 'PHPUnit\Framework\MockObject\Invocation\ObjectInvocation',
             ],
         ];
     }

--- a/tests/DependencyInjection/ConfigurableRectorImportConfigCallsMergeTest.php
+++ b/tests/DependencyInjection/ConfigurableRectorImportConfigCallsMergeTest.php
@@ -60,6 +60,7 @@ final class ConfigurableRectorImportConfigCallsMergeTest extends AbstractRectorT
             __DIR__ . '/config/main_config_with_override_value.php', [
                 'old_2' => 'new_2',
                 'old_1' => 'new_1',
+                'old_4' => 'new_4',
             ],
         ];
 
@@ -67,6 +68,7 @@ final class ConfigurableRectorImportConfigCallsMergeTest extends AbstractRectorT
             __DIR__ . '/config/main_config_with_own_value.php', [
                 'old_2' => 'new_2',
                 'old_1' => 'new_1',
+                'old_4' => 'new_4',
                 'old_3' => 'new_3',
             ],
         ];

--- a/tests/DependencyInjection/config/main_config_with_override_value.php
+++ b/tests/DependencyInjection/config/main_config_with_override_value.php
@@ -13,6 +13,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             RenameClassRector::OLD_TO_NEW_CLASSES => [
                 'old_2' => 'new_2',
             ],
+        ]])
+        ->call('configure', [[
+            RenameClassRector::OLD_TO_NEW_CLASSES => [
+                'old_4' => 'new_4',
+            ],
         ]]);
 
     $containerConfigurator->import(__DIR__ . '/first_config.php');

--- a/tests/DependencyInjection/config/main_config_with_own_value.php
+++ b/tests/DependencyInjection/config/main_config_with_own_value.php
@@ -13,6 +13,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             RenameClassRector::OLD_TO_NEW_CLASSES => [
                 'old_3' => 'new_3',
             ],
+        ]])
+        ->call('configure', [[
+            RenameClassRector::OLD_TO_NEW_CLASSES => [
+                'old_4' => 'new_4',
+            ],
         ]]);
 
     $containerConfigurator->import(__DIR__ . '/first_config.php');

--- a/tests/DependencyInjection/config/one_set.php
+++ b/tests/DependencyInjection/config/one_set.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\Set\ValueObject\SetList;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $parameters = $containerConfigurator->parameters();
+
+    $parameters->set(Option::SETS, [SetList::PHPUNIT_60]);
+};

--- a/tests/DependencyInjection/config/one_set_with_own_rename.php
+++ b/tests/DependencyInjection/config/one_set_with_own_rename.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+use Rector\Set\ValueObject\SetList;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $parameters = $containerConfigurator->parameters();
+
+    $parameters->set(Option::SETS, [SetList::PHPUNIT_60]);
+
+    $services = $containerConfigurator->services();
+
+    $services->set(RenameClassRector::class)
+        ->call('configure', [[
+            RenameClassRector::OLD_TO_NEW_CLASSES => [
+                'Old' => 'New',
+            ],
+        ]]);
+};

--- a/tests/DependencyInjection/config/two_sets.php
+++ b/tests/DependencyInjection/config/two_sets.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\Set\ValueObject\SetList;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $parameters = $containerConfigurator->parameters();
+
+    $parameters->set(Option::SETS, [SetList::PHPUNIT_60, SetList::TWIG_20]);
+};

--- a/tests/DependencyInjection/config/two_sets_with_own_rename.php
+++ b/tests/DependencyInjection/config/two_sets_with_own_rename.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+use Rector\Set\ValueObject\SetList;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $parameters = $containerConfigurator->parameters();
+
+    $parameters->set(Option::SETS, [SetList::PHPUNIT_60, SetList::TWIG_20]);
+
+    $services = $containerConfigurator->services();
+
+    $services->set(RenameClassRector::class)
+        ->call('configure', [[
+            RenameClassRector::OLD_TO_NEW_CLASSES => [
+                'Old' => 'New',
+            ],
+        ]]);
+};


### PR DESCRIPTION
I spent a lot of time debugging this but when I fixed one issue another one popped up 🤯 

It's all related to the loading of sets that is different from the normal rector.php configuration. 

There were 3 failing scenarios:
- ✅ load one set that configures RenameClassRector + configure your own
- ❌ load two sets that configure both RenameClassRector ( they should merge, they don't )
- ❌ load two sets that configure both RenameClassRector + configure your own

Chained configure calls inside your own config were already working fine. 

@samsonasik @TomasVotruba Any advice? 

Another thing I noticed that drove me completely insane is that the tests are re-using the same container that is stored somewhere in a temp directory on my filesystem. In my case, `/private/var/folders/m4/2_8czq_s1xxxx0000gn/T/_rector`. From time to time I needed to manually purge that directory before new changes would popup. I really think that tests should not rely on those artifacts as that makes debugging issues very hard.

1) can we store the temp stuff relative to the project in `var`?
2) can we by default bust cache on start of the test?