### PR TITLE
[Renaming] Skip RenameMethodRector when target method is __invoke with private/protected modifier

### DIFF
--- a/rules/renaming/src/Rector/MethodCall/RenameMethodRector.php
+++ b/rules/renaming/src/Rector/MethodCall/RenameMethodRector.php
@@ -178,14 +178,10 @@ CODE_SAMPLE
             return true;
         }
 
-        if (! $classMethod instanceof ClassMethod) {
+        if ($newMethodName !== '__invoke') {
             return false;
         }
 
-        if (! $classMethod->isPrivate()) {
-            return false;
-        }
-
-        return $newMethodName === '__invoke';
+        return ! $classMethod->isPublic();
     }
 }

--- a/rules/renaming/src/Rector/MethodCall/RenameMethodRector.php
+++ b/rules/renaming/src/Rector/MethodCall/RenameMethodRector.php
@@ -182,7 +182,8 @@ CODE_SAMPLE
             return false;
         }
 
-        $classMethod = new ClassMethod($newMethodName);
+        $classMethod = clone $classMethod;
+        $classMethod->name = new Identifier($newMethodName);
         return $classMethod->isMagic();
     }
 }

--- a/rules/renaming/src/Rector/MethodCall/RenameMethodRector.php
+++ b/rules/renaming/src/Rector/MethodCall/RenameMethodRector.php
@@ -173,7 +173,8 @@ CODE_SAMPLE
             return false;
         }
 
-        if ($classMethod->getAttribute(AttributeKey::CLASS_NAME) === $type) {
+        $isExactClassMethodForClasssMethod = $classMethod->getAttribute(AttributeKey::CLASS_NAME) === $type;
+        if ($isExactClassMethodForClasssMethod) {
             return true;
         }
 

--- a/rules/renaming/src/Rector/MethodCall/RenameMethodRector.php
+++ b/rules/renaming/src/Rector/MethodCall/RenameMethodRector.php
@@ -178,10 +178,11 @@ CODE_SAMPLE
             return true;
         }
 
-        if ($newMethodName !== '__invoke') {
+        if ($classMethod->isPublic()) {
             return false;
         }
 
-        return ! $classMethod->isPublic();
+        $classMethod = new ClassMethod($newMethodName);
+        return $classMethod->isMagic();
     }
 }

--- a/rules/renaming/src/Rector/MethodCall/RenameMethodRector.php
+++ b/rules/renaming/src/Rector/MethodCall/RenameMethodRector.php
@@ -182,8 +182,8 @@ CODE_SAMPLE
             return false;
         }
 
-        $classMethod = clone $classMethod;
-        $classMethod->name = new Identifier($newMethodName);
-        return $classMethod->isMagic();
+        $newClassMethod = clone $classMethod;
+        $newClassMethod->name = new Identifier($newMethodName);
+        return $newClassMethod->isMagic();
     }
 }

--- a/rules/renaming/src/Rector/MethodCall/RenameMethodRector.php
+++ b/rules/renaming/src/Rector/MethodCall/RenameMethodRector.php
@@ -141,7 +141,11 @@ CODE_SAMPLE
             return true;
         }
 
-        return $this->shouldSkipForExactClassMethodForClassMethod($node, $methodCallRename->getOldClass());
+        return $this->shouldSkipForExactClassMethodForClassMethodOrTargetInvokePrivate(
+            $node,
+            $methodCallRename->getOldClass(),
+            $methodCallRename->getNewMethod()
+        );
     }
 
     private function shouldSkipForAlreadyExistingClassMethod(
@@ -156,8 +160,11 @@ CODE_SAMPLE
         return (bool) $classLike->getMethod($methodCallRename->getNewMethod());
     }
 
-    private function shouldSkipForExactClassMethodForClassMethod(ClassMethod $classMethod, string $type): bool
-    {
+    private function shouldSkipForExactClassMethodForClassMethodOrTargetInvokePrivate(
+        ClassMethod $classMethod,
+        string $type,
+        string $newMethodName
+    ): bool {
         $className = $classMethod->getAttribute(AttributeKey::CLASS_NAME);
         $methodCalls = $this->nodeRepository->findMethodCallsOnClass($className);
 
@@ -166,6 +173,18 @@ CODE_SAMPLE
             return false;
         }
 
-        return $classMethod->getAttribute(AttributeKey::CLASS_NAME) === $type;
+        if ($classMethod->getAttribute(AttributeKey::CLASS_NAME) === $type) {
+            return true;
+        }
+
+        if (! $classMethod instanceof ClassMethod) {
+            return false;
+        }
+
+        if (! $classMethod->isPrivate()) {
+            return false;
+        }
+
+        return $newMethodName === '__invoke';
     }
 }

--- a/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/Fixture/skip_private_to_invoke.php.inc
+++ b/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/Fixture/skip_private_to_invoke.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture;
+
+class SkipPrivateToInvoke
+{
+    private function run()
+    {
+    }
+}
+
+?>

--- a/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/Fixture/skip_protected_to_invoke.php.inc
+++ b/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/Fixture/skip_protected_to_invoke.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture;
+
+class SkipProtectedToInvoke
+{
+    protected function run()
+    {
+    }
+}
+
+?>

--- a/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/config/configured_rule.php
+++ b/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/config/configured_rule.php
@@ -27,6 +27,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 ),
                 new MethodCallRename('*Presenter', 'run', '__invoke'),
                 new MethodCallRename('*SkipPrivateToInvoke', 'run', '__invoke'),
+                new MethodCallRename('*SkipProtectedToInvoke', 'run', '__invoke'),
                 new MethodCallRename(
                     \Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture\SkipSelfMethodRename::class,
                     'preventPHPStormRefactoring',

--- a/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/config/configured_rule.php
+++ b/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/config/configured_rule.php
@@ -26,6 +26,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                     'new'
                 ),
                 new MethodCallRename('*Presenter', 'run', '__invoke'),
+                new MethodCallRename('*SkipPrivateToInvoke', 'run', '__invoke'),
                 new MethodCallRename(
                     \Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture\SkipSelfMethodRename::class,
                     'preventPHPStormRefactoring',


### PR DESCRIPTION
Closes #5511