### PR TITLE
Failing tests for override ChangePackageVersionComposerRector

### DIFF
--- a/rules/composer/tests/Rector/OverrideChangePackageVersionComposerRector/Fixture/override_change_package.json
+++ b/rules/composer/tests/Rector/OverrideChangePackageVersionComposerRector/Fixture/override_change_package.json
@@ -1,0 +1,17 @@
+{
+    "require": {
+        "nette/application": "^2.4",
+        "nette/bootstrap": "^2.4",
+        "nette/neon": "^2.4",
+        "latte/latte": "^2.4"
+    }
+}
+-----
+{
+    "require": {
+        "nette/application": "~3.0.6",
+        "nette/bootstrap": "^3.0",
+        "nette/neon": "^3.0",
+        "latte/latte": "~2.8.3"
+    }
+}

--- a/rules/composer/tests/Rector/OverrideChangePackageVersionComposerRector/OverrideImportChangePackageVersionComposerRectorTest.php
+++ b/rules/composer/tests/Rector/OverrideChangePackageVersionComposerRector/OverrideImportChangePackageVersionComposerRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Composer\Tests\Rector\OverrideChangePackageVersionComposerRector;
+
+use Iterator;
+use Rector\Composer\Tests\Rector\AbstractComposerRectorTestCase;
+use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class OverrideImportChangePackageVersionComposerRectorTest extends AbstractComposerRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    public function provideData(): Iterator
+    {
+        return StaticFixtureFinder::yieldDirectory(__DIR__ . '/Fixture', '*.json');
+    }
+
+    public function provideConfigFile(): string
+    {
+        return __DIR__ . '/config/override_import.php';
+    }
+}

--- a/rules/composer/tests/Rector/OverrideChangePackageVersionComposerRector/OverrideSetListChangePackageVersionComposerRectorTest.php
+++ b/rules/composer/tests/Rector/OverrideChangePackageVersionComposerRector/OverrideSetListChangePackageVersionComposerRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Composer\Tests\Rector\OverrideChangePackageVersionComposerRector;
+
+use Iterator;
+use Rector\Composer\Tests\Rector\AbstractComposerRectorTestCase;
+use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class OverrideSetListChangePackageVersionComposerRectorTest extends AbstractComposerRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    public function provideData(): Iterator
+    {
+        return StaticFixtureFinder::yieldDirectory(__DIR__ . '/Fixture', '*.json');
+    }
+
+    public function provideConfigFile(): string
+    {
+        return __DIR__ . '/config/override_setlist.php';
+    }
+}

--- a/rules/composer/tests/Rector/OverrideChangePackageVersionComposerRector/config/override_import.php
+++ b/rules/composer/tests/Rector/OverrideChangePackageVersionComposerRector/config/override_import.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Composer\Rector\ChangePackageVersionComposerRector;
+use Rector\Composer\ValueObject\PackageAndVersion;
+use Rector\Set\ValueObject\SetList;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\SymfonyPhpConfig\ValueObjectInliner;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(SetList::NETTE_30);
+
+    $services = $containerConfigurator->services();
+    $services->set(ChangePackageVersionComposerRector::class)
+        ->call('configure', [[
+            ChangePackageVersionComposerRector::PACKAGES_AND_VERSIONS => ValueObjectInliner::inline([
+                new PackageAndVersion('nette/application', '~3.0.6'),
+                new PackageAndVersion('latte/latte', '~2.8.3'),
+            ]),
+        ]]);
+};

--- a/rules/composer/tests/Rector/OverrideChangePackageVersionComposerRector/config/override_setlist.php
+++ b/rules/composer/tests/Rector/OverrideChangePackageVersionComposerRector/config/override_setlist.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Composer\Rector\ChangePackageVersionComposerRector;
+use Rector\Composer\ValueObject\PackageAndVersion;
+use Rector\Core\Configuration\Option;
+use Rector\Set\ValueObject\SetList;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\SymfonyPhpConfig\ValueObjectInliner;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::SETS, [
+        SetList::NETTE_30,
+    ]);
+
+    $services = $containerConfigurator->services();
+    $services->set(ChangePackageVersionComposerRector::class)
+        ->call('configure', [[
+            ChangePackageVersionComposerRector::PACKAGES_AND_VERSIONS => ValueObjectInliner::inline([
+                new PackageAndVersion('nette/application', '~3.0.6'),
+                new PackageAndVersion('latte/latte', '~2.8.3'),
+            ]),
+        ]]);
+};


### PR DESCRIPTION
Based on discussion in https://github.com/rectorphp/rector/pull/5523

I've created two test cases for override part of configuration of ChangePackageVersionComposerRector:
1) using NETTE_30 as set
2) using NETTE_30 as import

For both I am trying to override nette/application and latte/latte versions.

With 1) it seems SET is not used at all for some reason. But in real application it is used and behave some as 2): "local" configuration is executed first so it is then overriden by imports

