### PR TITLE
Build "scoped" Docker images in GitHub Actions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+*~ 
 .DS_Store
 .idea/
 
@@ -26,3 +27,7 @@ docker-compose.dist.yml
 
 /vendor
 /docs
+/rector-nested/
+/rector-scoped/
+
+*.phar

--- a/.github/workflows/publish_docker_images.yaml
+++ b/.github/workflows/publish_docker_images.yaml
@@ -36,6 +36,7 @@ jobs:
 
                   docker buildx create --name builder-php${{ matrix.php-version }} --use
                   docker buildx build \
+                        --progress plain \
                         --cache-from=$GITHUB_REPOSITORY:build-cache-php${{ matrix.php-version }} \
                         --cache-to=type=registry,ref=$GITHUB_REPOSITORY:build-cache-php${{ matrix.php-version }},mode=max,push=true \
                         --target rector \
@@ -44,6 +45,7 @@ jobs:
                         --build-arg PHP_VERSION=${{ matrix.php-version }} .
 
                   docker buildx build \
+                        --progress plain \
                         --cache-from=$GITHUB_REPOSITORY:build-cache-php${{ matrix.php-version }} \
                         --cache-to=type=registry,ref=$GITHUB_REPOSITORY:build-cache-php${{ matrix.php-version }},mode=max,push=true \
                         --target rector-secured \

--- a/.github/workflows/publish_docker_images.yaml
+++ b/.github/workflows/publish_docker_images.yaml
@@ -21,7 +21,6 @@ jobs:
             - name: Log into container registries
               run: |
                   echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-                  echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
 
             - name: Build images
               run: |
@@ -36,8 +35,8 @@ jobs:
 
                   docker buildx create --name builder-php${{ matrix.php-version }} --use
                   docker buildx build \
-                        --cache-from=ghcr.io/$GITHUB_REPOSITORY:build-cache-php${{ matrix.php-version }} \
-                        --cache-to=type=registry,ref=ghcr.io/$GITHUB_REPOSITORY:build-cache-php${{ matrix.php-version }},mode=max,push=true \
+                        --cache-from=$GITHUB_REPOSITORY:build-cache-php${{ matrix.php-version }} \
+                        --cache-to=type=registry,ref=$GITHUB_REPOSITORY:build-cache-php${{ matrix.php-version }},mode=max,push=true \
                         --target rector \
                         --push \
                         --tag $GITHUB_REPOSITORY:$VERSION-php${{ matrix.php-version }} \

--- a/.github/workflows/publish_docker_images.yaml
+++ b/.github/workflows/publish_docker_images.yaml
@@ -4,6 +4,7 @@ on:
         # Publish `master` as Docker `latest` image.
         branches:
             - master
+            - experimental-scoped
 
         # Publish `v1.2.3` tags as releases.
         tags:

--- a/.github/workflows/publish_docker_images.yaml
+++ b/.github/workflows/publish_docker_images.yaml
@@ -44,11 +44,13 @@ jobs:
                         --tag $GITHUB_REPOSITORY:$VERSION-php${{ matrix.php-version }} \
                         --build-arg PHP_VERSION=${{ matrix.php-version }} .
 
+            - name: Build Rector "secured"
+              if: matrix.php-version == '8.0'
+              run: |
                   docker buildx build \
                         --progress plain \
                         --cache-from=$GITHUB_REPOSITORY:build-cache-php${{ matrix.php-version }} \
-                        --cache-to=type=registry,ref=$GITHUB_REPOSITORY:build-cache-php${{ matrix.php-version }},mode=max,push=true \
                         --target rector-secured \
                         --push \
-                        --tag $GITHUB_REPOSITORY:$VERSION-php${{ matrix.php-version }}-secured \
+                        --tag $GITHUB_REPOSITORY:secured \
                         --build-arg PHP_VERSION=${{ matrix.php-version }} .

--- a/.github/workflows/publish_docker_images.yaml
+++ b/.github/workflows/publish_docker_images.yaml
@@ -11,9 +11,17 @@ on:
 
 jobs:
     publish_images:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
