### PR TITLE
[scoped] rector now runs without command name too

### DIFF
--- a/scoped/.github/workflows/along_phpstan.yaml
+++ b/scoped/.github/workflows/along_phpstan.yaml
@@ -36,5 +36,5 @@ jobs:
             -
                 run: |
                     cd standalone
-                    vendor/bin/rector -h --ansi
+                    vendor/bin/rector list -h --ansi
                     vendor/bin/phpstan -h --ansi

--- a/scoped/.github/workflows/bare_run.yaml
+++ b/scoped/.github/workflows/bare_run.yaml
@@ -20,4 +20,4 @@ jobs:
                     php-version: ${{ matrix.php_version }}
                     coverage: none
 
-            -   run: php bin/rector --ansi
+            -   run: php bin/rector list --ansi

--- a/scoped/.github/workflows/composer_dependency.yaml
+++ b/scoped/.github/workflows/composer_dependency.yaml
@@ -47,4 +47,4 @@ jobs:
                     # run
                     composer require rector/rector-prefixed:dev-main --dev --ansi
                     composer require symfony/console ${{ matrix.symfony_version }}
-                    vendor/bin/rector --debug --ansi
+                    vendor/bin/rector list --debug --ansi


### PR DESCRIPTION
Rector now runs also without `process` command.


This PR fixes exception if no config is around https://github.com/rectorphp/rector-prefixed/runs/2107855629


/cc @samsonasik 