### PR TITLE
Add missing paths to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,7 +12,6 @@
 .gitignore export-ignore
 .phpstorm.meta.php export-ignore
 CODE_OF_CONDUCT.md export-ignore
-LICENSE export-ignore
 ecs.php export-ignore
 phpstan.neon export-ignore
 phpunit.xml export-ignore
@@ -26,6 +25,19 @@ stubs export-ignore
 tests export-ignore
 packages-tests export-ignore
 rules-tests export-ignore
+build export-ignore
+full_build.sh export-ignore
+Dockerfile export-ignore
+UPGRADE_09.md export-ignore
+rule-doc-generator.php export-ignore
+docs export-ignore
+scoper.php export-ignore
+.docker export-ignore
+.github export-ignore
+.dockerignore export-ignore
+CONTRIBUTING.md export-ignore
+README.md export-ignore
+CHANGELOG.md export-ignore
 
 # testing Windows spaces - https://help.github.com/en/github/using-git/configuring-git-to-handle-line-endings
 packages/better-php-doc-parser/tests/PhpDocInfo/PhpDocInfoPrinter/FixtureBasic/with_spac.txt text eol=crlf


### PR DESCRIPTION
I have added a bunch of files to being ignored in exports. 

I think the biggest difference here is adding docs folder as it contains pictures. 

I have also re-added back the license file, as I don't think the license should be excluded when I include the package 👍 


I was unsure if the `phpstan-for-rector.neon` file should be excluded or not, so I left it in.


closes: #5948 