### PR TITLE
Change success message

### DIFF
--- a/packages/changes-reporting/src/Output/ConsoleOutputFormatter.php
+++ b/packages/changes-reporting/src/Output/ConsoleOutputFormatter.php
@@ -218,7 +218,7 @@ final class ConsoleOutputFormatter implements OutputFormatterInterface
         }
 
         return sprintf(
-            'Rector changed %d file%s %s.',
+            '%d file%s %s by Rector.',
             $changeCount,
             $changeCount > 1 ? 's' : '',
             $this->configuration->isDryRun() ? 'would have changed (dry-run)' : ($changeCount === 1 ? 'has' : 'have') . ' been changed'


### PR DESCRIPTION
Changes the success messages from

- Rector changed 175 files have been changed.
- Rector changed 175 would have changed (dry-run).

to
- 175 files has been changed by Rector.
- 175 files would have changed (dry-run) by Rector.

Not sure if you have any idea for better wording, but already a huge improvement I would say 👍 

closes #5743 