### PR TITLE
[Coverage] Add --testdox to phpunit command on weekly code coverage generation

### DIFF
--- a/.github/workflows/weekly_code_coverage.yaml
+++ b/.github/workflows/weekly_code_coverage.yaml
@@ -16,10 +16,10 @@ jobs:
                         run: |
                             composer require --dev nimut/phpunit-merger
 
-                            vendor/bin/phpunit --coverage-php build/logs/rules.cov rules
-                            vendor/bin/phpunit --coverage-php build/logs/packages.cov packages
-                            vendor/bin/phpunit --coverage-php build/logs/tests.cov tests
-                            vendor/bin/phpunit --coverage-php build/logs/utils.cov utils
+                            vendor/bin/phpunit --coverage-php build/logs/rules.cov rules --testdox
+                            vendor/bin/phpunit --coverage-php build/logs/packages.cov packages --testdox
+                            vendor/bin/phpunit --coverage-php build/logs/tests.cov tests --testdox
+                            vendor/bin/phpunit --coverage-php build/logs/utils.cov utils --testdox
 
                             vendor/bin/phpunit-merger coverage build/logs clover.xml
 

--- a/packages/node-type-resolver/src/NodeTypeCorrector/GenericClassStringTypeCorrector.php
+++ b/packages/node-type-resolver/src/NodeTypeCorrector/GenericClassStringTypeCorrector.php
@@ -26,7 +26,7 @@ final class GenericClassStringTypeCorrector
     public function correct(Type $mainType): Type
     {
         // inspired from https://github.com/phpstan/phpstan-src/blob/94e3443b2d21404a821e05b901dd4b57fcbd4e7f/src/Type/Generic/TemplateTypeHelper.php#L18
-        return TypeTraverser::map($mainType, function (Type $type, callable $traverse) {
+        return TypeTraverser::map($mainType, function (Type $type, callable $traverse): Type {
             if (! $type instanceof ConstantStringType) {
                 return $traverse($type);
             }

--- a/rules/type-declaration/src/TypeInferer/ParamTypeInferer/PHPUnitDataProviderParamTypeInferer.php
+++ b/rules/type-declaration/src/TypeInferer/ParamTypeInferer/PHPUnitDataProviderParamTypeInferer.php
@@ -130,9 +130,7 @@ final class PHPUnitDataProviderParamTypeInferer implements ParamTypeInfererInter
             return new MixedType();
         }
 
-        $p = $this->typeFactory->createMixedPassedOrUnionType($paramOnPositionTypes);
-
-        return $p;
+        return $this->typeFactory->createMixedPassedOrUnionType($paramOnPositionTypes);
     }
 
     private function getTypeFromClassMethodReturn(Array_ $classMethodReturnArrayNode): Type


### PR DESCRIPTION
Last week, there is unknown error on phpunit generation:

![Screen Shot 2021-02-20 at 21 15 19](https://user-images.githubusercontent.com/459648/108598548-c6bb2280-73c0-11eb-8d1d-35872d7aec19.png)

I added `--testdox` to know the nearest source of error when coverage regenerated tomorrow if happen again.