### PR TITLE
[Bin] Handle possible PHPStan Stubs runtime locations

### DIFF
--- a/bin/rector
+++ b/bin/rector
@@ -9,9 +9,9 @@
  */
 (static function () {
     $vendorPaths = [
-        realpath(__DIR__ . '/../vendor'),          // on bin/
-        realpath(__DIR__ . '/../../vendor'),       // on vendor/rector/bin/
-        realpath(__DIR__ . '/../../../../vendor'), // on vendor/rector/rector/bin/
+        realpath(__DIR__ . '/../vendor'),          // bin/rector
+        realpath(__DIR__ . '/../../../../vendor'), // vendor/rector/rector/bin/rector
+        realpath(__DIR__ . '/../../vendor'),       // vendor/bin/rector , it may be a symlink of vendor/rector/rector/bin/rector
     ];
 
     $areStubsFound = static function (string $vendorPath) : bool {

--- a/bin/rector
+++ b/bin/rector
@@ -1,43 +1,4 @@
 #!/usr/bin/env php
 <?php
 
-/**
- * @see https://github.com/phpstan/phpstan/issues/4541#issuecomment-779434916
- *
- * Point possible vendor locations by use the __DIR__ as start to locate
- * @see https://github.com/rectorphp/rector/pull/5581 that may not detected in https://getrector.org/ which uses docker to run
- */
-(static function () {
-    $vendorPaths = [
-        realpath(__DIR__ . '/../vendor'),          // bin/rector
-        realpath(__DIR__ . '/../../../../vendor'), // vendor/rector/rector/bin/rector
-        realpath(__DIR__ . '/../../vendor'),       // vendor/bin/rector , it may be a symlink of vendor/rector/rector/bin/rector
-        'vendor',                                  // last fallback of existing behaviour
-    ];
-
-    $areStubsFound = static function (string $vendorPath) : bool {
-        if (! file_exists("phar://$vendorPath/phpstan/phpstan/phpstan.phar/stubs/runtime/ReflectionUnionType.php")) {
-            return false;
-        }
-
-        return file_exists("phar://$vendorPath/phpstan/phpstan/phpstan.phar/stubs/runtime/Attribute.php");
-    };
-
-    foreach ($vendorPaths as $vendorPath) {
-        if (! $vendorPath) {
-            continue;
-        }
-
-        if (! $areStubsFound($vendorPath)) {
-            continue;
-        }
-
-        require_once "phar://$vendorPath/phpstan/phpstan/phpstan.phar/stubs/runtime/ReflectionUnionType.php";
-        require_once "phar://$vendorPath/phpstan/phpstan/phpstan.phar/stubs/runtime/Attribute.php";
-
-        // already loaded? stop loop
-        break;
-    }
-})();
-
 require_once __DIR__ . '/rector.php';

--- a/bin/rector
+++ b/bin/rector
@@ -9,8 +9,9 @@
  */
 (static function () {
     $vendorPaths = [
-        realpath(__DIR__ . '/../vendor'),
-        realpath(__DIR__ . '/../../vendor'),
+        realpath(__DIR__ . '/../vendor'),          // on bin/
+        realpath(__DIR__ . '/../../vendor'),       // on vendor/rector/bin/
+        realpath(__DIR__ . '/../../../../vendor'), // on vendor/rector/rector/bin/
     ];
 
     $areStubsFound = static function (string $vendorPath) : bool {

--- a/bin/rector
+++ b/bin/rector
@@ -1,14 +1,41 @@
 #!/usr/bin/env php
 <?php
 
-// @see https://github.com/phpstan/phpstan/issues/4541#issuecomment-779434916
-if (
-    file_exists('phar://vendor/phpstan/phpstan/phpstan.phar/stubs/runtime/ReflectionUnionType.php')
-    &&
-    file_exists('phar://vendor/phpstan/phpstan/phpstan.phar/stubs/runtime/Attribute.php')
-) {
-    require_once 'phar://vendor/phpstan/phpstan/phpstan.phar/stubs/runtime/ReflectionUnionType.php';
-    require_once 'phar://vendor/phpstan/phpstan/phpstan.phar/stubs/runtime/Attribute.php';
-}
+/**
+ * @see https://github.com/phpstan/phpstan/issues/4541#issuecomment-779434916
+ *
+ * Point possible vendor locations by use the __DIR__ as start to locate
+ * @see https://github.com/rectorphp/rector/pull/5581 that may not detected in https://getrector.org/ which uses docker to run
+ */
+(static function () {
+    $vendorPaths = [
+        realpath(__DIR__ . '/../vendor'),
+        realpath(__DIR__ . '/../../vendor'),
+    ];
+
+    $areStubsFound = static function (string $vendorPath) : bool {
+        if (! file_exists("phar://$vendorPath/phpstan/phpstan/phpstan.phar/stubs/runtime/ReflectionUnionType.php")) {
+            return false;
+        }
+
+        return file_exists("phar://$vendorPath/phpstan/phpstan/phpstan.phar/stubs/runtime/Attribute.php");
+    };
+
+    foreach ($vendorPaths as $vendorPath) {
+        if (! $vendorPath) {
+            continue;
+        }
+
+        if (! $areStubsFound($vendorPath)) {
+            continue;
+        }
+
+        require_once "phar://$vendorPath/phpstan/phpstan/phpstan.phar/stubs/runtime/ReflectionUnionType.php";
+        require_once "phar://$vendorPath/phpstan/phpstan/phpstan.phar/stubs/runtime/Attribute.php";
+
+        // already loaded? stop loop
+        break;
+    }
+})();
 
 require_once __DIR__ . '/rector.php';

--- a/bin/rector
+++ b/bin/rector
@@ -12,6 +12,7 @@
         realpath(__DIR__ . '/../vendor'),          // bin/rector
         realpath(__DIR__ . '/../../../../vendor'), // vendor/rector/rector/bin/rector
         realpath(__DIR__ . '/../../vendor'),       // vendor/bin/rector , it may be a symlink of vendor/rector/rector/bin/rector
+        'vendor',
     ];
 
     $areStubsFound = static function (string $vendorPath) : bool {

--- a/bin/rector
+++ b/bin/rector
@@ -12,7 +12,7 @@
         realpath(__DIR__ . '/../vendor'),          // bin/rector
         realpath(__DIR__ . '/../../../../vendor'), // vendor/rector/rector/bin/rector
         realpath(__DIR__ . '/../../vendor'),       // vendor/bin/rector , it may be a symlink of vendor/rector/rector/bin/rector
-        'vendor',
+        'vendor',                                  // last fallback of existing behaviour
     ];
 
     $areStubsFound = static function (string $vendorPath) : bool {

--- a/ci/downgrade/configuration.php
+++ b/ci/downgrade/configuration.php
@@ -2,9 +2,10 @@
 
 declare(strict_types=1);
 
-// @see https://github.com/phpstan/phpstan/issues/4541
-require_once 'phar://vendor/phpstan/phpstan/phpstan.phar/stubs/runtime/ReflectionUnionType.php';
-require_once 'phar://vendor/phpstan/phpstan/phpstan.phar/stubs/runtime/Attribute.php';
+use Rector\Core\Stubs\PHPStanStubLoader;
+
+$phpStanStubLoader = new PHPStanStubLoader();
+$phpStanStubLoader->loadStubs();
 
 /**
  * Configuration consts for the different rector.php config files

--- a/src/DependencyInjection/RectorContainerFactory.php
+++ b/src/DependencyInjection/RectorContainerFactory.php
@@ -8,6 +8,7 @@ use Psr\Container\ContainerInterface;
 use Rector\Caching\Detector\ChangedFilesDetector;
 use Rector\Core\Configuration\Configuration;
 use Rector\Core\HttpKernel\RectorKernel;
+use Rector\Core\Stubs\PHPStanStubLoader;
 use Rector\Core\Stubs\StubLoader;
 use Rector\Core\ValueObject\Bootstrap\BootstrapConfigs;
 use Symplify\PackageBuilder\Console\Input\StaticInputDetector;
@@ -34,6 +35,9 @@ final class RectorContainerFactory
 
         $stubLoader = new StubLoader();
         $stubLoader->loadStubs();
+
+        $phpStanStubLoader = new PHPStanStubLoader();
+        $phpStanStubLoader->loadStubs();
 
         $rectorKernel->boot();
 

--- a/src/Stubs/PHPStanStubLoader.php
+++ b/src/Stubs/PHPStanStubLoader.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\Stubs;
+
+final class PHPStanStubLoader
+{
+    /**
+     * @var bool
+     */
+    private $areStubsLoaded = false;
+
+    /**
+     * @var string[]
+     */
+    private const STUBS = [
+        'ReflectionUnionType.php',
+        'Attribute.php',
+    ];
+
+    /**
+     * @see https://github.com/phpstan/phpstan/issues/4541#issuecomment-779434916
+     *
+     * Point possible vendor locations by use the __DIR__ as start to locate
+     * @see https://github.com/rectorphp/rector/pull/5581 that may not detected in https://getrector.org/ which uses docker to run
+     */
+    public function loadStubs(): void
+    {
+        if ($this->areStubsLoaded) {
+            return;
+        }
+
+        $vendorPaths = [
+            'vendor',
+            realpath(__DIR__ . '/../../vendor'),
+            realpath(__DIR__ . '/../../../../../vendor'),
+        ];
+
+        foreach ($vendorPaths as $vendorPath) {
+            if (! $vendorPath) {
+                continue;
+            }
+
+            foreach (self::STUBS as $stub) {
+                if (! file_exists(sprintf('phar://%s/phpstan/phpstan/phpstan.phar/stubs/runtime/%s', $vendorPath, $stub))) {
+                    continue 2;
+                }
+
+                require_once sprintf('phar://%s/phpstan/phpstan/phpstan.phar/stubs/runtime/%s', $vendorPath, $stub);
+            }
+
+            $this->areStubsLoaded = true;
+
+            // already loaded? stop loop
+            break;
+        }
+    }
+}

--- a/src/Stubs/PHPStanStubLoader.php
+++ b/src/Stubs/PHPStanStubLoader.php
@@ -23,9 +23,12 @@ final class PHPStanStubLoader
      * @var string[]
      */
     private const VENDOR_PATHS = [
+        // 1. relative path with composer require rector/rector and run vendor/bin/rector
         'vendor',
+        // 2. relative path with composer require rector/rector with symlink run vendor/bin/rector
         __DIR__ . '/../../vendor',
-        __DIR__ . '/../../../../../vendor', // vendor/rector/rector/bin/rector
+        // 3. run outside project like in https://getrector.org/ from docker, so it look up // vendor/rector/rector/bin/rector
+        __DIR__ . '/../../../../../vendor',
     ];
 
     /**

--- a/src/Stubs/PHPStanStubLoader.php
+++ b/src/Stubs/PHPStanStubLoader.php
@@ -20,6 +20,15 @@ final class PHPStanStubLoader
     ];
 
     /**
+     * @var string[]
+     */
+    private const VENDOR_PATHS = [
+        'vendor',
+        __DIR__ . '/../../vendor',
+        __DIR__ . '/../../../../../vendor',
+    ];
+
+    /**
      * @see https://github.com/phpstan/phpstan/issues/4541#issuecomment-779434916
      *
      * Point possible vendor locations by use the __DIR__ as start to locate
@@ -31,13 +40,8 @@ final class PHPStanStubLoader
             return;
         }
 
-        $vendorPaths = [
-            'vendor',
-            realpath(__DIR__ . '/../../vendor'),
-            realpath(__DIR__ . '/../../../../../vendor'),
-        ];
-
-        foreach ($vendorPaths as $vendorPath) {
+        foreach (self::VENDOR_PATHS as $vendorPath) {
+            $vendorPath = realpath($vendorPath);
             if (! $vendorPath) {
                 continue;
             }

--- a/src/Stubs/PHPStanStubLoader.php
+++ b/src/Stubs/PHPStanStubLoader.php
@@ -47,11 +47,14 @@ final class PHPStanStubLoader
             }
 
             foreach (self::STUBS as $stub) {
-                if (! file_exists(sprintf('phar://%s/phpstan/phpstan/phpstan.phar/stubs/runtime/%s', $vendorPath, $stub))) {
+                $path     = sprintf('phar://%s/phpstan/phpstan/phpstan.phar/stubs/runtime/%s', $vendorPath, $stub);
+                $isExists = file_exists($path);
+
+                if (! $isExists) {
                     continue 2;
                 }
 
-                require_once sprintf('phar://%s/phpstan/phpstan/phpstan.phar/stubs/runtime/%s', $vendorPath, $stub);
+                require_once $path;
             }
 
             $this->areStubsLoaded = true;

--- a/src/Stubs/PHPStanStubLoader.php
+++ b/src/Stubs/PHPStanStubLoader.php
@@ -25,7 +25,7 @@ final class PHPStanStubLoader
     private const VENDOR_PATHS = [
         'vendor',
         __DIR__ . '/../../vendor',
-        __DIR__ . '/../../../../../vendor',
+        __DIR__ . '/../../../../../vendor', // vendor/rector/rector/bin/rector
     ];
 
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,14 +2,11 @@
 
 declare(strict_types=1);
 
+use Rector\Core\Stubs\PHPStanStubLoader;
 use Rector\Core\Stubs\StubLoader;
 use Tracy\Debugger;
 
 require_once __DIR__ . '/../vendor/autoload.php';
-
-// @see https://github.com/phpstan/phpstan/issues/4541#issuecomment-779434916
-require_once 'phar://vendor/phpstan/phpstan/phpstan.phar/stubs/runtime/ReflectionUnionType.php';
-require_once 'phar://vendor/phpstan/phpstan/phpstan.phar/stubs/runtime/Attribute.php';
 
 // silent deprecations, since we test them
 error_reporting(E_ALL ^ E_DEPRECATED);
@@ -20,6 +17,9 @@ gc_disable();
 // load stubs
 $stubLoader = new StubLoader();
 $stubLoader->loadStubs();
+
+$phpStanStubLoader = new PHPStanStubLoader();
+$phpStanStubLoader->loadStubs();
 
 // make dump() useful and not nest infinity spam
 Debugger::$maxDepth = 2;


### PR DESCRIPTION
Point possible vendor locations by use the` __DIR__` as start to locate
Like in https://github.com/rectorphp/rector/pull/5581 that may not detected in https://getrector.org/ which uses docker to run
