### PR TITLE
Use require string argument in constructor rule

### DIFF
--- a/rules/nette-to-symfony/src/NodeFactory/ActionWithFormProcessClassMethodFactory.php
+++ b/rules/nette-to-symfony/src/NodeFactory/ActionWithFormProcessClassMethodFactory.php
@@ -37,7 +37,7 @@ final class ActionWithFormProcessClassMethodFactory
         $classMethod->params[] = new Param($requestVariable, null, new FullyQualified(
             'Symfony\Component\HttpFoundation\Request'
         ));
-        $classMethod->returnType = new FullyQualified(Response::class);
+        $classMethod->returnType = new FullyQualified('Symfony\Component\HttpFoundation\Response');
 
         $formVariable = new Variable('form');
 

--- a/rules/nette-to-symfony/src/Rector/Class_/NetteControlToSymfonyControllerRector.php
+++ b/rules/nette-to-symfony/src/Rector/Class_/NetteControlToSymfonyControllerRector.php
@@ -148,7 +148,7 @@ CODE_SAMPLE
         $classMethod->stmts[] = $return;
 
         if ($this->isAtLeastPhpVersion(PhpVersionFeature::SCALAR_TYPES)) {
-            $classMethod->returnType = new FullyQualified(Response::class);
+            $classMethod->returnType = new FullyQualified('Symfony\Component\HttpFoundation\Response');
         }
 
         $this->removeNodes($classMethodRender->getNodesToRemove());

--- a/utils/doctrine-annotation-parser-syncer/src/Rector/Assign/AssignNewDocParserRector.php
+++ b/utils/doctrine-annotation-parser-syncer/src/Rector/Assign/AssignNewDocParserRector.php
@@ -38,7 +38,7 @@ final class AssignNewDocParserRector extends AbstractRector implements ClassSync
             return null;
         }
 
-        $node->expr = new New_(new FullyQualified(ConstantPreservingDocParser::class));
+        $node->expr = new New_(new FullyQualified('Rector\DoctrineAnnotationGenerated\ConstantPreservingDocParser'));
 
         return $node;
     }

--- a/utils/doctrine-annotation-parser-syncer/src/Rector/ClassMethod/ChangeOriginalTypeToCustomRector.php
+++ b/utils/doctrine-annotation-parser-syncer/src/Rector/ClassMethod/ChangeOriginalTypeToCustomRector.php
@@ -39,7 +39,7 @@ final class ChangeOriginalTypeToCustomRector extends AbstractRector implements C
         }
 
         $firstParam = $node->params[0];
-        $firstParam->type = new FullyQualified(ConstantPreservingDocParser::class);
+        $firstParam->type = new FullyQualified('Rector\DoctrineAnnotationGenerated\ConstantPreservingDocParser');
 
         return $node;
     }

--- a/utils/doctrine-annotation-parser-syncer/src/Rector/ClassMethod/LogIdentifierAndResolverValueInConstantClassMethodRector.php
+++ b/utils/doctrine-annotation-parser-syncer/src/Rector/ClassMethod/LogIdentifierAndResolverValueInConstantClassMethodRector.php
@@ -131,7 +131,7 @@ CODE_SAMPLE
     private function createStaticCallExpression(Variable $identifierVariable, Variable $resolvedVariable): Expression
     {
         $args = [new Arg($identifierVariable), new Arg($resolvedVariable)];
-        $staticCall = new StaticCall(new FullyQualified(ResolvedConstantStaticCollector::class), 'collect', $args);
+        $staticCall = new StaticCall(new FullyQualified('Rector\DoctrineAnnotationGenerated\DataCollector\ResolvedConstantStaticCollector'), 'collect', $args);
 
         return new Expression($staticCall);
     }

--- a/utils/phpstan-extensions/config/rector-rules.neon
+++ b/utils/phpstan-extensions/config/rector-rules.neon
@@ -139,6 +139,14 @@ services:
                 Rector\Core\Rector\AbstractRector:
                     isObjectType: [1]
 
+    # this rule prevents bug in phar like these: https://github.com/rectorphp/rector/issues/5596
+    -
+        class: Symplify\PHPStanRules\Rules\RequireStringArgumentInConstructorRule
+        tags: [phpstan.rules.rule]
+        arguments:
+            stringArgPositionsByType:
+                PhpParser\Node\Name\FullyQualified: [0]
+
     -
         class: Symplify\PHPStanRules\Rules\ClassNameRespectsParentSuffixRule
         tags: [phpstan.rules.rule]

--- a/utils/phpstan-extensions/config/rector-rules.neon
+++ b/utils/phpstan-extensions/config/rector-rules.neon
@@ -135,7 +135,7 @@ services:
         class: Symplify\PHPStanRules\Rules\RequireStringArgumentInMethodCallRule
         tags: [phpstan.rules.rule]
         arguments:
-            stringArgByMethodByType:
+            stringArgPositionByMethodByType:
                 Rector\Core\Rector\AbstractRector:
                     isObjectType: [1]
 


### PR DESCRIPTION
Waiting on new tagged release for Symplify PHPStan Rules now that https://github.com/symplify/symplify/pull/2968 is merged.

This PR is a reminder for that. 

It should prevent #5596 from happening again.