### PR TITLE
[RemoveFuncCallArgRector] Use getName instead of isName to fix closure call

### DIFF
--- a/packages/node-name-resolver/src/NodeNameResolver.php
+++ b/packages/node-name-resolver/src/NodeNameResolver.php
@@ -97,11 +97,7 @@ final class NodeNameResolver
     public function isName($node, string $name): bool
     {
         if ($node instanceof MethodCall) {
-            $message = sprintf(
-                'Name called on "%s" is not possible. Use $this->getName($node->name) instead',
-                get_class($node)
-            );
-            throw new ShouldNotHappenException($message);
+            return false;
         }
 
         $nodes = is_array($node) ? $node : [$node];

--- a/packages/node-name-resolver/src/NodeNameResolver.php
+++ b/packages/node-name-resolver/src/NodeNameResolver.php
@@ -97,7 +97,11 @@ final class NodeNameResolver
     public function isName($node, string $name): bool
     {
         if ($node instanceof MethodCall) {
-            return false;
+            $message = sprintf(
+                'Name called on "%s" is not possible. Use $this->getName($node->name) instead',
+                get_class($node)
+            );
+            throw new ShouldNotHappenException($message);
         }
 
         $nodes = is_array($node) ? $node : [$node];

--- a/rules/removing/src/Rector/FuncCall/RemoveFuncCallArgRector.php
+++ b/rules/removing/src/Rector/FuncCall/RemoveFuncCallArgRector.php
@@ -61,10 +61,11 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
+        if ($node->name instanceof Expr) {
+            return null;
+        }
+
         foreach ($this->removedFunctionArguments as $removedFunctionArgument) {
-            if ($node->name instanceof MethodCall) {
-                continue;
-            }
 
             if (! $this->isName($node->name, $removedFunctionArgument->getFunction())) {
                 continue;

--- a/rules/removing/src/Rector/FuncCall/RemoveFuncCallArgRector.php
+++ b/rules/removing/src/Rector/FuncCall/RemoveFuncCallArgRector.php
@@ -61,7 +61,7 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         foreach ($this->removedFunctionArguments as $removedFunctionArgument) {
-            if (! $this->isName($node->name, $removedFunctionArgument->getFunction())) {
+            if ($this->getName($node->name) !== $removedFunctionArgument->getFunction()) {
                 continue;
             }
 

--- a/rules/removing/src/Rector/FuncCall/RemoveFuncCallArgRector.php
+++ b/rules/removing/src/Rector/FuncCall/RemoveFuncCallArgRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\Removing\Rector\FuncCall;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
@@ -66,7 +67,6 @@ CODE_SAMPLE
         }
 
         foreach ($this->removedFunctionArguments as $removedFunctionArgument) {
-
             if (! $this->isName($node->name, $removedFunctionArgument->getFunction())) {
                 continue;
             }

--- a/rules/removing/src/Rector/FuncCall/RemoveFuncCallArgRector.php
+++ b/rules/removing/src/Rector/FuncCall/RemoveFuncCallArgRector.php
@@ -61,7 +61,7 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         foreach ($this->removedFunctionArguments as $removedFunctionArgument) {
-            if ($this->getName($node->name) !== $removedFunctionArgument->getFunction()) {
+            if (! $this->isName($node->name, $removedFunctionArgument->getFunction())) {
                 continue;
             }
 

--- a/rules/removing/src/Rector/FuncCall/RemoveFuncCallArgRector.php
+++ b/rules/removing/src/Rector/FuncCall/RemoveFuncCallArgRector.php
@@ -6,6 +6,7 @@ namespace Rector\Removing\Rector\FuncCall;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Removing\ValueObject\RemoveFuncCallArg;
@@ -61,6 +62,10 @@ CODE_SAMPLE
     public function refactor(Node $node): ?Node
     {
         foreach ($this->removedFunctionArguments as $removedFunctionArgument) {
+            if ($node->name instanceof MethodCall) {
+                continue;
+            }
+
             if (! $this->isName($node->name, $removedFunctionArgument->getFunction())) {
                 continue;
             }

--- a/rules/removing/tests/Rector/FuncCall/RemoveFuncCallArgRector/Fixture/skip_method_call_returning_closure.php.inc
+++ b/rules/removing/tests/Rector/FuncCall/RemoveFuncCallArgRector/Fixture/skip_method_call_returning_closure.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Removing\Tests\Rector\FuncCall\RemoveFuncCallArgRector\Fixture;
+
+final class SkipMethodCallReturningClosure
+{
+    public function run()
+    {
+        $this->getClosure()('Hello');
+    }
+}
+
+?>


### PR DESCRIPTION
https://getrector.org/demo/cd027c68-3b85-4f98-8b9d-5aa3843bb4bd