### PR TITLE
[AbstractRector] Point getStaticType() to call NodeTypeResolver->resolve()

### DIFF
--- a/rules/autodiscovery/src/Analyzer/ValueObjectClassAnalyzer.php
+++ b/rules/autodiscovery/src/Analyzer/ValueObjectClassAnalyzer.php
@@ -74,7 +74,7 @@ final class ValueObjectClassAnalyzer
 
         // resolve constructor types
         foreach ($constructClassMethod->params as $param) {
-            $paramType = $this->nodeTypeResolver->resolve($param);
+            $paramType = $this->getStaticType($param);
             if (! $paramType instanceof ObjectType) {
                 continue;
             }

--- a/rules/code-quality/src/NodeAnalyzer/CallableClassMethodMatcher.php
+++ b/rules/code-quality/src/NodeAnalyzer/CallableClassMethodMatcher.php
@@ -64,7 +64,7 @@ final class CallableClassMethodMatcher
             throw new ShouldNotHappenException();
         }
 
-        $objectType = $this->nodeTypeResolver->resolve($objectExpr);
+        $objectType = $this->getStaticType($objectExpr);
 
         if ($objectType instanceof ThisType) {
             $objectType = $objectType->getStaticObjectType();

--- a/rules/code-quality/src/Rector/Identical/FlipTypeControlToUseExclusiveTypeRector.php
+++ b/rules/code-quality/src/Rector/Identical/FlipTypeControlToUseExclusiveTypeRector.php
@@ -111,7 +111,7 @@ CODE_SAMPLE
         $type = $phpDocInfo->getVarType();
 
         if (! $type instanceof UnionType) {
-            $type = $this->getObjectType($assign->expr);
+            $type = $this->getStaticType($assign->expr);
         }
 
         if (! $type instanceof UnionType) {

--- a/rules/code-quality/src/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector.php
+++ b/rules/code-quality/src/Rector/Isset_/IssetOnPropertyObjectToPropertyExistsRector.php
@@ -96,7 +96,7 @@ CODE_SAMPLE
                 continue;
             }
 
-            $propertyFetchVarType = $this->getObjectType($issetVar->var);
+            $propertyFetchVarType = $this->getStaticType($issetVar->var);
 
             if ($propertyFetchVarType instanceof TypeWithClassName) {
                 if (! $this->reflectionProvider->hasClass($propertyFetchVarType->getClassName())) {

--- a/rules/dead-code/src/Doctrine/DoctrineEntityManipulator.php
+++ b/rules/dead-code/src/Doctrine/DoctrineEntityManipulator.php
@@ -125,7 +125,7 @@ final class DoctrineEntityManipulator
             return false;
         }
 
-        $objectType = $this->nodeTypeResolver->resolve($node->var);
+        $objectType = $this->getStaticType($node->var);
         if (! $objectType instanceof ObjectType) {
             return false;
         }

--- a/rules/dead-code/src/NodeManipulator/ClassMethodAndCallMatcher.php
+++ b/rules/dead-code/src/NodeManipulator/ClassMethodAndCallMatcher.php
@@ -78,7 +78,7 @@ final class ClassMethodAndCallMatcher
 
         $objectType = new ObjectType($className);
 
-        $callerStaticType = $this->nodeTypeResolver->resolve($staticCall->class);
+        $callerStaticType = $this->getStaticType($staticCall->class);
         if ($callerStaticType instanceof MixedType) {
             return false;
         }

--- a/rules/dead-code/src/Rector/Assign/RemoveAssignOfVoidReturnFunctionRector.php
+++ b/rules/dead-code/src/Rector/Assign/RemoveAssignOfVoidReturnFunctionRector.php
@@ -73,7 +73,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $exprType = $this->nodeTypeResolver->resolve($node->expr);
+        $exprType = $this->getStaticType($node->expr);
         if (! $exprType instanceof VoidType) {
             return null;
         }

--- a/rules/dead-code/src/SideEffect/SideEffectNodeDetector.php
+++ b/rules/dead-code/src/SideEffect/SideEffectNodeDetector.php
@@ -45,7 +45,7 @@ final class SideEffectNodeDetector
             return true;
         }
 
-        $exprStaticType = $this->nodeTypeResolver->resolve($expr);
+        $exprStaticType = $this->getStaticType($expr);
         if ($exprStaticType instanceof ConstantType) {
             return false;
         }

--- a/rules/dead-code/src/UselessIfCondBeforeForeachDetector.php
+++ b/rules/dead-code/src/UselessIfCondBeforeForeachDetector.php
@@ -57,7 +57,7 @@ final class UselessIfCondBeforeForeachDetector
         }
 
         // is array though?
