### PR TITLE
remove unmatched errors + require string in object types to avoid prefixing of generics objects

### DIFF
--- a/packages/node-name-resolver/src/NodeNameResolver.php
+++ b/packages/node-name-resolver/src/NodeNameResolver.php
@@ -206,7 +206,15 @@ final class NodeNameResolver
             return false;
         }
 
+        if ($node->var instanceof MethodCall) {
+            return false;
+        }
+
         if (! $this->isName($node->var, 'this')) {
+            return false;
+        }
+
+        if ($node->name instanceof Expr) {
             return false;
         }
 

--- a/packages/node-type-resolver/src/TypeAnalyzer/CountableTypeAnalyzer.php
+++ b/packages/node-type-resolver/src/TypeAnalyzer/CountableTypeAnalyzer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\NodeTypeResolver\TypeAnalyzer;
 
-use Countable;
 use PhpParser\Node;
 use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
@@ -55,7 +54,7 @@ final class CountableTypeAnalyzer
     private function isCountableObjectType(Type $type): bool
     {
         $countableObjectTypes = [
-            new ObjectType(Countable::class),
+            new ObjectType('Countable'),
             new ObjectType('SimpleXMLElement'),
             new ObjectType('ResourceBundle'),
         ];

--- a/packages/read-write/src/ReadNodeAnalyzer/PropertyFetchReadNodeAnalyzer.php
+++ b/packages/read-write/src/ReadNodeAnalyzer/PropertyFetchReadNodeAnalyzer.php
@@ -7,9 +7,26 @@ namespace Rector\ReadWrite\ReadNodeAnalyzer;
 use PhpParser\Node;
 use PhpParser\Node\Expr\PropertyFetch;
 use Rector\ReadWrite\Contract\ReadNodeAnalyzerInterface;
+use Rector\ReadWrite\NodeFinder\NodeUsageFinder;
 
-final class PropertyFetchReadNodeAnalyzer extends AbstractReadNodeAnalyzer implements ReadNodeAnalyzerInterface
+final class PropertyFetchReadNodeAnalyzer implements ReadNodeAnalyzerInterface
 {
+    /**
+     * @var ReadExprAnalyzer
+     */
+    private $readExprAnalyzer;
+
+    /**
+     * @var NodeUsageFinder
+     */
+    private $nodeUsageFinder;
+
+    public function __construct(ReadExprAnalyzer $readExprAnalyzer, NodeUsageFinder $nodeUsageFinder)
+    {
+        $this->readExprAnalyzer = $readExprAnalyzer;
+        $this->nodeUsageFinder = $nodeUsageFinder;
+    }
+
     public function supports(Node $node): bool
     {
         return $node instanceof PropertyFetch;
@@ -22,7 +39,7 @@ final class PropertyFetchReadNodeAnalyzer extends AbstractReadNodeAnalyzer imple
     {
         $propertyFetchUsages = $this->nodeUsageFinder->findPropertyFetchUsages($node);
         foreach ($propertyFetchUsages as $propertyFetchUsage) {
-            if ($this->isCurrentContextRead($propertyFetchUsage)) {
+            if ($this->readExprAnalyzer->isReadContext($propertyFetchUsage)) {
                 return true;
             }
         }

--- a/packages/read-write/src/ReadNodeAnalyzer/ReadExprAnalyzer.php
+++ b/packages/read-write/src/ReadNodeAnalyzer/ReadExprAnalyzer.php
@@ -10,34 +10,11 @@ use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Return_;
-use Rector\NodeNestingScope\ParentScopeFinder;
 use Rector\NodeTypeResolver\Node\AttributeKey;
-use Rector\ReadWrite\NodeFinder\NodeUsageFinder;
 
-abstract class AbstractReadNodeAnalyzer
+final class ReadExprAnalyzer
 {
-    /**
-     * @var ParentScopeFinder
-     */
-    protected $parentScopeFinder;
-
-    /**
-     * @var NodeUsageFinder
-     */
-    protected $nodeUsageFinder;
-
-    /**
-     * @required
-     */
-    public function autowireAbstractReadNodeAnalyzer(
-        ParentScopeFinder $parentScopeFinder,
-        NodeUsageFinder $nodeUsageFinder
-    ): void {
-        $this->parentScopeFinder = $parentScopeFinder;
-        $this->nodeUsageFinder = $nodeUsageFinder;
-    }
-
-    protected function isCurrentContextRead(Expr $expr): bool
+    public function isReadContext(Expr $expr): bool
     {
         $parent = $expr->getAttribute(AttributeKey::PARENT_NODE);
         if ($parent instanceof Return_) {

--- a/packages/read-write/src/ReadNodeAnalyzer/VariableReadNodeAnalyzer.php
+++ b/packages/read-write/src/ReadNodeAnalyzer/VariableReadNodeAnalyzer.php
@@ -6,10 +6,37 @@ namespace Rector\ReadWrite\ReadNodeAnalyzer;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Variable;
+use Rector\NodeNestingScope\ParentScopeFinder;
 use Rector\ReadWrite\Contract\ReadNodeAnalyzerInterface;
+use Rector\ReadWrite\NodeFinder\NodeUsageFinder;
 
-final class VariableReadNodeAnalyzer extends AbstractReadNodeAnalyzer implements ReadNodeAnalyzerInterface
+final class VariableReadNodeAnalyzer implements ReadNodeAnalyzerInterface
 {
+    /**
+     * @var ParentScopeFinder
+     */
+    private $parentScopeFinder;
+
+    /**
+     * @var NodeUsageFinder
+     */
+    private $nodeUsageFinder;
+
+    /**
+     * @var ReadExprAnalyzer
+     */
+    private $readExprAnalyzer;
+
+    public function __construct(
+        ParentScopeFinder $parentScopeFinder,
+        NodeUsageFinder $nodeUsageFinder,
+        ReadExprAnalyzer $readExprAnalyzer
+    ) {
+        $this->parentScopeFinder = $parentScopeFinder;
+        $this->nodeUsageFinder = $nodeUsageFinder;
+        $this->readExprAnalyzer = $readExprAnalyzer;
+    }
+
     public function supports(Node $node): bool
     {
         return $node instanceof Variable;
@@ -27,7 +54,7 @@ final class VariableReadNodeAnalyzer extends AbstractReadNodeAnalyzer implements
 
         $variableUsages = $this->nodeUsageFinder->findVariableUsages((array) $parentScope->stmts, $node);
         foreach ($variableUsages as $variableUsage) {
-            if ($this->isCurrentContextRead($variableUsage)) {
+            if ($this->readExprAnalyzer->isReadContext($variableUsage)) {
                 return true;
             }
         }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -505,11 +505,6 @@ parameters:
             paths:
                 - packages/attribute-aware-php-doc/src/Ast/PhpDoc/AttributeAwareParamTagValueNode.php
 
-        # @todo bug, solve in Symplify
-        -
-             message: '#Constant type should be "class\-string", but is "string"#'
-             path: rules/symfony/src/Rector/BinaryOp/ResponseStatusCodeRector.php
-
         - '#Property Rector\\Core\\PhpParser\\Node\\AssignAndBinaryMap\:\:\$binaryOpToAssignClasses \(array<class\-string<PhpParser\\Node\\Expr\\BinaryOp\>, class\-string<PhpParser\\Node\\Expr\\BinaryOp\>\>\) does not accept array#'
         - '#Content of method "configure\(\)" is duplicated with method "configure\(\)" in "Rector\\RemovingStatic\\Rector\\Class_\\PassFactoryToUniqueObjectRector" class\. Use unique content or abstract service instead#'
 
@@ -602,3 +597,5 @@ parameters:
                 - packages/node-type-resolver/tests
 
         - '#Content of method "configure\(\)" is duplicated with method "configure\(\)" in "Rector\\Composer\\Rector\\AddPackageToRequireComposerRector" class\. Use unique content or abstract service instead#'
+        - '#Content of method "isConflicting\(\)" is duplicated with method "isConflicting\(\)" in "Rector\\Naming\\Guard\\PropertyConflictingNameGuard\\MatchPropertyTypeConflictingNameGuard" class\. Use unique content or abstract service instead#'
+        - '#Content of method "isConflicting\(\)" is duplicated with method "isConflicting\(\)" in "Rector\\Naming\\Guard\\PropertyConflictingNameGuard\\BoolPropertyConflictingNameGuard" class\. Use unique content or abstract service instead#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -99,8 +99,6 @@ parameters:
         # broken
         - '#Parameter \#2 \$name of method Rector\\NodeNameResolver\\NodeNameResolver\:\:isName\(\) expects string, string\|null given#'
 
-        - '#Parameter \#1 \$funcCall of method Rector\\Php80\\MatchAndRefactor\\StrStartsWithMatchAndRefactor\\AbstractMatchAndRefactor\:\:createStrStartsWithValueObjectFromFuncCall\(\) expects PhpParser\\Node\\Expr\\FuncCall, PhpParser\\Node\\Expr given#'
-
         # mostly strings in tests
         - '#Method Rector\\Naming\\Naming\\PropertyNaming\:\:resolveShortClassName\(\) should return string but returns string\|null#'
 
@@ -232,7 +230,6 @@ parameters:
                 - packages/better-php-doc-parser/src/PhpDocInfo/PhpDocInfo.php # 108
                 - rules/coding-style/src/Rector/ClassMethod/YieldClassMethodToArrayClassMethodRector.php # 47
                 - rules/php70/src/EregToPcreTransformer.php # 66
-                - rules/type-declaration/src/Rector/FunctionLike/ReturnTypeDeclarationRector.php # 82
 
         # trait in trait call
         - '#Parameter \#1 \$expr of class PhpParser\\Node\\Stmt\\Expression constructor expects PhpParser\\Node\\Expr, PhpParser\\Node\\Expr\|PhpParser\\Node\\Stmt given#'
@@ -437,8 +434,6 @@ parameters:
             paths:
                 - rules/removing-static/tests/Rector/Property/DesiredPropertyClassMethodTypeToDynamicRector/config/some_config.php
 
-        - '#Content of method "configure\(\)" is duplicated with method "configure\(\)" in "Rector\\Composer\\Rector\\AddPackageToRequireComposerRector" class\. Use unique content or abstract service instead#'
-
         # buggy phpstan clas-string
         - '#Method (.*?) should return class\-string but returns string#'
 
@@ -504,7 +499,6 @@ parameters:
         # known values
         - '#Method Rector\\Testing\\Finder\\RectorsFinder\:\:findClassesInDirectoriesByName\(\) should return array<class\-string\> but returns array<int, \(int\|string\)\>#'
         - '#Property PhpParser\\Node\\Param\:\:\$type \(PhpParser\\Node\\Identifier\|PhpParser\\Node\\Name\|PhpParser\\Node\\NullableType\|PhpParser\\Node\\UnionType\|null\) does not accept PhpParser\\Node#'
-        - '#Content of method "getFunctionLikePhpDocInfo\(\)" is duplicated with method "getFunctionLikePhpDocInfo\(\)" in "Rector\\TypeDeclaration\\TypeInferer\\ParamTypeInferer\\PHPUnitDataProviderParamTypeInferer" class\. Use unique content or abstract service instead#'
 
         -
             message: '#"%s" in sprintf\(\) format must be quoted#'
@@ -517,7 +511,6 @@ parameters:
              path: rules/symfony/src/Rector/BinaryOp/ResponseStatusCodeRector.php
 
         - '#Property Rector\\Core\\PhpParser\\Node\\AssignAndBinaryMap\:\:\$binaryOpToAssignClasses \(array<class\-string<PhpParser\\Node\\Expr\\BinaryOp\>, class\-string<PhpParser\\Node\\Expr\\BinaryOp\>\>\) does not accept array#'
-        - '#Content of method "configure\(\)" is duplicated with method "configure\(\)" in "Rector\\RemovingStatic\\Rector\\Class_\\NewUniqueObjectToEntityFactoryRector" class\. Use unique content or abstract service instead#'
         - '#Content of method "configure\(\)" is duplicated with method "configure\(\)" in "Rector\\RemovingStatic\\Rector\\Class_\\PassFactoryToUniqueObjectRector" class\. Use unique content or abstract service instead#'
 
         -
@@ -558,9 +551,6 @@ parameters:
 
         - '#Method Rector\\TypeDeclaration\\PhpParserTypeAnalyzer\:\:unwrapNullableAndToString\(\) should return string but returns string\|null#'
 
-        # @todo resolve in next PR!!! (Feb 2021)
-        - '#Function "array_filter\(\)" cannot be used/left in the code#'
-        - '#Cognitive complexity for "Rector\\CodeQuality\\Rector\\Isset_\\IssetOnPropertyObjectToPropertyExistsRector\:\:refactor\(\)" is 11, keep it under 9#'
         - '#Cognitive complexity for "Rector\\DeadCode\\UnusedNodeResolver\\ClassUnusedPrivateClassMethodResolver\:\:filterOutParentAbstractMethods\(\)" is 10, keep it under 9#'
 
         # known types
@@ -576,11 +566,6 @@ parameters:
             paths:
                 - rules/restoration/src/ClassMap/ExistingClassesProvider.php
 
-        # false positives
-        -
-             message: '#Empty array passed to foreach#'
-             paths:
-                 - rules/transform/src/Rector/New_/NewToConstructorInjectionRector.php
         -
             message: '#Parameter \#1 \$types of method Rector\\Defluent\\NodeAnalyzer\\FluentCallStaticTypeResolver\:\:filterOutAlreadyPresentParentClasses\(\) expects array<class\-string\>, array<int, string\> given#'
             paths:
@@ -594,15 +579,26 @@ parameters:
             paths:
                 - packages/read-write/src/Guard/VariableToConstantGuard.php
 
-        - '#Cognitive complexity for "Rector\\NetteCodeQuality\\FormControlTypeResolver\\MagicNetteFactoryInterfaceFormControlTypeResolver\:\:resolve\(\)" is 11, keep it under 9#'
         - '#Cognitive complexity for "Rector\\NetteCodeQuality\\FormControlTypeResolver\\MagicNetteFactoryInterfaceFormControlTypeResolver\:\:resolve\(\)" is 12, keep it under 9#'
         - '#Content of method "matchAssignExprToPropertyName\(\)" is duplicated with method "matchAssignExprToPropertyName\(\)" in "Rector\\TypeDeclaration\\AlreadyAssignDetector\\ConstructorAssignDetector" class\. Use unique content or abstract service instead#'
-        # make more tolerand, e.g. at least 2-3 lines
-        - '#Content of method "isConflicting\(\)" is duplicated with method "isConflicting\(\)" in "Rector\\Naming\\Guard\\PropertyConflictingNameGuard\\AbstractPropertyConflictingNameGuard" class\. Use unique content or abstract service instead#'
-        - '#Content of method "isConflicting\(\)" is duplicated with method "isConflicting\(\)" in "Rector\\Naming\\Guard\\PropertyConflictingNameGuard\\MatchPropertyTypeConflictingNameGuard" class\. Use unique content or abstract service instead#'
-        - '#Content of method "isConflicting\(\)" is duplicated with method "isConflicting\(\)" in "Rector\\Naming\\Guard\\PropertyConflictingNameGuard\\UnderscoreCamelCaseConflictingNameGuard" class\. Use unique content or abstract service instead#'
-        - '#Content of method "isConflicting\(\)" is duplicated with method "isConflicting\(\)" in "Rector\\Naming\\Guard\\PropertyConflictingNameGuard\\UnderscoreCamelCaseConflictingNameGuard" class\. Use unique content or abstract service instead#'
-        - '#Content of method "isConflicting\(\)" is duplicated with method "isConflicting\(\)" in "Rector\\Naming\\Guard\\PropertyConflictingNameGuard\\UnderscoreCamelCaseConflictingNameGuard" class\. Use unique content or abstract service instead#'
-        - '#Content of method "isConflicting\(\)" is duplicated with method "isConflicting\(\)" in "Rector\\Naming\\Guard\\PropertyConflictingNameGuard\\BoolPropertyConflictingNameGuard" class\. Use unique content or abstract service instead#'
-        - '#Content of method "isConflicting\(\)" is duplicated with method "isConflicting\(\)" in "Rector\\Naming\\Guard\\PropertyConflictingNameGuard\\BoolPropertyConflictingNameGuard" class\. Use unique content or abstract service instead#'
 
+        # make more tolerand, e.g. at least 2-3 lines
+        - '#Content of method "isConflicting\(\)" is duplicated with method "isConflicting\(\)" in "Rector\\Naming\\Guard\\PropertyConflictingNameGuard\\UnderscoreCamelCaseConflictingNameGuard" class\. Use unique content or abstract service instead#'
+
+
+        -
+            message: '#Offset 0 does not exist on array<PhpParser\\Node\\Stmt\>\|null#'
+            paths:
+                - rules/naming/src/Naming/PropertyNaming.php
+
+        -
+            message: '#Parameter \#1 \$value of function count expects array\|Countable, array<PhpParser\\Node\\Stmt\>\|null given#'
+            paths:
+                -  rules/naming/src/Naming/PropertyNaming.php
+
+        -
+            message: '#Use quoted string in constructor "new PHPStan\\Type\\ObjectType\(\)" argument on position 0 instead of "\:\:class\. It prevent scoping of the class in building prefixed package#'
+            paths:
+                - packages/node-type-resolver/tests
+
+        - '#Content of method "configure\(\)" is duplicated with method "configure\(\)" in "Rector\\Composer\\Rector\\AddPackageToRequireComposerRector" class\. Use unique content or abstract service instead#'

--- a/rules/doctrine-code-quality/src/Rector/Class_/MoveRepositoryFromParentToConstructorRector.php
+++ b/rules/doctrine-code-quality/src/Rector/Class_/MoveRepositoryFromParentToConstructorRector.php
@@ -4,11 +4,8 @@ declare(strict_types=1);
 
 namespace Rector\DoctrineCodeQuality\Rector\Class_;
 
-use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\EntityRepository;
 use Nette\Utils\Strings;
 use PhpParser\Node;
-use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\Type\ObjectType;
 use Rector\Core\NodeManipulator\ClassDependencyManipulator;
@@ -105,7 +102,7 @@ CODE_SAMPLE
         }
 
         $parentClassName = $node->getAttribute(AttributeKey::PARENT_CLASS_NAME);
-        if ($parentClassName !== EntityRepository::class) {
+        if ($parentClassName !== 'Doctrine\ORM\EntityRepository') {
             return null;
         }
 
@@ -123,7 +120,11 @@ CODE_SAMPLE
         $node->extends = null;
 
         // add $repository property
-        $this->classInsertManipulator->addPropertyToClass($node, 'repository', new ObjectType(EntityRepository::class));
+        $this->classInsertManipulator->addPropertyToClass(
+            $node,
+            'repository',
+            new ObjectType('Doctrine\ORM\EntityRepository')
+        );
 
         // add $entityManager and assign to constuctor
         $repositoryAssign = $this->repositoryAssignFactory->create($node);
@@ -131,7 +132,7 @@ CODE_SAMPLE
         $this->classDependencyManipulator->addConstructorDependencyWithCustomAssign(
             $node,
             'entityManager',
-            new ObjectType(EntityManagerInterface::class),
+            new ObjectType('Doctrine\ORM\EntityManagerInterface'),
             $repositoryAssign
         );
 

--- a/rules/doctrine-code-quality/tests/Rector/DoctrineRepositoryAsService/Fixture/PostController.php
+++ b/rules/doctrine-code-quality/tests/Rector/DoctrineRepositoryAsService/Fixture/PostController.php
@@ -24,8 +24,7 @@ final class PostController extends SymfonyController
 namespace Rector\DoctrineCodeQuality\Tests\Rector\DoctrineRepositoryAsService\Fixture;
 
 use Rector\DoctrineCodeQuality\Tests\Rector\DoctrineRepositoryAsService\Source\Entity\Post;
-use Rector\Core\Tests\Rector\Architecture\DoctrineRepositoryAsService\Source\SymfonyController;
-use Symfony\Component\HttpFoundation\Response;
+use Rector\Core\Tests\Rector\Architecture\DoctrineRepositoryAsService\Source\SymfonyController;use Symfony\Component\HttpFoundation\Response;
 
 final class PostController extends SymfonyController
 {

--- a/rules/downgrade-php70/src/Rector/FunctionLike/AbstractDowngradeReturnDeclarationRector.php
+++ b/rules/downgrade-php70/src/Rector/FunctionLike/AbstractDowngradeReturnDeclarationRector.php
@@ -15,7 +15,6 @@ use PHPStan\Type\UnionType;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTypeChanger;
 use Rector\Core\Rector\AbstractRector;
 use Rector\DowngradePhp70\Contract\Rector\DowngradeReturnDeclarationRectorInterface;
-use Traversable;
 
 abstract class AbstractDowngradeReturnDeclarationRector extends AbstractRector implements DowngradeReturnDeclarationRectorInterface
 {
@@ -68,7 +67,7 @@ abstract class AbstractDowngradeReturnDeclarationRector extends AbstractRector i
 
         $type = $this->staticTypeMapper->mapPhpParserNodePHPStanType($functionLike->returnType);
         if ($type instanceof IterableType) {
-            $type = new UnionType([$type, new IntersectionType([new ObjectType(Traversable::class)])]);
+            $type = new UnionType([$type, new IntersectionType([new ObjectType('Traversable')])]);
         }
 
         $this->phpDocTypeChanger->changeReturnType($phpDocInfo, $type);

--- a/rules/naming/src/Naming/PropertyNaming.php
+++ b/rules/naming/src/Naming/PropertyNaming.php
@@ -330,16 +330,11 @@ final class PropertyNaming
         $currentName = $this->nodeNameResolver->getName($property);
 
         return array_filter($prefixedClassMethods, function (ClassMethod $classMethod) use ($currentName): bool {
-            $stmts = $classMethod->stmts;
-            if ($stmts === null) {
+            if ((array) $classMethod->stmts === []) {
                 return false;
             }
 
-            if (! array_key_exists(0, $stmts)) {
-                return false;
-            }
-
-            $return = $stmts[0];
+            $return = $classMethod->stmts[0];
             if (! $return instanceof Return_) {
                 return false;
             }

--- a/rules/naming/src/PropertyRenamer/BoolPropertyRenamer.php
+++ b/rules/naming/src/PropertyRenamer/BoolPropertyRenamer.php
@@ -8,16 +8,24 @@ use PhpParser\Node\Stmt\Property;
 use Rector\Naming\Guard\PropertyConflictingNameGuard\BoolPropertyConflictingNameGuard;
 use Rector\Naming\ValueObject\PropertyRename;
 
-final class BoolPropertyRenamer extends AbstractPropertyRenamer
+final class BoolPropertyRenamer
 {
     /**
      * @var BoolPropertyConflictingNameGuard
      */
     private $boolPropertyConflictingNameGuard;
 
-    public function __construct(BoolPropertyConflictingNameGuard $boolPropertyConflictingNameGuard)
-    {
+    /**
+     * @var PropertyRenamer
+     */
+    private $propertyRenamer;
+
+    public function __construct(
+        BoolPropertyConflictingNameGuard $boolPropertyConflictingNameGuard,
+        PropertyRenamer $propertyRenamer
+    ) {
         $this->boolPropertyConflictingNameGuard = $boolPropertyConflictingNameGuard;
+        $this->propertyRenamer = $propertyRenamer;
     }
 
     public function rename(PropertyRename $propertyRename): ?Property
@@ -26,6 +34,6 @@ final class BoolPropertyRenamer extends AbstractPropertyRenamer
             return null;
         }
 
-        return parent::rename($propertyRename);
+        return $this->propertyRenamer->rename($propertyRename);
     }
 }

--- a/rules/naming/src/PropertyRenamer/MatchTypePropertyRenamer.php
+++ b/rules/naming/src/PropertyRenamer/MatchTypePropertyRenamer.php
@@ -8,16 +8,24 @@ use PhpParser\Node\Stmt\Property;
 use Rector\Naming\Guard\PropertyConflictingNameGuard\MatchPropertyTypeConflictingNameGuard;
 use Rector\Naming\ValueObject\PropertyRename;
 
-final class MatchTypePropertyRenamer extends AbstractPropertyRenamer
+final class MatchTypePropertyRenamer
 {
     /**
      * @var MatchPropertyTypeConflictingNameGuard
      */
     private $matchPropertyTypeConflictingNameGuard;
 
-    public function __construct(MatchPropertyTypeConflictingNameGuard $matchPropertyTypeConflictingNameGuard)
-    {
+    /**
+     * @var PropertyRenamer
+     */
+    private $propertyRenamer;
+
+    public function __construct(
+        PropertyRenamer $propertyRenamer,
+        MatchPropertyTypeConflictingNameGuard $matchPropertyTypeConflictingNameGuard
+    ) {
         $this->matchPropertyTypeConflictingNameGuard = $matchPropertyTypeConflictingNameGuard;
+        $this->propertyRenamer = $propertyRenamer;
     }
 
     public function rename(PropertyRename $propertyRename): ?Property
@@ -26,6 +34,6 @@ final class MatchTypePropertyRenamer extends AbstractPropertyRenamer
             return null;
         }
 
-        return parent::rename($propertyRename);
+        return $this->propertyRenamer->rename($propertyRename);
     }
 }

--- a/rules/naming/src/PropertyRenamer/PropertyFetchRenamer.php
+++ b/rules/naming/src/PropertyRenamer/PropertyFetchRenamer.php
@@ -39,10 +39,10 @@ final class PropertyFetchRenamer
         $this->simpleCallableNodeTraverser->traverseNodesWithCallable(
             $classLike,
             function (Node $node) use ($currentName, $expectedName): ?Node {
-                if ($this->nodeNameResolver->isLocalPropertyFetchNamed(
-                        $node,
-                        $currentName
-                    ) && $node instanceof PropertyFetch) {
+                if ($node instanceof PropertyFetch && $this->nodeNameResolver->isLocalPropertyFetchNamed(
+                    $node,
+                    $currentName
+                )) {
                     $node->name = new Identifier($expectedName);
                     return $node;
                 }

--- a/rules/naming/src/PropertyRenamer/PropertyRenamer.php
+++ b/rules/naming/src/PropertyRenamer/PropertyRenamer.php
@@ -9,7 +9,7 @@ use PhpParser\Node\VarLikeIdentifier;
 use Rector\Naming\RenameGuard\PropertyRenameGuard;
 use Rector\Naming\ValueObject\PropertyRename;
 
-abstract class AbstractPropertyRenamer
+final class PropertyRenamer
 {
     /**
      * @var PropertyFetchRenamer
@@ -21,20 +21,17 @@ abstract class AbstractPropertyRenamer
      */
     private $propertyRenameGuard;
 
-    /**
-     * @required
-     */
-    public function autowireAbstractPropertyRenamer(
+    public function __construct(
         PropertyRenameGuard $propertyRenameGuard,
         PropertyFetchRenamer $propertyFetchRenamer
-    ): void {
+    ) {
         $this->propertyRenameGuard = $propertyRenameGuard;
         $this->propertyFetchRenamer = $propertyFetchRenamer;
     }
 
     public function rename(PropertyRename $propertyRename): ?Property
     {
-        if (! $this->areNamesDifferent($propertyRename)) {
+        if (! $propertyRename->isAlreadyExpectedName()) {
             return null;
         }
 
@@ -56,10 +53,5 @@ abstract class AbstractPropertyRenamer
             $propertyRename->getCurrentName(),
             $propertyRename->getExpectedName()
         );
-    }
-
-    private function areNamesDifferent(PropertyRename $propertyRename): bool
-    {
-        return $propertyRename->getCurrentName() !== $propertyRename->getExpectedName();
     }
 }

--- a/rules/naming/src/PropertyRenamer/PropertyRenamer.php
+++ b/rules/naming/src/PropertyRenamer/PropertyRenamer.php
@@ -31,7 +31,7 @@ final class PropertyRenamer
 
     public function rename(PropertyRename $propertyRename): ?Property
     {
-        if (! $propertyRename->isAlreadyExpectedName()) {
+        if ($propertyRename->isAlreadyExpectedName()) {
             return null;
         }
 

--- a/rules/naming/src/PropertyRenamer/UnderscoreCamelCasePropertyRenamer.php
+++ b/rules/naming/src/PropertyRenamer/UnderscoreCamelCasePropertyRenamer.php
@@ -8,16 +8,24 @@ use PhpParser\Node\Stmt\Property;
 use Rector\Naming\Guard\PropertyConflictingNameGuard\UnderscoreCamelCaseConflictingNameGuard;
 use Rector\Naming\ValueObject\PropertyRename;
 
-final class UnderscoreCamelCasePropertyRenamer extends AbstractPropertyRenamer
+final class UnderscoreCamelCasePropertyRenamer
 {
     /**
      * @var UnderscoreCamelCaseConflictingNameGuard
      */
     private $underscoreCamelCaseConflictingNameGuard;
 
-    public function __construct(UnderscoreCamelCaseConflictingNameGuard $underscoreCamelCaseConflictingNameGuard)
-    {
+    /**
+     * @var PropertyRenamer
+     */
+    private $propertyRenamer;
+
+    public function __construct(
+        UnderscoreCamelCaseConflictingNameGuard $underscoreCamelCaseConflictingNameGuard,
+        PropertyRenamer $propertyRenamer
+    ) {
         $this->underscoreCamelCaseConflictingNameGuard = $underscoreCamelCaseConflictingNameGuard;
+        $this->propertyRenamer = $propertyRenamer;
     }
 
     public function rename(PropertyRename $propertyRename): ?Property
@@ -26,6 +34,6 @@ final class UnderscoreCamelCasePropertyRenamer extends AbstractPropertyRenamer
             return null;
         }
 
-        return parent::rename($propertyRename);
+        return $this->propertyRenamer->rename($propertyRename);
     }
 }

--- a/rules/naming/src/ValueObject/PropertyRename.php
+++ b/rules/naming/src/ValueObject/PropertyRename.php
@@ -77,6 +77,11 @@ final class PropertyRename implements RenamePropertyValueObjectInterface
         return $this->currentName;
     }
 
+    public function isAlreadyExpectedName(): string
+    {
+        return $this->currentName === $this->expectedName;
+    }
+
     public function getClassLike(): ClassLike
     {
         return $this->classLike;

--- a/rules/naming/src/ValueObject/PropertyRename.php
+++ b/rules/naming/src/ValueObject/PropertyRename.php
@@ -77,7 +77,7 @@ final class PropertyRename implements RenamePropertyValueObjectInterface
         return $this->currentName;
     }
 
-    public function isAlreadyExpectedName(): string
+    public function isAlreadyExpectedName(): bool
     {
         return $this->currentName === $this->expectedName;
     }

--- a/rules/nette-kdyby/src/Rector/MethodCall/ReplaceMagicPropertyEventWithEventClassRector.php
+++ b/rules/nette-kdyby/src/Rector/MethodCall/ReplaceMagicPropertyEventWithEventClassRector.php
@@ -18,7 +18,6 @@ use Rector\NetteKdyby\DataProvider\EventAndListenerTreeProvider;
 use Rector\NetteKdyby\ValueObject\EventAndListenerTree;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -129,7 +128,7 @@ CODE_SAMPLE
         $classLike = $node->getAttribute(AttributeKey::CLASS_NODE);
         $this->addConstructorDependencyToClass(
             $classLike,
-            new FullyQualifiedObjectType(EventDispatcherInterface::class),
+            new FullyQualifiedObjectType('Symfony\Contracts\EventDispatcher\EventDispatcherInterface'),
             'eventDispatcher'
         );
 

--- a/rules/symfony2/src/Rector/MethodCall/AddFlashRector.php
+++ b/rules/symfony2/src/Rector/MethodCall/AddFlashRector.php
@@ -10,7 +10,6 @@ use PHPStan\Type\ObjectType;
 use Rector\Core\Rector\AbstractRector;
 use Rector\Defluent\NodeAnalyzer\FluentChainMethodCallNodeAnalyzer;
 use Rector\NodeTypeResolver\Node\AttributeKey;
-use Symfony\Component\HttpFoundation\Request;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -79,7 +78,7 @@ CODE_SAMPLE
 
         if (! $this->fluentChainMethodCallNodeAnalyzer->isTypeAndChainCalls(
             $node,
-            new ObjectType(Request::class),
+            new ObjectType('Symfony\Component\HttpFoundation\Request'),
             ['getSession', 'getFlashBag', 'add']
         )
         ) {

--- a/rules/symfony3/src/Rector/MethodCall/FormTypeInstanceToClassConstRector.php
+++ b/rules/symfony3/src/Rector/MethodCall/FormTypeInstanceToClassConstRector.php
@@ -21,7 +21,6 @@ use Rector\Core\ValueObject\MethodName;
 use Rector\Symfony3\NodeFactory\BuilderFormNodeFactory;
 use Rector\Symfony3\NodeFactory\ConfigureOptionsNodeFactory;
 use ReflectionMethod;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 

--- a/rules/type-declaration/src/TypeInferer/PropertyTypeInferer/DoctrineColumnPropertyTypeInferer.php
+++ b/rules/type-declaration/src/TypeInferer/PropertyTypeInferer/DoctrineColumnPropertyTypeInferer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\TypeDeclaration\TypeInferer\PropertyTypeInferer;
 
-use DateTimeInterface;
 use PhpParser\Node\Stmt\Property;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\FloatType;
@@ -73,11 +72,11 @@ final class DoctrineColumnPropertyTypeInferer implements PropertyTypeInfererInte
             'varbinary' => new StringType(),
             'set' => new StringType(),
             // date time objects
-            'date' => new ObjectType(DateTimeInterface::class),
-            'datetime' => new ObjectType(DateTimeInterface::class),
-            'timestamp' => new ObjectType(DateTimeInterface::class),
-            'time' => new ObjectType(DateTimeInterface::class),
-            'year' => new ObjectType(DateTimeInterface::class),
+            'date' => new ObjectType('DateTimeInterface'),
+            'datetime' => new ObjectType('DateTimeInterface'),
+            'timestamp' => new ObjectType('DateTimeInterface'),
+            'time' => new ObjectType('DateTimeInterface'),
+            'year' => new ObjectType('DateTimeInterface'),
         ];
         $this->phpDocInfoFactory = $phpDocInfoFactory;
     }

--- a/rules/type-declaration/src/TypeInferer/ReturnTypeInferer/YieldNodesReturnTypeInferer.php
+++ b/rules/type-declaration/src/TypeInferer/ReturnTypeInferer/YieldNodesReturnTypeInferer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\TypeDeclaration\TypeInferer\ReturnTypeInferer;
 
-use Iterator;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Closure;
@@ -86,7 +85,7 @@ final class YieldNodesReturnTypeInferer implements ReturnTypeInfererInterface
             // @see https://www.php.net/manual/en/language.types.iterable.php
             $types[] = new IterableType(new MixedType(), new MixedType());
         } else {
-            $types[] = new ObjectType(Iterator::class);
+            $types[] = new ObjectType('Iterator');
         }
 
         return $this->typeFactory->createMixedPassedOrUnionType($types);

--- a/src/NodeManipulator/ClassMethodAssignManipulator.php
+++ b/src/NodeManipulator/ClassMethodAssignManipulator.php
@@ -186,7 +186,6 @@ final class ClassMethodAssignManipulator
     {
         return array_filter($readOnlyVariableAssigns, function (Assign $assign): bool {
             $parentNode = $assign->getAttribute(AttributeKey::PARENT_NODE);
-
             return ! $parentNode instanceof Assign;
         });
     }

--- a/utils/phpstan-extensions/config/rector-rules.neon
+++ b/utils/phpstan-extensions/config/rector-rules.neon
@@ -14,7 +14,6 @@ services:
                 - PHPStan\PhpDocParser\Parser\PhpDocParser
                 # resolve later
                 - Rector\Naming\Matcher\AbstractMatcher
-                - Rector\ReadWrite\ReadNodeAnalyzer\AbstractReadNodeAnalyzer
                 # value objects
                 - Rector\Defluent\ValueObject\AbstractRootExpr
                 - Symplify\SetConfigResolver\Provider\AbstractSetProvider

--- a/utils/phpstan-extensions/config/rector-rules.neon
+++ b/utils/phpstan-extensions/config/rector-rules.neon
@@ -14,7 +14,6 @@ services:
                 - PHPStan\PhpDocParser\Parser\PhpDocParser
                 # resolve later
                 - Rector\Naming\Matcher\AbstractMatcher
-                - Rector\Naming\PropertyRenamer\AbstractPropertyRenamer
                 - Rector\ReadWrite\ReadNodeAnalyzer\AbstractReadNodeAnalyzer
                 # value objects
                 - Rector\Defluent\ValueObject\AbstractRootExpr
@@ -171,6 +170,7 @@ services:
         arguments:
             stringArgPositionsByType:
                 PhpParser\Node\Name\FullyQualified: [0]
+                PHPStan\Type\ObjectType: [0]
 
     -
         class: Symplify\PHPStanRules\Rules\ClassNameRespectsParentSuffixRule
@@ -223,8 +223,6 @@ services:
                 - 'spl_autoload_register'
                 - 'spl_autoload_unregister'
                 - array_walk
-                # creates messy nested logic
-                - array_filter
                 # there are handled in ReflectionProvider->has*()
                 - 'class_exists'
                 - 'interface_exists'


### PR DESCRIPTION
Should fix cases like https://github.com/rectorphp/rector-prefixed/blob/c875b75d79b39d8882389670f6043c223cea60b8/rules/doctrine-code-quality/src/Rector/Class_/MoveRepositoryFromParentToConstructorRector.php#L6-L7