### PR TITLE
[EarlyReturn] Skip ReturnAfterToEarlyOnBreakRector on non-linear previous assignment before foreach

### DIFF
--- a/rules/early-return/src/Rector/Foreach_/ReturnAfterToEarlyOnBreakRector.php
+++ b/rules/early-return/src/Rector/Foreach_/ReturnAfterToEarlyOnBreakRector.php
@@ -132,24 +132,24 @@ CODE_SAMPLE
      * @param Break_[] $breaks
      */
     private function processEarlyReturn(
-        Expression $beforeBreak,
+        Expression $expression,
         Assign $assign,
         array $breaks,
-        Return_ $nextForeach,
+        Return_ $return,
         Assign $assignPreviousVariable,
-        Foreach_ $node
+        Foreach_ $foreach
     ): Foreach_ {
-        $this->removeNode($beforeBreak);
+        $this->removeNode($expression);
         $this->addNodeBeforeNode(new Return_($assign->expr), $breaks[0]);
         $this->removeNode($breaks[0]);
 
-        $nextForeach->expr = $assignPreviousVariable->expr;
+        $return->expr = $assignPreviousVariable->expr;
         $this->removeNode($assignPreviousVariable);
 
-        return $node;
+        return $foreach;
     }
 
-    private function shouldSkip(Return_ $return, ?Expr $expr = null, Foreach_ $node, Expr $assignVariable): bool
+    private function shouldSkip(Return_ $return, ?Expr $expr = null, Foreach_ $foreach, Expr $assignVariable): bool
     {
         if (! $expr instanceof Expr) {
             return true;
@@ -160,16 +160,11 @@ CODE_SAMPLE
         }
 
         // ensure the variable only used once in foreach
-        $usedVariable = $this->betterNodeFinder->find($node->stmts, function (Node $node) use (
+        $usedVariable = $this->betterNodeFinder->find($foreach->stmts, function (Node $node) use (
             $assignVariable
         ): bool {
             return $this->nodeComparator->areNodesEqual($node, $assignVariable);
         });
-
-        if (count($usedVariable) > 1) {
-            return true;
-        }
-
-        return false;
+        return count($usedVariable) > 1;
     }
 }

--- a/rules/early-return/src/Rector/Foreach_/ReturnAfterToEarlyOnBreakRector.php
+++ b/rules/early-return/src/Rector/Foreach_/ReturnAfterToEarlyOnBreakRector.php
@@ -130,6 +130,11 @@ CODE_SAMPLE
             return null;
         }
 
+        $nextParent = $parent->getAttribute(AttributeKey::NEXT_NODE);
+        if ($nextParent !== $node) {
+            return null;
+        }
+
         $this->removeNode($beforeBreak);
         $this->addNodeBeforeNode(new Return_($assign->expr), $breaks[0]);
         $this->removeNode($breaks[0]);

--- a/rules/early-return/tests/Rector/Foreach_/ReturnAfterToEarlyOnBreakRector/Fixture/skip_prev_assign_not_linear_expression.php.inc
+++ b/rules/early-return/tests/Rector/Foreach_/ReturnAfterToEarlyOnBreakRector/Fixture/skip_prev_assign_not_linear_expression.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\EarlyReturn\Tests\Rector\Foreach_\ReturnAfterToEarlyOnBreakRector\Fixture;
+
+class SkipPrevAssignNotLinearExpression
+{
+    public function run(array $pathConstants, string $dirPath, string $allowedPath)
+    {
+        if (rand(0, 1)) {
+            $pathOK = false;
+        }
+
+        foreach ($pathConstants as $allowedPath) {
+            if ($dirPath == $allowedPath) {
+                $pathOK = true;
+                break;
+            }
+        }
+
+        return $pathOK;
+    }
+}
+
+?>


### PR DESCRIPTION
It handle for example, previous foreach has assignment, but inside if, not directly.