### PR TITLE
[Bin] Add PHPStan Stub ReflectionUnionType and Attribute to bin/rector

### DIFF
--- a/bin/rector
+++ b/bin/rector
@@ -1,4 +1,8 @@
 #!/usr/bin/env php
 <?php
 
+// @see https://github.com/phpstan/phpstan/issues/4541#issuecomment-779434916
+require_once 'phar://vendor/phpstan/phpstan/phpstan.phar/stubs/runtime/ReflectionUnionType.php';
+require_once 'phar://vendor/phpstan/phpstan/phpstan.phar/stubs/runtime/Attribute.php';
+
 require_once __DIR__ . '/rector.php';


### PR DESCRIPTION
To avoid the following error in PHP < 8.0

```bash
"Class 'ReflectionUnionType' not found". 
```

