### PR TITLE
Stripping quotation marks of argument default value

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -122,7 +122,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(ArgumentAdderRector::class)
         ->call('configure', [[
 ArgumentAdderRector::ADDED_ARGUMENTS => ValueObjectInliner::inline([
-    new ArgumentAdder('SomeExampleClass', 'someMethod', 0, 'someArgument', 'true', 'SomeType', null),
+    new ArgumentAdder('SomeExampleClass', 'someMethod', 0, 'someArgument', true, 'SomeType', null),
     ]),
 ]]);
 };
@@ -150,7 +150,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(ArgumentAdderRector::class)
         ->call('configure', [[
 ArgumentAdderRector::ADDED_ARGUMENTS => ValueObjectInliner::inline([
-    new ArgumentAdder('SomeExampleClass', 'someMethod', 0, 'someArgument', 'true', 'SomeType', null),
+    new ArgumentAdder('SomeExampleClass', 'someMethod', 0, 'someArgument', true, 'SomeType', null),
     ]),
 ]]);
 };

--- a/rules/Arguments/Rector/ClassMethod/ArgumentAdderRector.php
+++ b/rules/Arguments/Rector/ClassMethod/ArgumentAdderRector.php
@@ -56,7 +56,7 @@ final class ArgumentAdderRector extends AbstractRector implements ConfigurableRe
     {
         $exampleConfiguration = [
             self::ADDED_ARGUMENTS => [
-                new ArgumentAdder('SomeExampleClass', 'someMethod', 0, 'someArgument', 'true', 'SomeType'),
+                new ArgumentAdder('SomeExampleClass', 'someMethod', 0, 'someArgument', true, 'SomeType'),
             ],
         ];
 


### PR DESCRIPTION
When I follow the instructions to configure `ArgumentAdderRector`

```php
use Rector\Arguments\Rector\ClassMethod\ArgumentAdderRector;
use Rector\Arguments\ValueObject\ArgumentAdder;
use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
use Symplify\SymfonyPhpConfig\ValueObjectInliner;

return static function (ContainerConfigurator $containerConfigurator): void {
    $services = $containerConfigurator->services();

    $services->set(ArgumentAdderRector::class)
        ->call('configure', [[
ArgumentAdderRector::ADDED_ARGUMENTS => ValueObjectInliner::inline([
    new ArgumentAdder('SomeExampleClass', 'someMethod', 0, 'someArgument', 'true', 'SomeType', null),
    ]),
]]);
};
```

## What did Rector change?

```diff
 $someObject = new SomeExampleClass;
-$someObject->someMethod();
+$someObject->someMethod('true');
```

## Expected Behavior
```diff
 $someObject = new SomeExampleClass;
-$someObject->someMethod();
+$someObject->someMethod(true);
```