-        $arrayType = $this->nodeTypeResolver->resolve($empty->expr);
+        $arrayType = $this->getStaticType($empty->expr);
 
         return ! $arrayType instanceof MixedType;
     }

--- a/rules/defluent/src/NodeAnalyzer/FluentChainMethodCallNodeAnalyzer.php
+++ b/rules/defluent/src/NodeAnalyzer/FluentChainMethodCallNodeAnalyzer.php
@@ -202,7 +202,7 @@ final class FluentChainMethodCallNodeAnalyzer
             $node = $node->var;
         }
 
-        $variableType = $this->nodeTypeResolver->resolve($node);
+        $variableType = $this->getStaticType($node);
         if ($variableType instanceof MixedType) {
             return false;
         }

--- a/rules/defluent/src/NodeAnalyzer/NewFluentChainMethodCallNodeAnalyzer.php
+++ b/rules/defluent/src/NodeAnalyzer/NewFluentChainMethodCallNodeAnalyzer.php
@@ -46,12 +46,12 @@ final class NewFluentChainMethodCallNodeAnalyzer
             return null;
         }
 
-        $newType = $this->nodeTypeResolver->resolve($onlyArgValue);
+        $newType = $this->getStaticType($onlyArgValue);
         if ($newType instanceof MixedType) {
             return null;
         }
 
-        $parentMethodCallReturnType = $this->nodeTypeResolver->resolve($methodCall);
+        $parentMethodCallReturnType = $this->getStaticType($methodCall);
         if (! $newType->equals($parentMethodCallReturnType)) {
             return null;
         }

--- a/rules/dependency-injection/src/Rector/Class_/ActionInjectionToConstructorInjectionRector.php
+++ b/rules/dependency-injection/src/Rector/Class_/ActionInjectionToConstructorInjectionRector.php
@@ -108,7 +108,7 @@ CODE_SAMPLE
                 continue;
             }
 
-            $paramNodeType = $this->getObjectType($paramNode);
+            $paramNodeType = $this->getStaticType($paramNode);
 
             /** @var string $paramName */
             $paramName = $this->getName($paramNode->var);
@@ -131,7 +131,7 @@ CODE_SAMPLE
             return false;
         }
 
-        $paramStaticType = $this->getObjectType($param);
+        $paramStaticType = $this->getStaticType($param);
         if (! $paramStaticType instanceof ObjectType) {
             return false;
         }

