### PR TITLE
[[PHP 7.1 Scoped] Run phpunit on root directory [part 2]

### DIFF
--- a/ci/downgrade/target-repo/.github/workflows/tests_root.yaml
+++ b/ci/downgrade/target-repo/.github/workflows/tests_root.yaml
@@ -1,4 +1,4 @@
-name: Tests
+name: Tests Root Directory
 
 on: [pull_request, push]
 
@@ -23,17 +23,10 @@ jobs:
 
             # Use library versions compatible with PHP 7.1
             -   run: |
-                    mkdir temp && cd temp
                     composer require "doctrine/orm:~2.7.5" --ansi --no-interaction
                     composer require "phpunit/phpunit:~7.5" --dev --ansi --no-interaction
 
-            # Apply Rector on a few sources
-            -   run: |
-                    cd temp
-                    ../bin/rector process ../ci/downgrade/tests/Finalize/Fixture/Source --config ../ci/downgrade/rector-test-downgrade.php --ansi
-
             # Validate the results are the expected ones
             -   run: |
-                    cd temp
-                    vendor/bin/phpunit ../ci/downgrade/tests/
+                    vendor/bin/phpunit
 


### PR DESCRIPTION
Add different yaml config `ci/downgrade/target-repo/.github/workflows/tests_root.yaml` for run phpunit in root directory.