### PR TITLE
[changelog] remove CHANGELOG.md first before run composer changelog on weekly composer changelog

### DIFF
--- a/.github/workflows/weekly_pull_requests.yaml
+++ b/.github/workflows/weekly_pull_requests.yaml
@@ -13,7 +13,7 @@ jobs:
                 actions:
                     -
                         name: "Re-Generate CHANGELOG.md"
-                        run: "composer changelog"
+                        run: "rm -rf CHANGELOG.md && composer changelog"
                         branch: 'automated-regenerated-changelog'
 
                     -


### PR DESCRIPTION
It seems automatic PR https://github.com/rectorphp/rector/pull/5789 doesn't generate tag header like manual delete and re-create at https://github.com/rectorphp/rector/pull/5719 . 

This ensure CHANGELOG.md re-generated by remove it first.