### PR TITLE
PropertyTypeVendorLockResolver deal with null scope from trait

### DIFF
--- a/packages/VendorLocker/NodeVendorLocker/PropertyTypeVendorLockResolver.php
+++ b/packages/VendorLocker/NodeVendorLocker/PropertyTypeVendorLockResolver.php
@@ -33,8 +33,12 @@ final class PropertyTypeVendorLockResolver
 
     public function isVendorLocked(Property $property): bool
     {
-        /** @var Scope $scope */
+        /** @var Scope|null $scope */
         $scope = $property->getAttribute(AttributeKey::SCOPE);
+
+        if($scope === null) {
+            return false;
+        }
 
         $classReflection = $scope->getClassReflection();
         if (! $classReflection instanceof ClassReflection) {


### PR DESCRIPTION
Was causing Uncaught Error: Call to a member function
getClassReflection() on null

PHPStan does not provide scope for traits themselves,
as they only exist inside a context of a class.

Fixes #5955