### PR TITLE
Point to the new parser nodes docs URL

### DIFF
--- a/src/Contract/Rector/PhpRectorInterface.php
+++ b/src/Contract/Rector/PhpRectorInterface.php
@@ -11,7 +11,7 @@ interface PhpRectorInterface extends NodeVisitor, RectorInterface
 {
     /**
      * List of nodes this class checks, classes that implements \PhpParser\Node
-     * See beautiful map of all nodes https://github.com/rectorphp/rector/blob/master/docs/nodes_overview.md
+     * See beautiful map of all nodes https://github.com/rectorphp/php-parser-nodes-docs
      *
      * @return array<class-string<Node>>
      */


### PR DESCRIPTION
This would make it easier to include the interface in the book, @TomasVotruba Would you agree to do it like this?