### PR TITLE
Readme and docs should be included in rector installation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -36,7 +36,6 @@ scoper.php export-ignore
 .github export-ignore
 .dockerignore export-ignore
 CONTRIBUTING.md export-ignore
-README.md export-ignore
 CHANGELOG.md export-ignore
 
 # testing Windows spaces - https://help.github.com/en/github/using-git/configuring-git-to-handle-line-endings

--- a/.gitattributes
+++ b/.gitattributes
@@ -30,7 +30,6 @@ full_build.sh export-ignore
 Dockerfile export-ignore
 UPGRADE_09.md export-ignore
 rule-doc-generator.php export-ignore
-docs export-ignore
 scoper.php export-ignore
 .docker export-ignore
 .github export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -30,6 +30,7 @@ full_build.sh export-ignore
 Dockerfile export-ignore
 UPGRADE_09.md export-ignore
 rule-doc-generator.php export-ignore
+docs/images export-ignore
 scoper.php export-ignore
 .docker export-ignore
 .github export-ignore

--- a/README.md
+++ b/README.md
@@ -30,25 +30,25 @@ It supports all versions of PHP from 5.3 and major open-source projects:
 <br>
 
 <p align="center">
-    <img src="/docs/images/php.png">
-    <img src="/docs/images/space.png" width=30>
-    <a href="https://github.com/rectorphp/rector-phpunit"><img src="/docs/images/phpunit.png"></a>
-    <img src="/docs/images/space.png" width=30>
-    <a href="https://github.com/rectorphp/rector-symfony"><img src="/docs/images/symfony.png"></a>
-    <img src="/docs/images/space.png" width=30>
+    <img src="https://github.com/rectorphp/rector/blob/main/docs/images/php.png">
+    <img src="https://github.com/rectorphp/rector/blob/main/docs/images/space.png" width=30>
+    <a href="https://github.com/rectorphp/rector-phpunit"><img src="https://github.com/rectorphp/rector/blob/main/docs/images/phpunit.png"></a>
+    <img src="https://github.com/rectorphp/rector/blob/main/docs/images/space.png" width=30>
+    <a href="https://github.com/rectorphp/rector-symfony"><img src="https://github.com/rectorphp/rector/blob/main/docs/images/symfony.png"></a>
+    <img src="https://github.com/rectorphp/rector/blob/main/docs/images/space.png" width=30>
     <a href="https://github.com/palantirnet/drupal-rector">
-        <img src="/docs/images/drupal.png" alt="Drupal Rector rules">
+        <img src="https://github.com/rectorphp/rector/blob/main/docs/images/drupal.png" alt="Drupal Rector rules">
     </a>
     <br>
-    <img src="/docs/images/space.png" height=15>
+    <img src="https://github.com/rectorphp/rector/blob/main/docs/images/space.png" height=15>
     <br>
-    <a href="https://github.com/rectorphp/rector-cakephp"><img src="/docs/images/cakephp.png"></a>
-    <img src="/docs/images/space.png" width=30>
+    <a href="https://github.com/rectorphp/rector-cakephp"><img src="https://github.com/rectorphp/rector/blob/main/docs/images/cakephp.png"></a>
+    <img src="https://github.com/rectorphp/rector/blob/main/docs/images/space.png" width=30>
     <a href="https://github.com/sabbelasichon/typo3-rector">
-        <img src="/docs/images/typo3.png">
+        <img src="https://github.com/rectorphp/rector/blob/main/docs/images/typo3.png">
     </a>
     <br>
-    <img src="/docs/images/space.png" height=15>
+    <img src="https://github.com/rectorphp/rector/blob/main/docs/images/space.png" height=15>
 </p>
 
 ### What Can Rector Do for You?


### PR DESCRIPTION
I think Readme and docs files should be included in rector installation so user doesn't need to look at github repo to read it.