### PR TITLE
[StaticReflection] Add OptimizedDirectorySourceLocator to speedup directory analysis

### DIFF
--- a/.github/workflows/rector.yaml
+++ b/.github/workflows/rector.yaml
@@ -22,13 +22,11 @@ jobs:
             matrix:
                 directories:
                     #- rules
-                    - rules/arguments rules/autodiscovery rules/cakephp rules/carbon rules/code-quality rules/code-quality-strict rules/coding-style rules/composer rules/dead-code rules/dead-doc-block rules/defluent rules/dependency-injection rules/doctrine rules/doctrine-code-quality rules/doctrine-gedmo-to-knplabs rules/downgrade-php70  rules/downgrade-php71 rules/downgrade-php72 rules/downgrade-php73
+                    - rules/arguments rules/autodiscovery rules/cakephp rules/carbon rules/code-quality rules/code-quality-strict rules/coding-style rules/composer rules/dead-code rules/dead-doc-block rules/defluent rules/dependency-injection rules/doctrine rules/doctrine-code-quality rules/doctrine-gedmo-to-knplabs rules/downgrade-php70  rules/downgrade-php71 rules/downgrade-php72 rules/downgrade-php73 rules/naming rules/nette rules/nette-code-quality rules/nette-kdyby
 
-                    - rules/downgrade-php74 rules/downgrade-php80 rules/early-return rules/generics rules/laravel rules/legacy rules/mockery-to-prophecy rules/mockista-to-mockery rules/mysql-to-mysqli rules/naming rules/nette rules/nette-code-quality rules/nette-kdyby
+                    - rules/downgrade-php74 rules/downgrade-php80 rules/early-return rules/generics rules/laravel rules/legacy rules/mockery-to-prophecy rules/mockista-to-mockery rules/mysql-to-mysqli rules/symfony3 rules/symfony4 rules/symfony5 rules/transform rules/type-declaration rules/visibility
 
                     - rules/nette-tester-to-phpunit rules/nette-to-symfony rules/nette-utils-code-quality rules/order rules/php-office rules/php-spec-to-phpunit rules/php52 rules/php53 rules/php54 rules/php55 rules/php56 rules/php70 rules/php71 rules/php72 rules/php73 rules/php74 rules/php80 rules/phpunit rules/phpunit-symfony rules/privatization rules/psr4 rules/removing rules/removing-static rules/renaming rules/restoration rules/sensio rules/symfony rules/symfony-code-quality rules/symfony-php-config rules/symfony2
-
-                    - rules/symfony3 rules/symfony4 rules/symfony5 rules/transform rules/type-declaration rules/visibility
 
                     - packages
                     - src
@@ -61,7 +59,7 @@ jobs:
             -   run: composer install --no-progress --ansi
 
             ## First run Rector - here can't be --dry-run !!! it would stop the job with it and not commit anything in the future
-            -   run: bin/rector rectify ${{ matrix.directories }} --ansi --no-progress-bar
+            -   run: bin/rector process ${{ matrix.directories }} --ansi --no-progress-bar
 
             -   run: vendor/bin/ecs check --match-git-diff --fix --ansi
 

--- a/packages/testing/src/PHPUnit/AbstractRectorTestCase.php
+++ b/packages/testing/src/PHPUnit/AbstractRectorTestCase.php
@@ -178,16 +178,7 @@ abstract class AbstractRectorTestCase extends AbstractKernelTestCase
         $this->doTestFileMatchesExpectedContent($inputFileInfo, $expectedFileInfo, $fixtureFileInfo, $extraFileInfos);
         $this->originalTempFileInfo = $inputFileInfo;
 
-        // runnable?
-        if (! file_exists($inputFileInfo->getPathname())) {
-            return;
-        }
-
-        if (! Strings::contains($inputFileInfo->getContents(), RunnableInterface::class)) {
-            return;
-        }
-
-        $this->assertOriginalAndFixedFileResultEquals($inputFileInfo, $expectedFileInfo);
+        $this->processRunnableTest($inputFileInfo, $expectedFileInfo);
     }
 
     protected function doTestExtraFile(string $expectedExtraFileName, string $expectedExtraContentFilePath): void
