### PR TITLE
[CodeQualityStrict] Allow MoveVariableDeclarationNearReferenceRector to pass static call on Throwable instance

### DIFF
--- a/rules-tests/CodeQualityStrict/Rector/Variable/MoveVariableDeclarationNearReferenceRector/Fixture/static_call_next_exception.php.inc
+++ b/rules-tests/CodeQualityStrict/Rector/Variable/MoveVariableDeclarationNearReferenceRector/Fixture/static_call_next_exception.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Tests\CodeQualityStrict\Rector\Variable\MoveVariableDeclarationNearReferenceRector\Fixture;
+
+use Rector\Tests\CodeQualityStrict\Rector\Variable\MoveVariableDeclarationNearReferenceRector\Source\MyException;
+
+class StaticCallNextException
+{
+    function myMethod()
+    {
+        $var = do_something();
+        if (rand(0, 1)) {
+            throw MyException::notFound();
+        }
+        echo $var;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQualityStrict\Rector\Variable\MoveVariableDeclarationNearReferenceRector\Fixture;
+
+use Rector\Tests\CodeQualityStrict\Rector\Variable\MoveVariableDeclarationNearReferenceRector\Source\MyException;
+
+class StaticCallNextException
+{
+    function myMethod()
+    {
+        if (rand(0, 1)) {
+            throw MyException::notFound();
+        }
+        $var = do_something();
+        echo $var;
+    }
+}
+
+?>

--- a/rules-tests/CodeQualityStrict/Rector/Variable/MoveVariableDeclarationNearReferenceRector/Source/MyException.php
+++ b/rules-tests/CodeQualityStrict/Rector/Variable/MoveVariableDeclarationNearReferenceRector/Source/MyException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\CodeQualityStrict\Rector\Variable\MoveVariableDeclarationNearReferenceRector\Source;
+
+class MyException extends \Exception
+{
+    public static function notFound()
+    {
+        return new self('Page not found');
+    }
+}

--- a/rules/CodeQualityStrict/Rector/Variable/MoveVariableDeclarationNearReferenceRector.php
+++ b/rules/CodeQualityStrict/Rector/Variable/MoveVariableDeclarationNearReferenceRector.php
@@ -15,6 +15,7 @@ use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Do_;
 use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\ElseIf_;
@@ -25,6 +26,7 @@ use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Switch_;
 use PhpParser\Node\Stmt\TryCatch;
 use PhpParser\Node\Stmt\While_;
+use PHPStan\Type\ObjectType;
 use Rector\Core\Rector\AbstractRector;
 use Rector\NodeNestingScope\NodeFinder\ScopeAwareNodeFinder;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -261,10 +263,23 @@ CODE_SAMPLE
         return false;
     }
 
+    private function isClassCallerThrowable(StaticCall $staticCall): bool
+    {
+        $class = $staticCall->class;
+        if (! $class instanceof Name) {
+            return false;
+        }
+
+        $throwableType = new ObjectType('Throwable');
+        $type = new ObjectType($class->toString());
+
+        return $throwableType->isSuperTypeOf($type)->yes();
+    }
+
     private function hasCall(Node $node): bool
     {
         return (bool) $this->betterNodeFinder->findFirst($node, function (Node $n): bool {
-            if ($n instanceof StaticCall) {
+            if ($n instanceof StaticCall && ! $this->isClassCallerThrowable($n)) {
                 return true;
             }
 


### PR DESCRIPTION
Throwable instance with static call mostly used for named constructor call, eg:

```php
throw MyException::notFound();
```

which usually not change external data. This allow to pass it to move variable after it.