### PR TITLE
Add failing test fixture for ChangeReadOnlyPropertyWithDefaultValueToConstantRector

### DIFF
--- a/rules-tests/Privatization/Rector/Property/ChangeReadOnlyPropertyWithDefaultValueToConstantRector/Fixture/skip_referenced.php.inc
+++ b/rules-tests/Privatization/Rector/Property/ChangeReadOnlyPropertyWithDefaultValueToConstantRector/Fixture/skip_referenced.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Tests\Privatization\Rector\Class_\ChangeReadOnlyPropertyWithDefaultValueToConstantRector\Fixture;
+
+class SkipReferenced
+{
+    private $value = [];
+
+    public function run()
+    {
+        $this->process($this->value);
+    }
+
+    private function process(array &$value)
+    {
+    }
+}


### PR DESCRIPTION
# Failing Test for ChangeReadOnlyPropertyWithDefaultValueToConstantRector

Based on https://getrector.org/demo/c2fe122c-152a-4fec-90c2-9f6be9929614