### PR TITLE
Add failing test fixture for ChangeOrIfReturnToEarlyReturnRector

### DIFF
--- a/rules/early-return/tests/Rector/If_/ChangeOrIfReturnToEarlyReturnRector/Fixture/rex_formatter.php.inc
+++ b/rules/early-return/tests/Rector/If_/ChangeOrIfReturnToEarlyReturnRector/Fixture/rex_formatter.php.inc
@@ -1,0 +1,33 @@
+<?php
+namespace Rector\EarlyReturn\Tests\Rector\If_\ChangeOrIfReturnToEarlyReturnRector\Fixture;
+
+abstract class rex_formatter
+{
+    private static function getTimestamp($value)
+    {
+        if (is_int($value) || ctype_digit($value)) {
+            return (int) $value;
+        }
+
+        return strtotime($value);
+    }
+}
+?>
+-----
+<?php
+namespace Rector\EarlyReturn\Tests\Rector\If_\ChangeOrIfReturnToEarlyReturnRector\Fixture;
+
+abstract class rex_formatter
+{
+    private static function getTimestamp($value)
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+        if (ctype_digit($value)) {
+            return (int) $value;
+        }
+        return strtotime($value);
+    }
+}
+?>


### PR DESCRIPTION
# Failing Test for ChangeOrIfReturnToEarlyReturnRector

Based on https://getrector.org/demo/ce6c9301-ea30-4f20-a367-adb82b5933f7

got similar cases with `bool`  types

![grafik](https://user-images.githubusercontent.com/120441/109414629-25316380-79b4-11eb-84b5-7a471beaea3e.png)
