### PR TITLE
Add failing test fixture for RemoveUselessReturnTagRector

### DIFF
--- a/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessReturnTagRector/Fixture/demo_file.php.inc
+++ b/rules-tests/DeadCode/Rector/ClassMethod/RemoveUselessReturnTagRector/Fixture/demo_file.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\DeadCode\Tests\Rector\ClassMethod\RemoveUselessReturnTagRector\Fixture;
+
+final class DemoFile
+{
+    /**
+     * @return static
+     */
+    public function run(): self
+    {
+        return new self();
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\DeadCode\Tests\Rector\ClassMethod\RemoveUselessReturnTagRector\Fixture;
+
+final class DemoFile
+{
+    /**
+     * @return static
+     */
+    public function run(): self
+    {
+        return new self();
+    }
+}
+?>


### PR DESCRIPTION
# Failing Test for RemoveUselessReturnTagRector

Based on https://getrector.org/demo/507ba36e-e7da-4f4f-9d7f-a34a239606c2

IMHO this should be kept like it is