### PR TITLE
[Github Action]  Fixes fail-fast location to be in strategy on publish_docker_images action

### DIFF
--- a/.github/workflows/publish_docker_images.yaml
+++ b/.github/workflows/publish_docker_images.yaml
@@ -15,7 +15,7 @@ jobs:
         strategy:
             matrix:
                 php-version: ['7.3', '7.4', '8.0']
-                fail-fast: false
+            fail-fast: false
         steps:
             - name: Checkout
               uses: actions/checkout@v2

--- a/.github/workflows/publish_docker_images.yaml
+++ b/.github/workflows/publish_docker_images.yaml
@@ -13,9 +13,9 @@ jobs:
     publish_images:
         runs-on: ubuntu-20.04
         strategy:
+            fail-fast: false
             matrix:
                 php-version: ['7.3', '7.4', '8.0']
-            fail-fast: false
         steps:
             - name: Checkout
               uses: actions/checkout@v2


### PR DESCRIPTION
Fixes #5849