### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,10 +166,16 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // is your PHP version different from the one your refactor to? [default: your PHP version], uses PHP_VERSION_ID format
     $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_72);
 
-    // auto import fully qualified class names? [default: false]
+    // whether Rector can leave FQCN or automatically add them to use statements and remove from code occurences [default: false]
+    // e.g. 
+    // private \My\Namespace\MyService $field;
+    // vs
+    // use My\Namespace\MyService;
+    // ...
+    // private MyService $field;
     $parameters->set(Option::AUTO_IMPORT_NAMES, true);
 
-    // skip root namespace classes, like \DateTime or \Exception [default: true]
+    // whether to add use statements for root namespace classes, like \DateTime or \Exception [default: true]
     $parameters->set(Option::IMPORT_SHORT_CLASSES, false);
 
     // skip classes used in PHP DocBlocks, like in /** @var \Some\Class */ [default: true]


### PR DESCRIPTION
I find the current comment confusing.
1. `skip` in comment and `IMPORT...`  in constant name do not fit here together. Btw. `AUTO_IMPORT_NAMES` constant name is not clear to me. What "names"? It doesn't have to be changed but let's improve the comment here.
2. added very verbose and common term i.e. `... use statements` , because `import` word in context of what Rector does here can also be understood as `add type hint for root namespace classes`  
3. I don't know IMPORT_DOC_BLOCKS option yet, but I may require the same reword. I will have a look at this later or you can propose you own based on my 2 rewords.