### PR TITLE
[RenameMethodRector] Failing test

### DIFF
--- a/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/Fixture/skip_when_interface_and_wildcard.php.inc
+++ b/rules/renaming/tests/Rector/MethodCall/RenameMethodRector/Fixture/skip_when_interface_and_wildcard.php.inc
@@ -2,12 +2,65 @@
 
 namespace Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture;
 
-interface WildcardSubscriberInterface
+// This one does not implement an interface
+// But it does match `*WildcardSubscriber`
+final class OtherWildcardSubscriber
+{
+    public function old()
+    {
+        return 5;
+    }
+}
+
+// Interface also matches the wildcard `*WildcardSubscriber`
+interface WildcardSubscriber
 {
     public function old();
 }
 
-final class SomeWildcardSubscriber implements WildcardSubscriberInterface
+// This one does match `*WildcardSubscriber` too, but DOES implement the interface
+// It should not replace this one
+final class SomeWildcardSubscriber implements WildcardSubscriber
+{
+    public function old()
+    {
+        return 5;
+    }
+}
+
+final class SomeWildcardCaller
+{
+    public static function execute()
+    {
+        $demo = new SomeWildcardSubscriber();
+        $demo->old();
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Renaming\Tests\Rector\MethodCall\RenameMethodRector\Fixture;
+
+// This one does not implement an interface
+// But it does match `*WildcardSubscriber`
+final class OtherWildcardSubscriber
+{
+    public function new()
+    {
+        return 5;
+    }
+}
+
+// Interface also matches the wildcard `*WildcardSubscriber`
+interface WildcardSubscriber
+{
+    public function old();
+}
+
+// This one does match `*WildcardSubscriber` too, but DOES implement the interface
+// It should not replace this one
+final class SomeWildcardSubscriber implements WildcardSubscriber
 {
     public function old()
     {


### PR DESCRIPTION
I realized that I did not provide the test case in #5564 correctly as I was running it in my project.

By changing the existing test it fails again.

Why? Because `interface WildcardSubscriber` matches the config.

#5622  only partially fixed the problem. It should also check if `$methodCallRename->getOldClass()` is an interface, and skip that too.

/cc @samsonasik