### PR TITLE
[Naming] Skip RenameForeachValueVariableToMatchExprVariableRector on empty singular value name result

### DIFF
--- a/rules-tests/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchExprVariableRector/Fixture/skip_empty_singular_value.php.inc
+++ b/rules-tests/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchExprVariableRector/Fixture/skip_empty_singular_value.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\Naming\Rector\Foreach_\RenameForeachValueVariableToMatchExprVariableRector\Fixture;
+
+class SkipEmptySingularValue
+{
+    public function run()
+    {
+        foreach ($_FOO as $file) {
+
+        }
+    }
+}

--- a/rules/Naming/ExpectedNameResolver/InflectorSingularResolver.php
+++ b/rules/Naming/ExpectedNameResolver/InflectorSingularResolver.php
@@ -64,6 +64,10 @@ final class InflectorSingularResolver
             $singularValueVarName .= $this->inflector->singularize($camelCase['camelcase']);
         }
 
+        if ($singularValueVarName === '') {
+            return $currentName;
+        }
+
         $singularValueVarName = $singularValueVarName === $currentName
             ? self::SINGLE . ucfirst($singularValueVarName)
             : $singularValueVarName;

--- a/rules/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchExprVariableRector.php
+++ b/rules/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchExprVariableRector.php
@@ -99,11 +99,11 @@ CODE_SAMPLE
         }
 
         $singularValueVarName = $this->inflectorSingularResolver->resolve($exprName);
-        if ($this->shouldSkip($valueVarName, $singularValueVarName, $node)) {
+        if ($singularValueVarName === $exprName) {
             return null;
         }
 
-        if ($singularValueVarName === '') {
+        if ($this->shouldSkip($valueVarName, $singularValueVarName, $node)) {
             return null;
         }
 

--- a/rules/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchExprVariableRector.php
+++ b/rules/Naming/Rector/Foreach_/RenameForeachValueVariableToMatchExprVariableRector.php
@@ -103,6 +103,10 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($singularValueVarName === '') {
+            return null;
+        }
+
         return $this->processRename($node, $valueVarName, $singularValueVarName);
     }
 


### PR DESCRIPTION
Fixes #5977 