### PR TITLE
Forward compatibility with PHPStan 0.12.82

### DIFF
--- a/src/NodeManipulator/ClassMethodAssignManipulator.php
+++ b/src/NodeManipulator/ClassMethodAssignManipulator.php
@@ -19,7 +19,7 @@ use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Foreach_;
-use PHPStan\Reflection\ObjectTypeMethodReflection;
+use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParameterReflection;
 use PHPStan\Reflection\ParametersAcceptor;
 use PHPStan\Type\Type;
@@ -333,7 +333,7 @@ final class ClassMethodAssignManipulator
         }
 
         $methodReflection = $this->callReflectionResolver->resolveCall($node);
-        if (! $methodReflection instanceof ObjectTypeMethodReflection) {
+        if (! $methodReflection instanceof MethodReflection) {
             return false;
         }
 


### PR DESCRIPTION
ObjectTypeMethodReflection is just one of the implementations of MethodReflection interface, its existence was never part of a public API promise. Now a different implementation is returned, it depends on the situation. I guess this change is sufficient.