### PR TITLE
[TypeDeclaration] Skip null type on non-private property and not used on CompleteVarDocTypePropertyRector

### DIFF
--- a/rules-tests/TypeDeclaration/Rector/Property/CompleteVarDocTypePropertyRector/Fixture/private_var_null_unused.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/CompleteVarDocTypePropertyRector/Fixture/private_var_null_unused.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\CompleteVarDocTypePropertyRector\Fixture;
+
+class PrivateVarNullUnused
+{
+    private $config = null;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\CompleteVarDocTypePropertyRector\Fixture;
+
+class PrivateVarNullUnused
+{
+    /**
+     * @var null
+     */
+    private $config = null;
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Property/CompleteVarDocTypePropertyRector/Fixture/public_var_null_used.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/CompleteVarDocTypePropertyRector/Fixture/public_var_null_used.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\CompleteVarDocTypePropertyRector\Fixture;
+
+use stdClass;
+
+class PublicVarNullUsed
+{
+    public $config = null;
+
+    public function run()
+    {
+        $this->config = new stdClass;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\CompleteVarDocTypePropertyRector\Fixture;
+
+use stdClass;
+
+class PublicVarNullUsed
+{
+    /**
+     * @var null|\stdClass
+     */
+    public $config = null;
+
+    public function run()
+    {
+        $this->config = new stdClass;
+    }
+}
+
+?>

--- a/rules-tests/TypeDeclaration/Rector/Property/CompleteVarDocTypePropertyRector/Fixture/skip_public_var_null_unused.php.inc
+++ b/rules-tests/TypeDeclaration/Rector/Property/CompleteVarDocTypePropertyRector/Fixture/skip_public_var_null_unused.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rector\Tests\TypeDeclaration\Rector\Property\CompleteVarDocTypePropertyRector\Fixture;
+
+class SkipPublicVarNull
+{
+    public $config = null;
+}

--- a/rules/TypeDeclaration/Rector/Property/CompleteVarDocTypePropertyRector.php
+++ b/rules/TypeDeclaration/Rector/Property/CompleteVarDocTypePropertyRector.php
@@ -12,6 +12,7 @@ use Rector\Core\Rector\AbstractRector;
 use Rector\TypeDeclaration\TypeInferer\PropertyTypeInferer;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use PHPStan\Type\NullType;
 
 /**
  * @see \Rector\Tests\TypeDeclaration\Rector\Property\CompleteVarDocTypePropertyRector\CompleteVarDocTypePropertyRectorTest
@@ -85,6 +86,10 @@ CODE_SAMPLE
     {
         $propertyType = $this->propertyTypeInferer->inferProperty($node);
         if ($propertyType instanceof MixedType) {
+            return null;
+        }
+
+        if (! $node->isPrivate() && $propertyType instanceof NullType) {
             return null;
         }
 


### PR DESCRIPTION
Skip null default value on non-private property, eg: public can be used by outside class.