### PR TITLE
Add failing test fixture for RemoveUselessParamTagRector

### DIFF
--- a/rules/dead-doc-block/tests/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/demo_file.php.inc
+++ b/rules/dead-doc-block/tests/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/demo_file.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\DeadDocBlock\Tests\Rector\ClassMethod\RemoveUselessParamTagRector\Fixture;
+
+final class DemoFile
+{
+    /**
+     * @param iterable<stdClass> $foo
+     */
+    public function run(iterable $foo)
+    {
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\DeadDocBlock\Tests\Rector\ClassMethod\RemoveUselessParamTagRector\Fixture;
+
+final class DemoFile
+{
+    /**
+     * @param iterable<stdClass> $foo
+     */
+    public function run(iterable $foo)
+    {
+    }
+}
+?>

--- a/rules/dead-doc-block/tests/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/demo_file.php.inc
+++ b/rules/dead-doc-block/tests/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/demo_file.php.inc
@@ -25,6 +25,7 @@ final class DemoFile
      */
     public function run(iterable $foo)
     {
+        yield from $foo;
     }
 }
 ?>

--- a/rules/dead-doc-block/tests/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/demo_file.php.inc
+++ b/rules/dead-doc-block/tests/Rector/ClassMethod/RemoveUselessParamTagRector/Fixture/demo_file.php.inc
@@ -9,6 +9,7 @@ final class DemoFile
      */
     public function run(iterable $foo)
     {
+        yield from $foo;
     }
 }
 ?>


### PR DESCRIPTION
# Failing Test for RemoveUselessParamTagRector

Based on https://getrector.org/demo/fa28aacc-8081-4f41-8c64-db0e680434e3

This should be kept, as the utterable type is specified more strict.

Nearly the same as #5674 