### PR TITLE
Add failing test fixture for UnderscoreToCamelCaseLocalVariableNameRector

### DIFF
--- a/rules/naming/tests/Rector/Variable/UnderscoreToCamelCaseLocalVariableNameRector/Fixture/do_not_overwrite_existing_variables.php.inc
+++ b/rules/naming/tests/Rector/Variable/UnderscoreToCamelCaseLocalVariableNameRector/Fixture/do_not_overwrite_existing_variables.php.inc
@@ -1,0 +1,34 @@
+<?php
+
+namespace Rector\Naming\Tests\Rector\Variable\UnderscoreToCamelCaseLocalVariableNameRector\Fixture;
+
+final class DoNotOverwriteExistingVariables
+{
+    public function foo()
+    {
+       foreach ([[4]] as list ($foo_bar)) {}
+
+       foreach ([4] as $foo_bar) {}
+        
+       yield function () use (&$foo_bar) {
+           list ($foo_bar) = [$foo_bar];
+           return $foo_bar === 1;
+       };
+
+       $fooBar = 2;
+       
+       if ($foo_bar === 4) {
+           $test_example = 1;
+
+           $testExample = 5;
+
+           yield function () use (&$test_example) {
+               return $test_example === 1;
+           };
+       }
+        
+
+    }
+}
+?>
+-----


### PR DESCRIPTION
# Failing Test for UnderscoreToCamelCaseLocalVariableNameRector

Based on https://getrector.org/demo/754d498e-ac9d-4f72-9d8c-d695f340318b

Another addition to #5739 and #5715. 

Shall we fix #5750 this once and for all, or shall I invent more cases?