### PR TITLE
[BetterNodeFinder] [WIP] Refactor BetterNodeFinder::findFirstPrevious()

### DIFF
--- a/rules/early-return/src/Rector/Foreach_/ReturnAfterToEarlyOnBreakRector.php
+++ b/rules/early-return/src/Rector/Foreach_/ReturnAfterToEarlyOnBreakRector.php
@@ -97,7 +97,7 @@ CODE_SAMPLE
         }
 
         $assignVariable = $assign->var;
-        $variablePrevious = $this->betterNodeFinder->findFirstPreviousOfNode($node, function (Node $node) use (
+        $variablePrevious = $this->betterNodeFinder->findFirstPrevious($node, function (Node $node) use (
             $assignVariable
         ): bool {
             $parent = $node->getAttribute(AttributeKey::PARENT_NODE);

--- a/rules/nette/src/Rector/Class_/MoveFinalGetUserToCheckRequirementsClassMethodRector.php
+++ b/rules/nette/src/Rector/Class_/MoveFinalGetUserToCheckRequirementsClassMethodRector.php
@@ -101,7 +101,7 @@ CODE_SAMPLE
         }
 
         $checkRequirementsClassMethod = $node->getMethod('checkRequirements');
-        if ($checkRequirementsClassMethod === null) {
+        if (! $checkRequirementsClassMethod instanceof ClassMethod) {
             $checkRequirementsClassMethod = $this->checkRequirementsClassMethodFactory->create(
                 (array) $getUserClassMethod->stmts
             );

--- a/rules/phpunit/src/NodeManipulator/SetUpClassMethodNodeManipulator.php
+++ b/rules/phpunit/src/NodeManipulator/SetUpClassMethodNodeManipulator.php
@@ -6,6 +6,7 @@ namespace Rector\PHPUnit\NodeManipulator;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
 use Rector\Core\ValueObject\MethodName;
 use Rector\PHPUnit\NodeFactory\SetUpClassMethodFactory;
 
@@ -38,7 +39,7 @@ final class SetUpClassMethodNodeManipulator
 
         $setUpClassMethod = $class->getMethod(MethodName::SET_UP);
 
-        if ($setUpClassMethod === null) {
+        if (! $setUpClassMethod instanceof ClassMethod) {
             $setUpClassMethod = $this->setUpClassMethodFactory->createSetUpMethod($stmts);
             $class->stmts = array_merge([$setUpClassMethod], $class->stmts);
         } else {

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -9,6 +9,8 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Param;
+use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
@@ -309,16 +311,20 @@ final class BetterNodeFinder
     {
         $currentStatement = $node instanceof Expression ? $node : $node->getAttribute(AttributeKey::CURRENT_STATEMENT);
 
-        // move to previous expression
+        $previousNode      = $currentStatement->getAttribute(AttributeKey::PREVIOUS_NODE);
         $previousStatement = $currentStatement->getAttribute(AttributeKey::PREVIOUS_STATEMENT);
-        if ($previousStatement !== null) {
-            $foundNode = $this->findFirst([$previousStatement], $filter);
+        if (! $previousNode instanceof Param && $previousStatement instanceof FunctionLike) {
+            $previousNode = $currentStatement->getAttribute(AttributeKey::PREVIOUS_STATEMENT);
+        }
+
+        if ($previousNode !== null) {
+            $foundNode = $this->findFirst([$previousNode], $filter);
             // we found what we need
             if ($foundNode !== null) {
                 return $foundNode;
             }
 
-            return $this->findFirstPrevious($previousStatement, $filter);
+            return $this->findFirstPrevious($previousNode, $filter);
         }
 
         $parent = $node->getAttribute(AttributeKey::PARENT_NODE);

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -310,9 +310,8 @@ final class BetterNodeFinder
     {
         $currentStatement = $node instanceof Expression ? $node : $node->getAttribute(AttributeKey::CURRENT_STATEMENT);
         $previousNode     = $currentStatement->getAttribute(AttributeKey::PREVIOUS_STATEMENT);
-
-        if ($previousNode instanceof FunctionLike) {
-            return null;
+        if ($previousNode instanceof Node && property_exists($previousNode, 'stmts')) {
+            $previousNode = $currentStatement->getAttribute(AttributeKey::PREVIOUS_NODE);
         }
 
         if ($previousNode instanceof Node) {
@@ -321,11 +320,7 @@ final class BetterNodeFinder
                 return $foundNode;
             }
 
-            $previousNode = $currentStatement->getAttribute(AttributeKey::PREVIOUS_NODE);
-            $foundNode    = $this->findFirst([$previousNode], $filter);
-            if ($foundNode instanceof Node) {
-                return $foundNode;
-            }
+            return $this->findFirstPrevious($previousNode, $filter);
         }
 
         $parent = $node->getAttribute(AttributeKey::PARENT_NODE);

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -305,7 +305,7 @@ final class BetterNodeFinder
         });
     }
 
-    public function findFirstPreviousOfNode(Node $node, callable $filter): ?Node
+    public function findFirstPrevious(Node $node, callable $filter): ?Node
     {
         // move to previous expression
         $previousStatement = $node->getAttribute(AttributeKey::PREVIOUS_NODE);
@@ -316,18 +316,18 @@ final class BetterNodeFinder
                 return $foundNode;
             }
 
-            return $this->findFirstPreviousOfNode($previousStatement, $filter);
+            return $this->findFirstPrevious($previousStatement, $filter);
         }
 
         $parent = $node->getAttribute(AttributeKey::PARENT_NODE);
         if ($parent instanceof Node) {
-            return $this->findFirstPreviousOfNode($parent, $filter);
+            return $this->findFirstPrevious($parent, $filter);
         }
 
         return null;
     }
 
-    public function findFirstPrevious(Node $node, callable $filter): ?Node
+    /*public function findFirstPrevious(Node $node, callable $filter): ?Node
     {
         $node = $node instanceof Expression ? $node : $node->getAttribute(AttributeKey::CURRENT_STATEMENT);
         if ($node === null) {
@@ -352,7 +352,7 @@ final class BetterNodeFinder
         }
 
         return $this->findFirstPrevious($parent, $filter);
-    }
+    }*/
 
     /**
      * @param class-string<T>[] $types

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -334,33 +334,6 @@ final class BetterNodeFinder
         return null;
     }
 
-    /*public function findFirstPrevious(Node $node, callable $filter): ?Node
-    {
-        $node = $node instanceof Expression ? $node : $node->getAttribute(AttributeKey::CURRENT_STATEMENT);
-        if ($node === null) {
-            return null;
-        }
-
-        $foundNode = $this->findFirst([$node], $filter);
-        // we found what we need
-        if ($foundNode !== null) {
-            return $foundNode;
-        }
-
-        // move to previous expression
-        $previousStatement = $node->getAttribute(AttributeKey::PREVIOUS_STATEMENT);
-        if ($previousStatement !== null) {
-            return $this->findFirstPrevious($previousStatement, $filter);
-        }
-
-        $parent = $node->getAttribute(AttributeKey::PARENT_NODE);
-        if ($parent === null) {
-            return null;
-        }
-
-        return $this->findFirstPrevious($parent, $filter);
-    }*/
-
     /**
      * @param class-string<T>[] $types
      * @return T|null

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -311,14 +311,21 @@ final class BetterNodeFinder
         $currentStatement = $node instanceof Expression ? $node : $node->getAttribute(AttributeKey::CURRENT_STATEMENT);
         $previousNode     = $currentStatement->getAttribute(AttributeKey::PREVIOUS_STATEMENT);
 
-        if ($previousNode !== null) {
+        if ($previousNode instanceof FunctionLike) {
+            return null;
+        }
+
+        if ($previousNode instanceof Node) {
             $foundNode = $this->findFirst([$previousNode], $filter);
-            // we found what we need
-            if ($foundNode !== null) {
+            if ($foundNode instanceof Node) {
                 return $foundNode;
             }
 
-            return $this->findFirstPrevious($previousNode, $filter);
+            $previousNode = $currentStatement->getAttribute(AttributeKey::PREVIOUS_NODE);
+            $foundNode    = $this->findFirst([$previousNode], $filter);
+            if ($foundNode instanceof Node) {
+                return $foundNode;
+            }
         }
 
         $parent = $node->getAttribute(AttributeKey::PARENT_NODE);

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -310,7 +310,7 @@ final class BetterNodeFinder
     {
         $currentStatement = $node instanceof Expression ? $node : $node->getAttribute(AttributeKey::CURRENT_STATEMENT);
         $previousNode     = $currentStatement->getAttribute(AttributeKey::PREVIOUS_STATEMENT);
-        if ($previousNode instanceof Node && property_exists($previousNode, 'stmts')) {
+        if ($previousNode instanceof FunctionLike) {
             $previousNode = $currentStatement->getAttribute(AttributeKey::PREVIOUS_NODE);
         }
 

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -307,8 +307,10 @@ final class BetterNodeFinder
 
     public function findFirstPrevious(Node $node, callable $filter): ?Node
     {
+        $currentStatement = $node instanceof Expression ? $node : $node->getAttribute(AttributeKey::CURRENT_STATEMENT);
+
         // move to previous expression
-        $previousStatement = $node->getAttribute(AttributeKey::PREVIOUS_NODE);
+        $previousStatement = $currentStatement->getAttribute(AttributeKey::PREVIOUS_STATEMENT);
         if ($previousStatement !== null) {
             $foundNode = $this->findFirst([$previousStatement], $filter);
             // we found what we need

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -14,6 +14,7 @@ use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\NodeFinder;
 use Rector\Core\PhpParser\Printer\BetterStandardPrinter;
 use Rector\Core\Util\StaticInstanceOf;
@@ -309,8 +310,9 @@ final class BetterNodeFinder
     public function findFirstPrevious(Node $node, callable $filter): ?Node
     {
         $currentStatement = $node instanceof Expression ? $node : $node->getAttribute(AttributeKey::CURRENT_STATEMENT);
-        $previousNode     = $currentStatement->getAttribute(AttributeKey::PREVIOUS_STATEMENT);
-        if ($previousNode instanceof FunctionLike) {
+        $previousNode = $currentStatement->getAttribute(AttributeKey::PREVIOUS_STATEMENT);
+
+        if ($previousNode instanceof FunctionLike || $previousNode instanceof ClassLike || $previousNode instanceof Namespace_) {
             $previousNode = $currentStatement->getAttribute(AttributeKey::PREVIOUS_NODE);
         }
 

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -8,9 +8,8 @@ use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Param;
 use PhpParser\Node\FunctionLike;
-use PhpParser\Node\Identifier;
+use PhpParser\Node\Param;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
@@ -311,7 +310,7 @@ final class BetterNodeFinder
     {
         $currentStatement = $node instanceof Expression ? $node : $node->getAttribute(AttributeKey::CURRENT_STATEMENT);
 
-        $previousNode      = $currentStatement->getAttribute(AttributeKey::PREVIOUS_NODE);
+        $previousNode = $currentStatement->getAttribute(AttributeKey::PREVIOUS_NODE);
         $previousStatement = $currentStatement->getAttribute(AttributeKey::PREVIOUS_STATEMENT);
         if (! $previousNode instanceof Param && $previousStatement instanceof FunctionLike) {
             $previousNode = $currentStatement->getAttribute(AttributeKey::PREVIOUS_STATEMENT);

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -309,12 +309,7 @@ final class BetterNodeFinder
     public function findFirstPrevious(Node $node, callable $filter): ?Node
     {
         $currentStatement = $node instanceof Expression ? $node : $node->getAttribute(AttributeKey::CURRENT_STATEMENT);
-
-        $previousNode = $currentStatement->getAttribute(AttributeKey::PREVIOUS_NODE);
-        $previousStatement = $currentStatement->getAttribute(AttributeKey::PREVIOUS_STATEMENT);
-        if (! $previousNode instanceof Param && $previousStatement instanceof FunctionLike) {
-            $previousNode = $currentStatement->getAttribute(AttributeKey::PREVIOUS_STATEMENT);
-        }
+        $previousNode     = $currentStatement->getAttribute(AttributeKey::PREVIOUS_STATEMENT);
 
         if ($previousNode !== null) {
             $foundNode = $this->findFirst([$previousNode], $filter);


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector/pull/5529#issuecomment-778628430 the current behaviour of `BetterNodeFinder::findFirstPrevious()` is invalid as when fallback to parent, it re-select current node searched. 

It may need update the code using it.