### PR TITLE
Use the autoloader from where Rector was installed, not started

### DIFF
--- a/bin/rector.php
+++ b/bin/rector.php
@@ -78,7 +78,7 @@ final class AutoloadIncluder
      */
     public function autoloadProjectAutoloaderFile(): void
     {
-        $this->loadIfExistsAndNotLoadedYet(__DIR__ . '/../../autoload.php');
+        $this->loadIfExistsAndNotLoadedYet(__DIR__ . '/../../../autoload.php');
     }
 
     public function autoloadFromCommandLine(): void

--- a/bin/rector.php
+++ b/bin/rector.php
@@ -27,7 +27,6 @@ $autoloadIncluder = new AutoloadIncluder();
 $autoloadIncluder->includeDependencyOrRepositoryVendorAutoloadIfExists();
 
 $autoloadIncluder->loadIfExistsAndNotLoadedYet(__DIR__ . '/../vendor/scoper-autoload.php');
-$autoloadIncluder->loadIfExistsAndNotLoadedYet(__DIR__ . '/../vendor/autoload.php');
 
 $autoloadIncluder->autoloadProjectAutoloaderFile();
 $autoloadIncluder->autoloadFromCommandLine();

--- a/bin/rector.php
+++ b/bin/rector.php
@@ -27,7 +27,7 @@ $autoloadIncluder = new AutoloadIncluder();
 $autoloadIncluder->includeDependencyOrRepositoryVendorAutoloadIfExists();
 
 $autoloadIncluder->loadIfExistsAndNotLoadedYet(__DIR__ . '/../vendor/scoper-autoload.php');
-$autoloadIncluder->loadIfExistsAndNotLoadedYet(getcwd() . '/vendor/autoload.php');
+$autoloadIncluder->loadIfExistsAndNotLoadedYet(__DIR__ . '/../vendor/autoload.php');
 
 $autoloadIncluder->autoloadProjectAutoloaderFile();
 $autoloadIncluder->autoloadFromCommandLine();


### PR DESCRIPTION
#5665 should allow Rector to work without autoloading code from the project that's analyzed. Since I knew about the conflicts between Rector and older Symfony versions, and since I happen to have an older project with Symfony 2.3 around here, I tried to run a Rector Docker image with the changes from #5665 on in.

It fails with

```
Fatal error: Declaration of Symfony\Component\Console\Style\OutputStyle::write($messages, bool $newline = false, int $type = self::OUTPUT_NORMAL) must be compatible with Symfony\Component\Console\Output\OutputInterface::write($messages, $newline = false, $type = self::OUTPUT_NORMAL) in /rector/vendor/symfony/console/Style/OutputStyle.php on line 52
```

So, proably some mess-up between my project's version of Symfony and the one included in Rector. 

I then modified `vendor/autoload.php` in my project to throw an exception:

```
Fatal error: Uncaught Exception in /project/vendor/autoload.php:3
Stack trace:
#0 /rector/bin/rector.php(115): require_once()
#1 /rector/bin/rector.php(30): AutoloadIncluder->loadIfExistsAndNotLoadedYet('/project/vendor...')
#2 /rector/bin/rector(4): require_once('/rector/bin/rec...')
#3 {main}
  thrown in /project/vendor/autoload.php on line 3
````

`bin/rector` includes my project's autoloader? That's because `bin/rector.php` loads `vendor/autoload.php` from the current cwd. At least in the Docker image, that's the project directory, not the `/rector` one.

Thus, I think it would make more sense to use `__DIR__`. That would always be the autoloader from where Rector was installed, not where it is running.