### PR TITLE
Bugfix for SimplifyForeachToArrayFilterRector

### DIFF
--- a/packages/Testing/PHPUnit/AbstractRectorTestCase.php
+++ b/packages/Testing/PHPUnit/AbstractRectorTestCase.php
@@ -160,7 +160,7 @@ abstract class AbstractRectorTestCase extends AbstractKernelTestCase
 
         $inputFileInfo = $inputFileInfoAndExpectedFileInfo->getInputFileInfo();
 
-        // needed for PHPStan, because the analyzed file is just create in /temp
+        // needed for PHPStan, because the analyzed file is just created in /temp
         /** @var NodeScopeResolver $nodeScopeResolver */
         $nodeScopeResolver = $this->getService(NodeScopeResolver::class);
         $nodeScopeResolver->setAnalysedFiles([$inputFileInfo->getRealPath()]);

--- a/rules-tests/CodeQuality/Rector/Foreach_/SimplifyForeachToArrayFilterRector/Fixture/same_var.php.inc
+++ b/rules-tests/CodeQuality/Rector/Foreach_/SimplifyForeachToArrayFilterRector/Fixture/same_var.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Foreach_\SimplifyForeachToArrayFilterRector\Fixture;
+
+$responseData = [];
+foreach ($responseData as $key => $value) {
+    if (is_string($value)) {
+        $responseData[$key] = $value;
+    }
+}
+
+?>

--- a/rules/CodeQuality/Rector/Foreach_/SimplifyForeachToArrayFilterRector.php
+++ b/rules/CodeQuality/Rector/Foreach_/SimplifyForeachToArrayFilterRector.php
@@ -74,11 +74,7 @@ CODE_SAMPLE
             return null;
         }
 
-        if (count($funcCallNode->args) !== 1) {
-            return null;
-        }
-
-        if (! $this->nodeComparator->areNodesEqual($funcCallNode->args[0], $node->valueVar)) {
+        if (! $this->isSimpleCall($funcCallNode, $node)) {
             return null;
         }
 
@@ -158,5 +154,14 @@ CODE_SAMPLE
         }
 
         return $loopVar->name !== $varThatIsModified->name;
+    }
+
+    private function isSimpleCall(FuncCall $funcCallNode, Foreach_ $foreach): bool
+    {
+        if (count($funcCallNode->args) !== 1) {
+            return false;
+        }
+
+        return $this->nodeComparator->areNodesEqual($funcCallNode->args[0], $foreach->valueVar);
     }
 }


### PR DESCRIPTION
Bugfix: leave the loop as it is if the array looped over is modified within the loop (rather then filled from scratch).

I have added an example to the PHPUnit tests which this Rector rule should not touch. The example is odd, but harmless. If the rule applies it would break.