### PR TITLE
Add failing test fixture for RemoveUnusedVariableAssignRector

### DIFF
--- a/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/skip_used_in_method_call.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/skip_used_in_method_call.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
+
+final class SkipUsedInMethodCall
+{
+    public function run()
+    {
+        $method = 'methodName';
+        $this->{$method}();
+    }
+}

--- a/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/skip_used_in_property_fetch.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/skip_used_in_property_fetch.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
+
+final class SkipUsedInPropertyFetch
+{
+    public function run()
+    {
+        $property = 'propertyName';
+        $this->{$property} = 1;
+    }
+}


### PR DESCRIPTION
Variable used in property fetch and method call should be skipped.