@@ -344,5 +335,19 @@ abstract class AbstractRectorTestCase extends AbstractKernelTestCase
         $stubLoader->loadStubs();
 
         self::$isInitialized = true;
+    }
+
+    private function processRunnableTest(SmartFileInfo $inputFileInfo, SmartFileInfo $expectedFileInfo): void
+    {
+        // runnable?
+        if (! file_exists($inputFileInfo->getPathname())) {
+            return;
+        }
+
+        if (! Strings::contains($inputFileInfo->getContents(), RunnableInterface::class)) {
+            return;
+        }
+
+        $this->assertOriginalAndFixedFileResultEquals($inputFileInfo, $expectedFileInfo);
     }
 }

--- a/rules/naming/src/Rector/Property/MakeBoolPropertyRespectIsHasWasMethodNamingRector.php
+++ b/rules/naming/src/Rector/Property/MakeBoolPropertyRespectIsHasWasMethodNamingRector.php
@@ -99,9 +99,6 @@ CODE_SAMPLE
             return null;
         }
 
-//        dump($expectedBoolName);
-//        die;
-
         $propertyRename = $this->propertyRenameFactory->createFromExpectedName($node, $expectedBoolName);
         if (! $propertyRename instanceof PropertyRename) {
             return null;

--- a/src/Autoloading/AdditionalAutoloader.php
+++ b/src/Autoloading/AdditionalAutoloader.php
@@ -58,8 +58,10 @@ final class AdditionalAutoloader
         $autoloadFiles = $this->fileSystemFilter->filterFiles($this->autoloadPaths);
 
         $this->autoloadFileFromInput($input);
-        $this->autoloadDirectories($autoloadDirectories);
-        $this->autoloadFiles($autoloadFiles);
+
+        // note: should be handled by static reflection
+        // $this->autoloadDirectories($autoloadDirectories);
+        // $this->autoloadFiles($autoloadFiles);
 
         // the scanned file needs to be autoloaded
         $directories = $this->fileSystemFilter->filterDirectories($source);

--- a/src/Autoloading/AdditionalAutoloader.php
+++ b/src/Autoloading/AdditionalAutoloader.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace Rector\Core\Autoloading;
 
-use Nette\Loaders\RobotLoader;
 use Rector\Core\Configuration\Option;
+use Rector\Core\StaticReflection\DynamicSourceLocatorDecorator;
 use Symfony\Component\Console\Input\InputInterface;
 use Symplify\PackageBuilder\Parameter\ParameterProvider;
-use Symplify\Skipper\SkipCriteriaResolver\SkippedPathsResolver;
-use Symplify\SmartFileSystem\FileSystemFilter;
 use Symplify\SmartFileSystem\FileSystemGuard;
 
 /**
@@ -18,108 +16,49 @@ use Symplify\SmartFileSystem\FileSystemGuard;
 final class AdditionalAutoloader
 {
     /**
-     * @var string[]
-     */
-    private $autoloadPaths = [];
-
-    /**
-     * @var FileSystemFilter
-     */
-    private $fileSystemFilter;
-
-    /**
-     * @var SkippedPathsResolver
-     */
-    private $skippedPathsResolver;
-
-    /**
      * @var FileSystemGuard
      */
     private $fileSystemGuard;
 
-    public function __construct(
-        FileSystemFilter $fileSystemFilter,
-        ParameterProvider $parameterProvider,
-        SkippedPathsResolver $skippedPathsResolver,
-        FileSystemGuard $fileSystemGuard
-    ) {
-        $this->autoloadPaths = (array) $parameterProvider->provideParameter(Option::AUTOLOAD_PATHS);
-        $this->fileSystemFilter = $fileSystemFilter;
-        $this->skippedPathsResolver = $skippedPathsResolver;
-        $this->fileSystemGuard = $fileSystemGuard;
-    }
+    /**
+     * @var ParameterProvider
+     */
+    private $parameterProvider;
 
     /**
-     * @param string[] $source
+     * @var DynamicSourceLocatorDecorator
      */
-    public function autoloadWithInputAndSource(InputInterface $input, array $source): void
-    {
-        $autoloadDirectories = $this->fileSystemFilter->filterDirectories($this->autoloadPaths);
-        $autoloadFiles = $this->fileSystemFilter->filterFiles($this->autoloadPaths);
+    private $dynamicSourceLocatorDecorator;
 
-        $this->autoloadFileFromInput($input);
-
-        // note: should be handled by static reflection
-        // $this->autoloadDirectories($autoloadDirectories);
-        // $this->autoloadFiles($autoloadFiles);
-
-        // the scanned file needs to be autoloaded
-        $directories = $this->fileSystemFilter->filterDirectories($source);
-        foreach ($directories as $directory) {
-            // load project autoload
-            if (file_exists($directory . '/vendor/autoload.php')) {
-                require_once $directory . '/vendor/autoload.php';
-            }
-        }
+    public function __construct(
+        FileSystemGuard $fileSystemGuard,
+        ParameterProvider $parameterProvider,
+        DynamicSourceLocatorDecorator $dynamicSourceLocatorDecorator
+    ) {
+        $this->fileSystemGuard = $fileSystemGuard;
+        $this->parameterProvider = $parameterProvider;
+        $this->dynamicSourceLocatorDecorator = $dynamicSourceLocatorDecorator;
     }
 
-    private function autoloadFileFromInput(InputInterface $input): void
+    public function autoloadWithInputAndSource(InputInterface $input): void
     {
-        if (! $input->hasOption(Option::OPTION_AUTOLOAD_FILE)) {
-            return;
+        if ($input->hasOption(Option::OPTION_AUTOLOAD_FILE)) {
+            $this->autoloadInputAutoloadFile($input);
         }
 
+        $autoloadPaths = $this->parameterProvider->provideArrayParameter(Option::AUTOLOAD_PATHS);
+        $this->dynamicSourceLocatorDecorator->addPaths($autoloadPaths);
+    }
+
+    private function autoloadInputAutoloadFile(InputInterface $input): void
+    {
         /** @var string|null $autoloadFile */
         $autoloadFile = $input->getOption(Option::OPTION_AUTOLOAD_FILE);
         if ($autoloadFile === null) {
             return;
         }
 
-        $this->autoloadFiles([$autoloadFile]);
-    }
-
-    /**
-     * @param string[] $directories
-     */
-    private function autoloadDirectories(array $directories): void
-    {
-        if ($directories === []) {
-            return;
-        }
-
-        $robotLoader = new RobotLoader();
-        $robotLoader->ignoreDirs[] = '*Fixtures';
-
-        $excludePaths = $this->skippedPathsResolver->resolve();
-        foreach ($excludePaths as $excludePath) {
-            $robotLoader->ignoreDirs[] = $excludePath;
-        }
-        // last argument is workaround: https://github.com/nette/robot-loader/issues/12
-        $robotLoader->setTempDirectory(sys_get_temp_dir() . '/_rector_robot_loader');
-        $robotLoader->addDirectory(...$directories);
-
-        $robotLoader->register();
-    }
-
-    /**
-     * @param string[] $files
-     */
-    private function autoloadFiles(array $files): void
-    {
-        foreach ($files as $file) {
-            $this->fileSystemGuard->ensureFileExists($file, 'Extra autoload');
-
-            require_once $file;
-        }
+        $this->fileSystemGuard->ensureFileExists($autoloadFile, 'Extra autoload');
+        $this->dynamicSourceLocatorDecorator->addPaths([$autoloadFile]);
     }
 }

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\Core\Console\Command;
 
-use Nette\Utils\Strings;
 use Rector\Caching\Application\CachedFileInfoFilterAndReporter;
 use Rector\Caching\Detector\ChangedFilesDetector;
 use Rector\ChangesReporting\Application\ErrorAndDiffCollector;
@@ -16,6 +15,7 @@ use Rector\Core\Configuration\Configuration;
 use Rector\Core\Configuration\Option;
 use Rector\Core\Console\Output\OutputFormatterCollector;
 use Rector\Core\FileSystem\FilesFinder;
+use Rector\Core\FileSystem\PhpFilesFinder;
 use Rector\Core\Guard\RectorGuard;
 use Rector\Core\NonPhpFile\NonPhpFileProcessor;
 use Rector\Core\PhpParser\NodeTraverser\RectorNodeTraverser;
@@ -27,7 +27,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symplify\PackageBuilder\Console\ShellCode;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class ProcessCommand extends AbstractCommand
 {
@@ -96,12 +95,17 @@ final class ProcessCommand extends AbstractCommand
      */
     private $composerProcessor;
 
+    /**
+     * @var PhpFilesFinder
+     */
+    private $phpFilesFinder;
+
     public function __construct(
         AdditionalAutoloader $additionalAutoloader,
         ChangedFilesDetector $changedFilesDetector,
         Configuration $configuration,
         ErrorAndDiffCollector $errorAndDiffCollector,
-        FilesFinder $phpFilesFinder,
+        FilesFinder $filesFinder,
         NonPhpFileProcessor $nonPhpFileProcessor,
         OutputFormatterCollector $outputFormatterCollector,
         RectorApplication $rectorApplication,
@@ -110,9 +114,10 @@ final class ProcessCommand extends AbstractCommand
         StubLoader $stubLoader,
         SymfonyStyle $symfonyStyle,
         CachedFileInfoFilterAndReporter $cachedFileInfoFilterAndReporter,
-        ComposerProcessor $composerProcessor
+        ComposerProcessor $composerProcessor,
+        PhpFilesFinder $phpFilesFinder
     ) {
-        $this->filesFinder = $phpFilesFinder;
+        $this->filesFinder = $filesFinder;
         $this->additionalAutoloader = $additionalAutoloader;
         $this->rectorGuard = $rectorGuard;
         $this->errorAndDiffCollector = $errorAndDiffCollector;
@@ -126,14 +131,13 @@ final class ProcessCommand extends AbstractCommand
         $this->symfonyStyle = $symfonyStyle;
         $this->cachedFileInfoFilterAndReporter = $cachedFileInfoFilterAndReporter;
         $this->composerProcessor = $composerProcessor;
+        $this->phpFilesFinder = $phpFilesFinder;
 
         parent::__construct();
     }
 
     protected function configure(): void
     {
-        $this->setAliases(['rectify']);
-
         $this->setDescription('Upgrade or refactor source code with provided rectors');
         $this->addArgument(
             Option::SOURCE,
@@ -201,7 +205,7 @@ final class ProcessCommand extends AbstractCommand
 
         $paths = $this->configuration->getPaths();
 
-        $phpFileInfos = $this->findPhpFileInfos($paths);
+        $phpFileInfos = $this->phpFilesFinder->findInPaths($paths);
 
         $this->additionalAutoloader->autoloadWithInputAndSource($input, $paths);
 
@@ -212,7 +216,7 @@ final class ProcessCommand extends AbstractCommand
         }
 
         $this->configuration->setFileInfos($phpFileInfos);
-        $this->rectorApplication->runOnFileInfos($phpFileInfos);
+        $this->rectorApplication->runOnPaths($paths);
 
         // must run after PHP rectors, because they might change class names, and these class names must be changed in configs
         $nonPhpFileInfos = $this->filesFinder->findInDirectoriesAndFiles(
@@ -248,25 +252,6 @@ final class ProcessCommand extends AbstractCommand
             return ShellCode::SUCCESS;
         }
         return ShellCode::ERROR;
-    }
-
-    /**
-     * @param string[] $paths
-     * @return SmartFileInfo[]
-     */
-    private function findPhpFileInfos(array $paths): array
-    {
-        $phpFileInfos = $this->filesFinder->findInDirectoriesAndFiles(
-            $paths,
-            $this->configuration->getFileExtensions()
-        );
-
-        // filter out non-PHP php files, e.g. blade templates in Laravel
-        $phpFileInfos = array_filter($phpFileInfos, function (SmartFileInfo $smartFileInfo): bool {
-            return ! Strings::endsWith($smartFileInfo->getPathname(), '.blade.php');
-        });
-
-        return $this->cachedFileInfoFilterAndReporter->filterFileInfos($phpFileInfos);
     }
 
     private function reportZeroCacheRectorsCondition(): void

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\Core\Console\Command;
 
-use Rector\Caching\Application\CachedFileInfoFilterAndReporter;
 use Rector\Caching\Detector\ChangedFilesDetector;
 use Rector\ChangesReporting\Application\ErrorAndDiffCollector;
 use Rector\ChangesReporting\Output\ConsoleOutputFormatter;
@@ -86,11 +85,6 @@ final class ProcessCommand extends AbstractCommand
     private $symfonyStyle;
 
     /**
-     * @var CachedFileInfoFilterAndReporter
-     */
-    private $cachedFileInfoFilterAndReporter;
-
-    /**
      * @var ComposerProcessor
      */
     private $composerProcessor;
@@ -113,7 +107,6 @@ final class ProcessCommand extends AbstractCommand
         RectorNodeTraverser $rectorNodeTraverser,
         StubLoader $stubLoader,
         SymfonyStyle $symfonyStyle,
-        CachedFileInfoFilterAndReporter $cachedFileInfoFilterAndReporter,
         ComposerProcessor $composerProcessor,
         PhpFilesFinder $phpFilesFinder
     ) {
@@ -129,7 +122,6 @@ final class ProcessCommand extends AbstractCommand
         $this->nonPhpFileProcessor = $nonPhpFileProcessor;
         $this->changedFilesDetector = $changedFilesDetector;
         $this->symfonyStyle = $symfonyStyle;
-        $this->cachedFileInfoFilterAndReporter = $cachedFileInfoFilterAndReporter;
         $this->composerProcessor = $composerProcessor;
         $this->phpFilesFinder = $phpFilesFinder;
 
@@ -207,7 +199,7 @@ final class ProcessCommand extends AbstractCommand
 
         $phpFileInfos = $this->phpFilesFinder->findInPaths($paths);
 
-        $this->additionalAutoloader->autoloadWithInputAndSource($input, $paths);
+        $this->additionalAutoloader->autoloadWithInputAndSource($input);
 
         if ($this->configuration->isCacheDebug()) {
             $message = sprintf('[cache] %d files after cache filter', count($phpFileInfos));

--- a/src/FileSystem/PhpFilesFinder.php
+++ b/src/FileSystem/PhpFilesFinder.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\FileSystem;
+
+use Nette\Utils\Strings;
+use Rector\Caching\Application\CachedFileInfoFilterAndReporter;
+use Rector\Core\Configuration\Configuration;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class PhpFilesFinder
+{
+    /**
+     * @var FilesFinder
+     */
+    private $filesFinder;
+
+    /**
+     * @var Configuration
+     */
+    private $configuration;
+
+    /**
+     * @var CachedFileInfoFilterAndReporter
+     */
+    private $cachedFileInfoFilterAndReporter;
+
+    public function __construct(
+        FilesFinder $filesFinder,
+        Configuration $configuration,
+        CachedFileInfoFilterAndReporter $cachedFileInfoFilterAndReporter
+    ) {
+        $this->filesFinder = $filesFinder;
+        $this->configuration = $configuration;
+        $this->cachedFileInfoFilterAndReporter = $cachedFileInfoFilterAndReporter;
+    }
+
+    /**
+     * @param string[] $paths
+     * @return SmartFileInfo[]
+     */
+    public function findInPaths(array $paths): array
+    {
+        $phpFileInfos = $this->filesFinder->findInDirectoriesAndFiles(
+            $paths,
+            $this->configuration->getFileExtensions()
+        );
+
+        // filter out non-PHP php files, e.g. blade templates in Laravel
+        $phpFileInfos = array_filter($phpFileInfos, function (SmartFileInfo $smartFileInfo): bool {
+            return ! Strings::endsWith($smartFileInfo->getPathname(), '.blade.php');
+        });
+
+        return $this->cachedFileInfoFilterAndReporter->filterFileInfos($phpFileInfos);
+    }
+}

--- a/src/StaticReflection/DynamicSourceLocatorDecorator.php
+++ b/src/StaticReflection/DynamicSourceLocatorDecorator.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Core\StaticReflection;
+
+use Rector\Core\FileSystem\PhpFilesFinder;
+use Rector\NodeTypeResolver\Reflection\BetterReflection\SourceLocatorProvider\DynamicSourceLocatorProvider;
+use Symplify\SmartFileSystem\FileSystemFilter;
+
+/**
+ * @see https://phpstan.org/blog/zero-config-analysis-with-static-reflection
+ * @see https://github.com/rectorphp/rector/issues/3490
+ */
+final class DynamicSourceLocatorDecorator
+{
+    /**
+     * @var FileSystemFilter
+     */
+    private $fileSystemFilter;
+
+    /**
+     * @var DynamicSourceLocatorProvider
+     */
+    private $dynamicSourceLocatorProvider;
+
+    /**
+     * @var PhpFilesFinder
+     */
+    private $phpFilesFinder;
+
+    public function __construct(
+        FileSystemFilter $fileSystemFilter,
+        DynamicSourceLocatorProvider $dynamicSourceLocatorProvider,
+        PhpFilesFinder $phpFilesFinder
+    ) {
+        $this->fileSystemFilter = $fileSystemFilter;
+        $this->dynamicSourceLocatorProvider = $dynamicSourceLocatorProvider;
+        $this->phpFilesFinder = $phpFilesFinder;
+    }
+
+    /**
+     * @param string[] $paths
+     */
+    public function addPaths(array $paths): void
+    {
+        $files = $this->fileSystemFilter->filterFiles($paths);
+        $this->dynamicSourceLocatorProvider->addFiles($files);
+
+        $directories = $this->fileSystemFilter->filterDirectories($paths);
+        foreach ($directories as $directory) {
+            $filesInfosInDirectory = $this->phpFilesFinder->findInPaths([$directory]);
+
+            $filesInDirectory = [];
+            foreach ($filesInfosInDirectory as $fileInfosInDirectory) {
+                $filesInDirectory[] = $fileInfosInDirectory->getRealPath();
+            }
+
+            $this->dynamicSourceLocatorProvider->addFilesByDirectory($directory, $filesInDirectory);
+        }
+    }
+}


### PR DESCRIPTION
Rector is failing in some weird combination of directories, after #5665 was merged.
I'm trying to figure out what combination on GitHub Actoins is causing this.

The `process` command is being stuck after 2 minutes, where usually is couple of hundred files:

![image](https://user-images.githubusercontent.com/924196/109658077-826d1680-7b66-11eb-8a67-e108ac428928.png)

With `--debug`, it gets stuck on 1st file:

```bash
➜  rector git:(multi-rector-matrix) bin/rector p rules -n --debug
[parsing] rules/arguments/config/config.php
[parsing] rules/arguments/src/NodeAnalyzer/ArgumentAddingScope.php
```

<br><br>

@ondrejmirtes Hi Ondra, do you have any tips on how to improve performance with static reflection? The parsing of each file is super slow after the #5665 gets merged.

Right now we're adding adding all the files found in processed directory right to SourceLocator: https://github.com/rectorphp/rector/blob/c6bf799da4a1f532f5bdb9f90f9ff236b2ce0756/src/Application/RectorApplication.php#L199 

Maybe it should be just the directory?