### PR TITLE
Add failing test fixture for CallableThisArrayToAnonymousFunctionRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/Fixture/skip_forward_static_call.php.inc
+++ b/rules-tests/CodeQuality/Rector/Array_/CallableThisArrayToAnonymousFunctionRector/Fixture/skip_forward_static_call.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\CodeQuality\Tests\Rector\Array_\CallableThisArrayToAnonymousFunctionRector\Fixture;
+
+final class SkipForwardStaticCall
+{
+    public function run()
+    {
+        forward_static_call([$this, 'static_function']);
+    }
+
+    public static function static_function()
+    {
+    }
+}


### PR DESCRIPTION
# Failing Test for CallableThisArrayToAnonymousFunctionRector

Based on https://getrector.org/demo/b47e4c0e-5dfb-4fc3-a2b3-74a30d31aca0