### PR TITLE
[Bin] Using file_exists() for check PHPStan stub ReflectionUnionType and Attribute exists

### DIFF
--- a/bin/rector
+++ b/bin/rector
@@ -2,7 +2,13 @@
 <?php
 
 // @see https://github.com/phpstan/phpstan/issues/4541#issuecomment-779434916
-require_once 'phar://vendor/phpstan/phpstan/phpstan.phar/stubs/runtime/ReflectionUnionType.php';
-require_once 'phar://vendor/phpstan/phpstan/phpstan.phar/stubs/runtime/Attribute.php';
+if (
+    file_exists('phar://vendor/phpstan/phpstan/phpstan.phar/stubs/runtime/ReflectionUnionType.php')
+    &&
+    file_exists('phar://vendor/phpstan/phpstan/phpstan.phar/stubs/runtime/Attribute.php')
+) {
+    require_once 'phar://vendor/phpstan/phpstan/phpstan.phar/stubs/runtime/ReflectionUnionType.php';
+    require_once 'phar://vendor/phpstan/phpstan/phpstan.phar/stubs/runtime/Attribute.php';
+}
 
 require_once __DIR__ . '/rector.php';


### PR DESCRIPTION
@TomasVotruba In https://getrector.org/demo/3ab7d981-2708-4f30-af81-b983a7a75135 , seems got error:

```bash
Fatal error: Warning: require_once(phar://vendor/phpstan/phpstan/phpstan.phar/stubs/runtime/ReflectionUnionType.php): Failed to open stream: phar error: invalid url or non-existent phar "phar://vendor/phpstan/phpstan/phpstan.phar/stubs/runtime/ReflectionUnionType.php" in /rector/bin/rector on line 5

Fatal error: Uncaught Error: Failed opening required 'phar://vendor/phpstan/phpstan/phpstan.phar/stubs/runtime/ReflectionUnionType.php' (include_path='.:/usr/local/lib/php') in /rector/bin/rector:5
Stack trace:
#0 {main}
thrown in /rector/bin/rector on line 5
```