### PR TITLE
Allow `proc_open` to be used in the Docker image

### DIFF
--- a/.docker/php/security.ini
+++ b/.docker/php/security.ini
@@ -1,6 +1,6 @@
 # inspired by https://www.cyberciti.biz/tips/php-security-best-practices-tutorial.html
 
-disable_functions = "exec, passthru, shell_exec, system, proc_open, popen, curl_exec, curl_multi_exec, parse_ini_file, show_source"
+disable_functions = "exec, passthru, shell_exec, system, popen, curl_exec, curl_multi_exec, parse_ini_file, show_source"
 
 allow_url_fopen = off
 allow_url_include = off


### PR DESCRIPTION
When I build the Docker image with `docker build -t rector .` and afterwards run `docker run -it --rm rector`, I get the following stack trace:

```
Fatal error: Uncaught Error: Call to undefined function Symfony\Component\Console\proc_open() in /rector/vendor/symfony/console/Terminal.php:162
Stack trace:
#0 /rector/vendor/symfony/console/Terminal.php(148): Symfony\Component\Console\Terminal::readFromProcess('stty -a | grep ...')
#1 /rector/vendor/symfony/console/Terminal.php(114): Symfony\Component\Console\Terminal::getSttyColumns()
#2 /rector/vendor/symfony/console/Terminal.php(97): Symfony\Component\Console\Terminal::initDimensionsUsingStty()
#3 /rector/vendor/symfony/console/Terminal.php(33): Symfony\Component\Console\Terminal::initDimensions()
#4 /rector/vendor/symfony/console/Style/SymfonyStyle.php(51): Symfony\Component\Console\Terminal->getWidth()
#5 /rector/src/Console/Style/SymfonyStyleFactory.php(40): Symfony\Component\Console\Style\SymfonyStyle->__construct(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#6 /rector/bin/rector.php(39): Rector\Core\Console\Style\SymfonyStyleFactory->create()
#7 /rector/bin/rector(14): require_once('/rector/bin/rec...')
#8 {main}
  thrown in /rector/vendor/symfony/console/Terminal.php on line 162
```

Thus, I think the `proc_open` function should be allowed.