### PR TITLE
[CodingStyle]  Escape content delimiter in pattern for ConsistentPregDelimiterRector

### DIFF
--- a/rules-tests/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector/Fixture/escape_content_delimiter_in_pattern.php.inc
+++ b/rules-tests/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector/Fixture/escape_content_delimiter_in_pattern.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\FuncCall\ConsistentPregDelimiterRector\Fixture;
+
+class EscapeContentDelimiterInPattern
+{
+    public function run($value)
+    {
+        preg_match('/^#(([a-f0-9]{3}){1,2})$/i', '#ffffff');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\FuncCall\ConsistentPregDelimiterRector\Fixture;
+
+class EscapeContentDelimiterInPattern
+{
+    public function run($value)
+    {
+        preg_match('#^\#(([a-f0-9]{3}){1,2})$#i', '#ffffff');
+    }
+}
+
+?>

--- a/rules-tests/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector/Fixture/escape_content_delimiter_in_pattern_multi.php.inc
+++ b/rules-tests/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector/Fixture/escape_content_delimiter_in_pattern_multi.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\FuncCall\ConsistentPregDelimiterRector\Fixture;
+
+class EscapeContentDelimiterInPatternMulti
+{
+    public function run($value)
+    {
+        preg_match('/^#(([a-f0-9]{3}){1,2})#$/i', '#ffffff#');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\FuncCall\ConsistentPregDelimiterRector\Fixture;
+
+class EscapeContentDelimiterInPatternMulti
+{
+    public function run($value)
+    {
+        preg_match('#^\#(([a-f0-9]{3}){1,2})\#$#i', '#ffffff#');
+    }
+}
+
+?>

--- a/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
@@ -169,9 +169,8 @@ CODE_SAMPLE
         $string->value = Strings::replace($value, self::INNER_REGEX, function (array $match): string {
             $innerPattern = $match['content'];
             $positionDelimiter = strpos($innerPattern, $this->delimiter);
-            $lengthInnerPattern = strlen($innerPattern);
 
-            if ($positionDelimiter > 0 && $positionDelimiter < $lengthInnerPattern) {
+            if ($positionDelimiter > 0) {
                 $innerPattern = str_replace($this->delimiter, '\\' . $this->delimiter, $innerPattern);
             }
 

--- a/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
@@ -168,6 +168,8 @@ CODE_SAMPLE
 
         $string->value = Strings::replace($value, self::INNER_REGEX, function (array $match): string {
             $innerPattern = $match['content'];
+            $innerPattern = str_replace($this->delimiter, '\\' . $this->delimiter, $innerPattern);
+
             // change delimiter
             if (strlen($innerPattern) > 2 && $innerPattern[0] === $innerPattern[strlen($innerPattern) - 1]) {
                 $innerPattern[0] = $this->delimiter;

--- a/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
@@ -168,7 +168,12 @@ CODE_SAMPLE
 
         $string->value = Strings::replace($value, self::INNER_REGEX, function (array $match): string {
             $innerPattern = $match['content'];
-            $innerPattern = str_replace($this->delimiter, '\\' . $this->delimiter, $innerPattern);
+            $positionDelimiter = strpos($innerPattern, $this->delimiter);
+            $lengthInnerPattern = strlen($innerPattern);
+
+            if ($positionDelimiter > 0 && $positionDelimiter < $lengthInnerPattern) {
+                $innerPattern = str_replace($this->delimiter, '\\' . $this->delimiter, $innerPattern);
+            }
 
             // change delimiter
             if (strlen($innerPattern) > 2 && $innerPattern[0] === $innerPattern[strlen($innerPattern) - 1]) {


### PR DESCRIPTION
Fixes #5987