### PR TITLE
[TypedPropertyFromStrictConstructorRector] Keep var tag when it defines iterable type

### DIFF
--- a/rules/type-declaration/tests/Rector/Property/TypedPropertyFromStrictConstructorRector/Fixture/iterable_namespaced_interface_var_tag.php.inc
+++ b/rules/type-declaration/tests/Rector/Property/TypedPropertyFromStrictConstructorRector/Fixture/iterable_namespaced_interface_var_tag.php.inc
@@ -4,7 +4,7 @@ namespace Rector\TypeDeclaration\Tests\Rector\Property\TypedPropertyFromStrictCo
 
 interface ApiInterface {}
 
-class KeepVarTagWhenIterable
+class IterableNamespacedInterfaceVarTag
 {
     /**
      * @var iterable|ApiInterface[]
@@ -24,7 +24,7 @@ namespace Rector\TypeDeclaration\Tests\Rector\Property\TypedPropertyFromStrictCo
 
 interface ApiInterface {}
 
-class KeepVarTagWhenIterable
+class IterableNamespacedInterfaceVarTag
 {
     /**
      * @var iterable|ApiInterface[]

--- a/rules/type-declaration/tests/Rector/Property/TypedPropertyFromStrictConstructorRector/Fixture/keep_var_tag_when_iterable.php.inc
+++ b/rules/type-declaration/tests/Rector/Property/TypedPropertyFromStrictConstructorRector/Fixture/keep_var_tag_when_iterable.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\TypeDeclaration\Tests\Rector\Property\TypedPropertyFromStrictConstructorRector\Fixture;
+
+interface ApiInterface {}
+
+class KeepVarTagWhenIterable
+{
+    /**
+     * @var iterable|ApiInterface[]
+     */
+    private $collection;
+
+    public function __construct(iterable $collection)
+    {
+        $this->collection = $collection;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\TypeDeclaration\Tests\Rector\Property\TypedPropertyFromStrictConstructorRector\Fixture;
+
+interface ApiInterface {}
+
+class KeepVarTagWhenIterable
+{
+    /**
+     * @var iterable|ApiInterface[]
+     */
+    private iterable $collection;
+
+    public function __construct(iterable $collection)
+    {
+        $this->collection = $collection;
+    }
+}
+?>


### PR DESCRIPTION
# Failing Test for TypedPropertyFromStrictConstructorRector

Based on https://getrector.org/demo/96c31357-6d0e-4f31-ac9a-2df5828efed9

It's not nice that Rector removes the iterable type definition as that will cause PHPStan to complain about it.

Turns out this only happens inside a namespace 🤔 

If the type is there, leave it. Same for array I think.