### PR TITLE
Fixture for UnderscoreToCamelCaseLocalVariableNameRector

### DIFF
--- a/rules/naming/tests/Rector/Variable/UnderscoreToCamelCaseLocalVariableNameRector/Fixture/do_not_overwrite_existing_variables.php.inc
+++ b/rules/naming/tests/Rector/Variable/UnderscoreToCamelCaseLocalVariableNameRector/Fixture/do_not_overwrite_existing_variables.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Naming\Tests\Rector\Variable\UnderscoreToCamelCaseLocalVariableNameRector\Fixture;
+
+final class DoNotOverwriteExistingVariables
+{
+    public function foo()
+    {
+       $foo_bar = 4;
+       $fooBar = 2;
+
+       $testExample = 5;
+       $test_example = 7;
+    }
+}


### PR DESCRIPTION
See #5715

```
$ php vendor/bin/phpunit  rules/naming/tests/Rector/Variable/UnderscoreToCamelCaseLocalVariableNameRector/
PHPUnit 9.5.2 by Sebastian Bergmann and contributors.

....................F                                             21 / 21 (100%)

Time: 00:05.459, Memory: 116.50 MB

There was 1 failure:

1) Rector\Naming\Tests\Rector\Variable\UnderscoreToCamelCaseLocalVariableNameRector\UnderscoreToCamelCaseLocalVariableNameRectorTest::test with data set #20 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
rules/naming/tests/Rector/Variable/UnderscoreToCamelCaseLocalVariableNameRector/Fixture/do_not_overwrite_existing_variables.php.inc
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
 {
     public function foo()
     {
-       $foo_bar = 4;
+       $fooBar = 4;
        $fooBar = 2;
 
        $testExample = 5;
-       $test_example = 7;
+       $testExample = 7;
     }
 }

packages/testing/src/PHPUnit/AbstractRectorTestCase.php:319
packages/testing/src/PHPUnit/AbstractRectorTestCase.php:178
rules/naming/tests/Rector/Variable/UnderscoreToCamelCaseLocalVariableNameRector/UnderscoreToCamelCaseLocalVariableNameRectorTest.php:19
```