### PR TITLE
[RenameMethodRector] Skip methods that are part of interface

### DIFF
--- a/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/Fixture/skip_when_interface.php.inc
+++ b/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/Fixture/skip_when_interface.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture;
+
+interface SubscriberInterface
+{
+    public function old();
+}
+
+final class SomeSubscriber implements SubscriberInterface
+{
+    public function old()
+    {
+        return 5;
+    }
+}
+
+final class SomeCaller
+{
+    public static function execute()
+    {
+        $demo = new SomeSubscriber();
+        $demo->old();
+    }
+}
+?>

--- a/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/config/configured_rule.php
+++ b/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/config/configured_rule.php
@@ -20,6 +20,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                     'notify',
                     '__invoke'
                 ),
+                new MethodCallRename(
+                    'Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture\SomeSubscriber',
+                    'old',
+                    'new'
+                ),
                 new MethodCallRename('*Presenter', 'run', '__invoke'),
                 new MethodCallRename(
                     \Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture\SkipSelfMethodRename::class,


### PR DESCRIPTION
# Failing Test for RenameMethodRector

Based on https://getrector.org/demo/3df11204-06c7-4fec-b909-e3acdffb23b1

I am able to prevent the rename when in the `ClassMethod` context... but I'm not able to do this for the `MethodCall`. 

@samsonasik Any advice?