--- a/rules/dependency-injection/src/Rector/Class_/MultiParentingToAbstractDependencyRector.php
+++ b/rules/dependency-injection/src/Rector/Class_/MultiParentingToAbstractDependencyRector.php
@@ -211,7 +211,7 @@ CODE_SAMPLE
 
         $objectTypes = [];
         foreach ($constructorClassMethod->getParams() as $param) {
-            $paramType = $this->getObjectType($param);
+            $paramType = $this->getStaticType($param);
             $paramType = $this->popFirstObjectTypeFromUnionType($paramType);
 
             if (! $paramType instanceof ObjectType) {

--- a/rules/naming/src/Guard/BreakingVariableRenameGuard.php
+++ b/rules/naming/src/Guard/BreakingVariableRenameGuard.php
@@ -269,7 +269,7 @@ final class BreakingVariableRenameGuard
      */
     private function isDateTimeAtNamingConvention(Param $param): bool
     {
-        $type = $this->nodeTypeResolver->resolve($param);
+        $type = $this->getStaticType($param);
         $type = $this->typeUnwrapper->unwrapFirstObjectTypeFromUnionType($type);
         if (! $type instanceof TypeWithClassName) {
             return false;

--- a/rules/naming/src/Guard/DateTimeAtNamingConventionGuard.php
+++ b/rules/naming/src/Guard/DateTimeAtNamingConventionGuard.php
@@ -47,7 +47,7 @@ final class DateTimeAtNamingConventionGuard implements ConflictingNameGuardInter
 
     private function isDateTimeAtNamingConvention(PropertyRename $propertyRename): bool
     {
-        $type = $this->nodeTypeResolver->resolve($propertyRename->getProperty());
+        $type = $this->getStaticType($propertyRename->getProperty());
         $type = $this->typeUnwrapper->unwrapFirstObjectTypeFromUnionType($type);
 
         if (! $type instanceof TypeWithClassName) {

--- a/rules/nette-code-quality/src/Rector/Assign/MakeGetComponentAssignAnnotatedRector.php
+++ b/rules/nette-code-quality/src/Rector/Assign/MakeGetComponentAssignAnnotatedRector.php
@@ -127,7 +127,7 @@ CODE_SAMPLE
             return null;
         }
 
-        $nodeVar = $this->getObjectType($node->var);
+        $nodeVar = $this->getStaticType($node->var);
         if (! $nodeVar instanceof MixedType) {
             return null;
         }

--- a/rules/php70/src/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector.php
+++ b/rules/php70/src/Rector/StaticCall/StaticCallOnNonStaticToInstanceCallRector.php
@@ -154,7 +154,7 @@ CODE_SAMPLE
     private function resolveStaticCallClassName(StaticCall $staticCall): ?string
     {
         if ($staticCall->class instanceof PropertyFetch) {
-            $objectType = $this->getObjectType($staticCall->class);
+            $objectType = $this->getStaticType($staticCall->class);
             if ($objectType instanceof ObjectType) {
                 return $objectType->getClassName();
             }

--- a/rules/php71/src/NodeAnalyzer/CountableAnalyzer.php
+++ b/rules/php71/src/NodeAnalyzer/CountableAnalyzer.php
@@ -47,7 +47,7 @@ final class CountableAnalyzer
             return false;
         }
 
-        $callerObjectType = $this->nodeTypeResolver->resolve($expr->var);
+        $callerObjectType = $this->getStaticType($expr->var);
 
         $propertyName = $this->nodeNameResolver->getName($expr->name);
         if (! is_string($propertyName)) {

--- a/rules/php80/src/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
+++ b/rules/php80/src/Rector/Class_/ClassPropertyAssignToConstructorPromotionRector.php
@@ -148,7 +148,7 @@ CODE_SAMPLE
     private function processNullableType(Property $property, Param $param): void
     {
         if ($this->nodeTypeResolver->isNullableType($property)) {
-            $objectType = $this->getObjectType($property);
+            $objectType = $this->getStaticType($property);
             $param->type = $this->staticTypeMapper->mapPHPStanTypeToPhpParserNode($objectType);
         }
     }

--- a/rules/phpunit/src/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector.php
+++ b/rules/phpunit/src/Rector/ClassMethod/AddDoesNotPerformAssertionToNonAssertingTestRector.php
@@ -272,10 +272,10 @@ CODE_SAMPLE
         }
 
         if ($node instanceof MethodCall) {
-            $objectType = $this->getObjectType($node->var);
+            $objectType = $this->getStaticType($node->var);
         } else {
             // StaticCall
-            $objectType = $this->getObjectType($node->class);
+            $objectType = $this->getStaticType($node->class);
         }
 
         $reflectionMethod = $this->classMethodReflectionFactory->createFromPHPStanTypeAndMethodName(

--- a/rules/privatization/src/NodeAnalyzer/ClassMethodExternalCallNodeAnalyzer.php
+++ b/rules/privatization/src/NodeAnalyzer/ClassMethodExternalCallNodeAnalyzer.php
@@ -93,7 +93,7 @@ final class ClassMethodExternalCallNodeAnalyzer
         });
 
         foreach ($methodCalls as $methodCall) {
-            $callerType = $this->nodeTypeResolver->resolve($methodCall->var);
+            $callerType = $this->getStaticType($methodCall->var);
 
             if (! $callerType instanceof TypeWithClassName) {
                 // unable to handle reliably

--- a/rules/restoration/src/Rector/ClassMethod/InferParamFromClassMethodReturnRector.php
+++ b/rules/restoration/src/Rector/ClassMethod/InferParamFromClassMethodReturnRector.php
@@ -192,7 +192,7 @@ CODE_SAMPLE
 
     private function isParamDocTypeEqualToPhpType(Param $param, Type $paramType): bool
     {
-        $currentParamType = $this->getObjectType($param);
+        $currentParamType = $this->getStaticType($param);
         if ($currentParamType instanceof UnionType) {
             $currentParamType = $currentParamType->getTypes()[0];
         }

--- a/rules/symfony/src/Rector/MethodCall/GetParameterToConstructorInjectionRector.php
+++ b/rules/symfony/src/Rector/MethodCall/GetParameterToConstructorInjectionRector.php
@@ -89,7 +89,7 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $varType = $this->nodeTypeResolver->resolve($node->var);
+        $varType = $this->getStaticType($node->var);
         if (! $varType instanceof TypeWithClassName) {
             return null;
         }

--- a/rules/symfony/src/Rector/Return_/SimpleFunctionAndFilterRector.php
+++ b/rules/symfony/src/Rector/Return_/SimpleFunctionAndFilterRector.php
@@ -125,7 +125,7 @@ CODE_SAMPLE
                 return null;
             }
 
-            $newObjectType = $this->nodeTypeResolver->resolve($node->value);
+            $newObjectType = $this->getStaticType($node->value);
             return $this->processArrayItem($node, $newObjectType);
         });
 

--- a/rules/type-declaration/src/NodeAnalyzer/CallTypesResolver.php
+++ b/rules/type-declaration/src/NodeAnalyzer/CallTypesResolver.php
@@ -81,7 +81,7 @@ final class CallTypesResolver
         if ($strictnessLevel === TypeStrictness::STRICTNESS_TYPE_DECLARATION) {
             $argValueType = $this->nodeTypeResolver->getNativeType($arg->value);
         } else {
-            $argValueType = $this->nodeTypeResolver->resolve($arg->value);
+            $argValueType = $this->getStaticType($arg->value);
         }
 
         // "self" in another object is not correct, this make it independent

--- a/rules/type-declaration/src/NodeTypeAnalyzer/CallTypeAnalyzer.php
+++ b/rules/type-declaration/src/NodeTypeAnalyzer/CallTypeAnalyzer.php
@@ -69,7 +69,7 @@ final class CallTypeAnalyzer
             return $this->nodeTypeResolver->getStaticType($node->var);
         }
 
-        return $this->nodeTypeResolver->resolve($node->class);
+        return $this->getStaticType($node->class);
     }
 
     /**

--- a/rules/type-declaration/src/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector.php
+++ b/rules/type-declaration/src/Rector/ClassMethod/ReturnTypeFromStrictTypedCallRector.php
@@ -251,7 +251,7 @@ CODE_SAMPLE
         Node $returnedStrictTypeNode,
         FunctionLike $functionLike
     ): Node {
-        $resolvedType = $this->nodeTypeResolver->resolve($return);
+        $resolvedType = $this->getStaticType($return);
 
         if ($resolvedType instanceof UnionType) {
             if (! $returnedStrictTypeNode instanceof NullableType) {

--- a/rules/type-declaration/src/Reflection/ReflectionTypeResolver.php
+++ b/rules/type-declaration/src/Reflection/ReflectionTypeResolver.php
@@ -56,7 +56,7 @@ final class ReflectionTypeResolver
 
     public function resolveMethodCallReturnType(MethodCall $methodCall): ?Type
     {
-        $objectType = $this->nodeTypeResolver->resolve($methodCall->var);
+        $objectType = $this->getStaticType($methodCall->var);
         if (! $objectType instanceof TypeWithClassName) {
             return null;
         }
@@ -86,7 +86,7 @@ final class ReflectionTypeResolver
 
     public function resolvePropertyFetchType(PropertyFetch $propertyFetch): ?Type
     {
-        $objectType = $this->nodeTypeResolver->resolve($propertyFetch->var);
+        $objectType = $this->getStaticType($propertyFetch->var);
         if (! $objectType instanceof TypeWithClassName) {
             return null;
         }

--- a/rules/type-declaration/src/TypeInferer/ParamTypeInferer/PHPUnitDataProviderParamTypeInferer.php
+++ b/rules/type-declaration/src/TypeInferer/ParamTypeInferer/PHPUnitDataProviderParamTypeInferer.php
@@ -161,7 +161,7 @@ final class PHPUnitDataProviderParamTypeInferer implements ParamTypeInfererInter
 
     private function getTypeFromClassMethodYield(Array_ $classMethodYieldArrayNode): Type
     {
-        $arrayTypes = $this->nodeTypeResolver->resolve($classMethodYieldArrayNode);
+        $arrayTypes = $this->getStaticType($classMethodYieldArrayNode);
 
         // impossible to resolve
         if (! $arrayTypes instanceof ConstantArrayType) {
@@ -201,7 +201,7 @@ final class PHPUnitDataProviderParamTypeInferer implements ParamTypeInfererInter
                     continue;
                 }
 
-                $paramOnPositionTypes[] = $this->nodeTypeResolver->resolve($singleDataProvidedSetItem->value);
+                $paramOnPositionTypes[] = $this->getStaticType($singleDataProvidedSetItem->value);
             }
         }
 

--- a/src/Rector/AbstractRector.php
+++ b/src/Rector/AbstractRector.php
@@ -348,7 +348,7 @@ abstract class AbstractRector extends NodeVisitorAbstract implements PhpRectorIn
 
     protected function getStaticType(Node $node): Type
     {
-        return $this->nodeTypeResolver->getStaticType($node);
+        return $this->nodeTypeResolver->resolve($node);
     }
 
     /**


### PR DESCRIPTION
As `NodeTypeResolver-> getStaticType()` is deprecated. 