### PR TITLE
Bugfix for AbsolutizeRequireAndIncludePathRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Include_/AbsolutizeRequireAndIncludePathRector/Fixture/dots.php.inc
+++ b/rules-tests/CodeQuality/Rector/Include_/AbsolutizeRequireAndIncludePathRector/Fixture/dots.php.inc
@@ -7,6 +7,8 @@ class Dots
     public function run()
     {
         require './vendor/autoload.php';
+
+        require '../AbsolutizeRequireAndIncludePathRectorTest.php';
     }
 }
 
@@ -20,7 +22,9 @@ class Dots
 {
     public function run()
     {
-        require __DIR__ . './vendor/autoload.php';
+        require __DIR__ . '/vendor/autoload.php';
+
+        require __DIR__ . '/../AbsolutizeRequireAndIncludePathRectorTest.php';
     }
 }
 

--- a/rules-tests/CodeQuality/Rector/Include_/AbsolutizeRequireAndIncludePathRector/Fixture/vendor_phar.php.inc
+++ b/rules-tests/CodeQuality/Rector/Include_/AbsolutizeRequireAndIncludePathRector/Fixture/vendor_phar.php.inc
@@ -26,7 +26,7 @@ class VendorPhar
     {
         require __DIR__ . '/vendor/autoload.php';
 
-        include __DIR__ . '/vendor/autoload.php';
+        include '/vendor/autoload.php';
 
         include_once 'phar://vendor/autoload.php';
     }

--- a/rules/CodeQuality/Rector/Include_/AbsolutizeRequireAndIncludePathRector.php
+++ b/rules/CodeQuality/Rector/Include_/AbsolutizeRequireAndIncludePathRector.php
@@ -38,7 +38,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-,
+                    ,
                     <<<'CODE_SAMPLE'
 class SomeClass
 {
@@ -50,7 +50,7 @@ class SomeClass
     }
 }
 CODE_SAMPLE
-            ),
+                ),
             ]
         );
     }

--- a/rules/CodeQuality/Rector/Include_/AbsolutizeRequireAndIncludePathRector.php
+++ b/rules/CodeQuality/Rector/Include_/AbsolutizeRequireAndIncludePathRector.php
@@ -75,14 +75,15 @@ CODE_SAMPLE
         /** @var string $includeValue */
         $includeValue = $this->valueResolver->getValue($node->expr);
 
-        // skip phar
-        if (Strings::startsWith($includeValue, 'phar://')) {
+        // skip phar and absolute paths
+        if (Strings::startsWith($includeValue, 'phar://') || Strings::startsWith($includeValue, '/')) {
             return null;
         }
 
         // add preslash to string
-        // keep dots
-        if (! Strings::startsWith($includeValue, '/') && ! Strings::startsWith($includeValue, '.')) {
+        if (Strings::startsWith($includeValue, './')) {
+            $node->expr->value = substr($includeValue, 1);
+        } else {
             $node->expr->value = '/' . $includeValue;
         }
 


### PR DESCRIPTION
Absolute paths should not be changed, dots need a leading slash.

Here is the original code I found this bug with:
- `include('../../prepend_light.php'); // unmodified`

After running Rector:
- `include(__DIR__ . '../../prepend_light.php'); // incorrectly modified (without this PR)`
- `include(__DIR__ . '/../../prepend_light.php'); // correctly modified (with this PR)`

See https://www.php.net/manual/en/function.include.php for how PHP treats the string passed to `include` and the related language constructs.

I am a bit confused how the broken PHPUnit fixtures were checked. What am I forgetting? 🤔