+        strategy:
+            matrix:
+                php-version: ['7.3', '7.4', '8.0']
         steps:
             - uses: actions/checkout@v2
+
+            - name: Log into container registries
+              run: |
+                  echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+                  echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
 
             - name: Build images
               run: |
@@ -26,14 +34,12 @@ jobs:
                   # Use Docker `latest` tag convention
                   [ "$VERSION" == "master" ] && VERSION=latest
 
-                  docker pull rector/rector || true
-                  docker build . --target rector --cache-from rector/rector --tag rector/rector:$VERSION
-                  docker build . --target rector-secured --cache-from rector/rector --tag rector/rector-secured:$VERSION
-
-            - name: Log into registry
-              run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-
-            - name: Push images
-              run: |
-                  docker push --all-tags rector/rector
-                  docker push --all-tags rector/rector-secured
+                  docker buildx create --name builder-php${{ matrix.php-version }} --use
+                  docker buildx build \
+                        --cache-from=ghcr.io/$GITHUB_REPOSITORY:build-cache-php${{ matrix.php-version }} \
+                        --cache-to=type=registry,ref=ghcr.io/$GITHUB_REPOSITORY:build-cache-php${{ matrix.php-version }},mode=max,push=true \
+                        --target rector \
+                        --push \
+                        --tag $GITHUB_REPOSITORY:$VERSION-php${{ matrix.php-version }} \
+                        --tag $GITHUB_REPOSITORY:latest-php${{ matrix.php-version }} \
+                        --build-arg PHP_VERSION=${{ matrix.php-version }} .

--- a/.github/workflows/publish_docker_images.yaml
+++ b/.github/workflows/publish_docker_images.yaml
@@ -40,5 +40,12 @@ jobs:
                         --target rector \
                         --push \
                         --tag $GITHUB_REPOSITORY:$VERSION-php${{ matrix.php-version }} \
-                        --tag $GITHUB_REPOSITORY:latest-php${{ matrix.php-version }} \
+                        --build-arg PHP_VERSION=${{ matrix.php-version }} .
+
+                  docker buildx build \
+                        --cache-from=$GITHUB_REPOSITORY:build-cache-php${{ matrix.php-version }} \
+                        --cache-to=type=registry,ref=$GITHUB_REPOSITORY:build-cache-php${{ matrix.php-version }},mode=max,push=true \
+                        --target rector-secured \
+                        --push \
+                        --tag $GITHUB_REPOSITORY:$VERSION-php${{ matrix.php-version }}-secured \
                         --build-arg PHP_VERSION=${{ matrix.php-version }} .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,55 +1,74 @@
