### PR TITLE
[DeadDocBlock] Skip RemoveUselessReturnTagRector on Generic Type

### DIFF
--- a/rules/dead-doc-block/src/DeadReturnTagValueNodeAnalyzer.php
+++ b/rules/dead-doc-block/src/DeadReturnTagValueNodeAnalyzer.php
@@ -6,6 +6,7 @@ namespace Rector\DeadDocBlock;
 
 use PhpParser\Node\FunctionLike;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
+use Rector\AttributeAwarePhpDoc\Ast\Type\AttributeAwareGenericTypeNode;
 use Rector\NodeTypeResolver\TypeComparator\TypeComparator;
 
 final class DeadReturnTagValueNodeAnalyzer
@@ -30,6 +31,10 @@ final class DeadReturnTagValueNodeAnalyzer
         if (! $this->typeComparator->arePhpParserAndPhpStanPhpDocTypesEqual($returnType, $returnTagValueNode->type,
             $functionLike
         )) {
+            return false;
+        }
+
+        if ($returnTagValueNode->type instanceof AttributeAwareGenericTypeNode) {
             return false;
         }
 

--- a/rules/dead-doc-block/tests/Rector/ClassMethod/RemoveUselessReturnTagRector/Fixture/skip_generic_type.php.inc
+++ b/rules/dead-doc-block/tests/Rector/ClassMethod/RemoveUselessReturnTagRector/Fixture/skip_generic_type.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\DeadDocBlock\Tests\Rector\ClassMethod\RemoveUselessReturnTagRector\Fixture;
+
+use stdClass;
+
+final class SkipGenericType
+{
+    /**
+     * @return iterable<stdClass>
+     */
+    public function run(): iterable
+    {
+        yield new stdClass;
+    }
+}


### PR DESCRIPTION
 Fixes #5674