### PR TITLE
Do not rename methods from interface when using wildcard

### DIFF
--- a/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/Fixture/skip_when_interface_and_wildcard.php.inc
+++ b/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/Fixture/skip_when_interface_and_wildcard.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture;
+
+interface WildcardSubscriberInterface
+{
+    public function old();
+}
+
+final class SomeWildcardSubscriber implements WildcardSubscriberInterface
+{
+    public function old()
+    {
+        return 5;
+    }
+}
+
+final class SomeWildcardCaller
+{
+    public static function execute()
+    {
+        $demo = new SomeWildcardSubscriber();
+        $demo->old();
+    }
+}
+?>

--- a/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/config/configured_rule.php
+++ b/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/config/configured_rule.php
@@ -25,6 +25,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                     'old',
                     'new'
                 ),
+                new MethodCallRename(
+                    'Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture\*WildcardSubscriber',
+                    'old',
+                    'new'
+                ),
                 new MethodCallRename('*Presenter', 'run', '__invoke'),
                 new MethodCallRename(
                     \Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture\SkipSelfMethodRename::class,


### PR DESCRIPTION
Failing test for https://github.com/rectorphp/rector/pull/5554

cc @samsonasik 