### PR TITLE
Fix for PhpSpec method shouldEqual

### DIFF
--- a/rules-tests/PhpSpecToPHPUnit/Rector/Variable/PhpSpecToPHPUnitRector/Fixture/identity_matcher.php.inc
+++ b/rules-tests/PhpSpecToPHPUnit/Rector/Variable/PhpSpecToPHPUnitRector/Fixture/identity_matcher.php.inc
@@ -1,0 +1,38 @@
+<?php
+
+namespace spec\Rector\Tests\PhpSpecToPHPUnit\Rector\Variable\PhpSpecToPHPUnitRector\Fixture;
+
+use PhpSpec\ObjectBehavior;
+
+class CurrencySpec extends ObjectBehavior
+{
+    public function it_returns_true()
+    {
+        $this->foo()->shouldEqual(true);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Tests\Rector\Tests\PhpSpecToPHPUnit\Rector\Variable\PhpSpecToPHPUnitRector\Fixture;
+
+use PhpSpec\ObjectBehavior;
+
+class CurrencyTest extends \PHPUnit\Framework\TestCase
+{
+    private \Rector\Tests\PhpSpecToPHPUnit\Rector\Variable\PhpSpecToPHPUnitRector\Fixture\Currency $currency;
+    private \CurrencyData|\PHPUnit\Framework\MockObject\MockObject $data;
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->currency = new \Rector\Tests\PhpSpecToPHPUnit\Rector\Variable\PhpSpecToPHPUnitRector\Fixture\Currency();
+    }
+    public function testReturnsTrue()
+    {
+        $this->assertEquals(true, $this->currency->foo());
+    }
+}
+
+?>

--- a/rules/PhpSpecToPHPUnit/Rector/MethodCall/PhpSpecPromisesToPHPUnitAssertRector.php
+++ b/rules/PhpSpecToPHPUnit/Rector/MethodCall/PhpSpecPromisesToPHPUnitAssertRector.php
@@ -40,7 +40,7 @@ final class PhpSpecPromisesToPHPUnitAssertRector extends AbstractPhpSpecToPHPUni
         'assertSame' => ['shouldBe', 'shouldReturn'],
         'assertNotSame' => ['shouldNotBe', 'shouldNotReturn'],
         'assertCount' => ['shouldHaveCount'],
-        'assertEquals' => ['shouldBeEqualTo'],
+        'assertEquals' => ['shouldBeEqualTo', 'shouldEqual'],
         'assertNotEquals' => ['shouldNotBeEqualTo'],
         'assertContains' => ['shouldContain'],
         'assertNotContains' => ['shouldNotContain'],


### PR DESCRIPTION
Hi

Here is a quick fix for handling PhpSpec method `shouldEqual` when using rector suite PhpSpecToPHPUnit