-FROM php:8.0-cli as rector
-WORKDIR /rector
+ARG PHP_VERSION=8.0
+FROM php:${PHP_VERSION}-cli as base
+
+RUN apt-get update && apt-get install -y \
+    libzip4 \
+    libicu63 \
+    && rm -rf /var/lib/apt/lists/*
+
+FROM base as build
+
+WORKDIR /build
 
 # Install php extensions
 RUN apt-get update && apt-get install -y \
-        git \
-        unzip \
         g++ \
-        libzip-dev \
+        git \
         libicu-dev \
-    && rm -rf /var/lib/apt/lists/* \
+        libzip-dev \
+        unzip \
+        wget \
+        zip \
     && pecl -q install \
         zip \
-    && docker-php-ext-configure \
-        opcache --enable-opcache \
-    && docker-php-ext-enable \
-        zip \
-        opcache \
     && docker-php-ext-configure intl \
-    && docker-php-ext-install intl
+    && docker-php-ext-configure opcache --enable-opcache \
+    && docker-php-ext-install \
+        intl \
+        opcache \
+        zip
 
 COPY --from=composer:2.0.9 /usr/bin/composer /usr/bin/composer
+ENV COMPOSER_ALLOW_SUPERUSER=1 COMPOSER_MEMORY_LIMIT=-1 COMPOSER_NO_INTERACTION=1
 
-ENV COMPOSER_ALLOW_SUPERUSER=1 COMPOSER_MEMORY_LIMIT=-1
-
-# Copy configuration
-COPY .docker/php/opcache.ini /usr/local/etc/php/conf.d/opcache.ini
-
-COPY composer.json composer.json
-COPY stubs stubs
+# Run php-scoper, results go to /scoped
+RUN wget https://github.com/humbug/php-scoper/releases/download/0.14.0/php-scoper.phar -N --no-verbose
 
 # This is to make parsing version possible
 COPY .git .git
 
-RUN composer install --no-dev --optimize-autoloader --prefer-dist \
-    && composer clear-cache
+# First copy composer.json only to leverage the build cache (as long as not git-committing)
+COPY composer.json composer.json
+RUN composer install --no-dev --no-progress --no-autoloader --prefer-dist
 
-RUN mkdir /tmp/opcache
-
+# Add source and generate full autoloader
 COPY . .
+RUN composer dump-autoload --optimize --classmap-authoritative --no-dev
 
-# To warmup opcache a little
-RUN bin/rector list
+RUN rm -f "phpstan-for-rector.neon" \
+    && php -d memory_limit=-1 php-scoper.phar add-prefix bin config packages rules src templates vendor composer.json --output-dir /scoped --config scoper.php \
+    && composer dump-autoload --optimize --classmap-authoritative --no-dev --working-dir /scoped
 
-RUN chmod 777 -R /tmp
+# Build runtime image
+FROM base as rector
 
-ENTRYPOINT [ "rector" ]
+COPY --from=build /usr/local/lib/php /usr/local/lib/php
+COPY --from=build /usr/local/etc/php /usr/local/etc/php
+COPY .docker/php/opcache.ini /usr/local/etc/php/conf.d/opcache.ini
 
 ENV PATH /rector/bin:$PATH
 
+ENTRYPOINT [ "rector" ]
+
 VOLUME ["/project"]
 WORKDIR "/project"
+
+COPY --from=build /scoped /rector
+RUN chmod +x /rector/bin/rector
+
+RUN mkdir -p /tmp/opcache \
+    && /rector/bin/rector list \
+    && chmod 777 -R /tmp
 
 ## Used for getrector.org/demo
 FROM rector as rector-secured


### PR DESCRIPTION
This follows up on #5599, in particular [this comment](https://github.com/rectorphp/rector/pull/5599#issuecomment-784370131).

It will build the "scoped" version of Rector for all pushes to `master` and for all `tags`. Images will be built for PHP 7.3, 7.4 and 8.0, based on the respective official PHP Docker images.

To keep the final images small and clean, this uses a multistage build. To allow for build caching on GitHub Actions and across all stages, the Docker `buildx` builder is used. That allows to push the resulting image and all intermediate layers (cache) separately.

According to [this research](https://dev.to/dtinth/caching-docker-builds-in-github-actions-which-approach-is-the-fastest-a-research-18ei) and the corresponding [POC repo](https://github.com/dtinth/github-actions-docker-layer-caching-poc), keeping build layers directly in the (new) [GitHub Container Registry](http://ghcr.io/) gives the fastest results. However, this happens for the build cache only. The final, "official" images are still pushed to the Docker Hub as previously.

It requires to [enable the GitHub Container Registry ghcr.io](https://docs.github.com/en/packages/guides/enabling-improved-container-support), which is currently in beta, for this repository. Also, a [Personal Access Token has to be created](https://docs.github.com/en/packages/guides/migrating-to-github-container-registry-for-docker-images#authenticating-with-the-container-registry) and setup as a GitHub Action Secret, because the new ghcr.io Registry does not (yet?) integrate with the `GITHUB_TOKEN` provided automatically.

In case you want to see this in action, have a look at the https://github.com/mpdude/rector/tree/scoped-docker-image-test branch, its [action runs](https://github.com/mpdude/rector/actions?query=branch%3Ascoped-docker-image-test) and the [Docker Hub Repo](https://hub.docker.com/r/mpdude/rector/tags?page=1&ordering=last_updated) where the test images have been pushed. From there, you can also pull the resulting images, give them a try or inspect the layers.

TODO:

- [ ] Update documentation on how to choose and run the Docker image 