### PR TITLE
[Symfony4] Skip ConsoleExecuteReturnIntRector on ternary returns number

### DIFF
--- a/rules/symfony4/src/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
+++ b/rules/symfony4/src/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
@@ -110,10 +110,7 @@ CODE_SAMPLE
             }
 
             $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
-            if ($parentNode instanceof Return_ && $this->nodeComparator->areNodesEqual(
-                $parentNode->expr,
-                $node
-            ) && $node instanceof Int_) {
+            if ($this->isAReturnWithExprIntEquals($parentNode, $node)) {
                 $hasReturn = true;
                 return null;
             }
@@ -122,17 +119,12 @@ CODE_SAMPLE
                 return null;
             }
 
-            if ($node->expr instanceof Int_) {
-                return null;
-            }
-
-            if ($node->expr instanceof Ternary && $node->expr->if instanceof LNumber && $node->expr->else instanceof LNumber) {
+            if ($node->expr instanceof Int_ || ($node->expr instanceof Ternary && $node->expr->if instanceof LNumber && $node->expr->else instanceof LNumber)) {
                 $hasReturn = true;
                 return null;
             }
 
             // is there return without nesting?
-            $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
             if ($this->nodeComparator->areNodesEqual($parentNode, $classMethod)) {
                 $hasReturn = true;
             }
@@ -147,6 +139,14 @@ CODE_SAMPLE
         }
 
         $classMethod->stmts[] = new Return_(new LNumber(0));
+    }
+
+    private function isAReturnWithExprIntEquals(?Node $parentNode, Node $node): bool
+    {
+        return $parentNode instanceof Return_ && $this->nodeComparator->areNodesEqual(
+            $parentNode->expr,
+            $node
+        ) && $node instanceof Int_;
     }
 
     private function setReturnTo0InsteadOfNull(Return_ $return): void

--- a/rules/symfony4/src/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
+++ b/rules/symfony4/src/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
@@ -119,7 +119,11 @@ CODE_SAMPLE
                 return null;
             }
 
-            if ($node->expr instanceof Int_ || ($node->expr instanceof Ternary && $node->expr->if instanceof LNumber && $node->expr->else instanceof LNumber)) {
+            if ($node->expr instanceof Int_) {
+                return null;
+            }
+
+            if ($node->expr instanceof Ternary && $node->expr->if instanceof LNumber && $node->expr->else instanceof LNumber) {
                 $hasReturn = true;
                 return null;
             }
@@ -134,6 +138,11 @@ CODE_SAMPLE
             return null;
         });
 
+        $this->processReturn0ToMethod($hasReturn, $classMethod);
+    }
+
+    private function processReturn0ToMethod(bool $hasReturn, ClassMethod $classMethod): void
+    {
         if ($hasReturn) {
             return;
         }
@@ -143,10 +152,15 @@ CODE_SAMPLE
 
     private function isAReturnWithExprIntEquals(?Node $parentNode, Node $node): bool
     {
-        return $parentNode instanceof Return_ && $this->nodeComparator->areNodesEqual(
-            $parentNode->expr,
-            $node
-        ) && $node instanceof Int_;
+        if (! $parentNode instanceof Return_) {
+            return false;
+        }
+
+        if (! $this->nodeComparator->areNodesEqual($parentNode->expr, $node)) {
+            return false;
+        }
+
+        return $node instanceof Int_;
     }
 
     private function setReturnTo0InsteadOfNull(Return_ $return): void

--- a/rules/symfony4/src/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
+++ b/rules/symfony4/src/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
@@ -126,6 +126,11 @@ CODE_SAMPLE
                 return null;
             }
 
+            if ($node->expr instanceof Ternary && $node->expr->if instanceof LNumber && $node->expr->else instanceof LNumber) {
+                $hasReturn = true;
+                return null;
+            }
+
             // is there return without nesting?
             $parentNode = $node->getAttribute(AttributeKey::PARENT_NODE);
             if ($this->nodeComparator->areNodesEqual($parentNode, $classMethod)) {

--- a/rules/symfony4/src/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
+++ b/rules/symfony4/src/Rector/ClassMethod/ConsoleExecuteReturnIntRector.php
@@ -123,9 +123,13 @@ CODE_SAMPLE
                 return null;
             }
 
-            if ($node->expr instanceof Ternary && $node->expr->if instanceof LNumber && $node->expr->else instanceof LNumber) {
-                $hasReturn = true;
-                return null;
+            if ($node->expr instanceof Ternary) {
+                $ifType = $this->getStaticType($node->expr->if);
+                $elseType = $this->getStaticType($node->expr->else);
+                if ($ifType instanceof IntegerType && $elseType instanceof IntegerType) {
+                    $hasReturn = true;
+                    return null;
+                }
             }
 
             // is there return without nesting?

--- a/rules/symfony4/tests/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/skip_ternary_return_int.php.inc
+++ b/rules/symfony4/tests/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/skip_ternary_return_int.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Symfony4\Tests\Rector\ClassMethod\ConsoleExecuteReturnIntRector\Fixture;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class SkipTernaryReturnInt extends Command
+{
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        return rand(0, 1) ? 0 : 1;
+    }
+}

--- a/rules/symfony4/tests/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/skip_ternary_return_int_variable.php.inc
+++ b/rules/symfony4/tests/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/skip_ternary_return_int_variable.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Symfony4\Tests\Rector\ClassMethod\ConsoleExecuteReturnIntRector\Fixture;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+function returns_bool()
+{
+    return rand(0, 1) === 0;
+}
+
+final class SkipTernaryReturnIntVariable extends Command
+{
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $boolVariable = returns_bool();
+        return $boolVariable ? 0 : 1;
+    }
+}

--- a/rules/symfony4/tests/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/skip_ternary_return_int_variable_assign_bool.php.inc
+++ b/rules/symfony4/tests/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/skip_ternary_return_int_variable_assign_bool.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Symfony4\Tests\Rector\ClassMethod\ConsoleExecuteReturnIntRector\Fixture;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class SkipTernaryReturnIntVariableAssignBool extends Command
+{
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $boolVariable = true;
+        return $boolVariable ? 0 : 1;
+    }
+}

--- a/rules/symfony4/tests/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/skip_ternary_return_int_variable_in_if_else.php.inc
+++ b/rules/symfony4/tests/Rector/ClassMethod/ConsoleExecuteReturnIntRector/Fixture/skip_ternary_return_int_variable_in_if_else.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Symfony4\Tests\Rector\ClassMethod\ConsoleExecuteReturnIntRector\Fixture;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class SkipTernaryReturnIntVariableInIfElse extends Command
+{
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $yes = 0;
+        $no = 1;
+        return rand(0, 1) ? $yes : $no;
+    }
+}


### PR DESCRIPTION
Fixes #5733