### PR TITLE
[DeadCode] Skip RemoveUnusedVariableAssignRector on used in Method call and PropertyFetch name

### DIFF
--- a/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/skip_used_in_method_call.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/skip_used_in_method_call.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
+
+final class SkipUsedInMethodCall
+{
+    public function run()
+    {
+        $method = 'methodName';
+        $this->{$method}();
+    }
+}

--- a/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/skip_used_in_property_fetch.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/skip_used_in_property_fetch.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
+
+final class SkipUsedInPropertyFetch
+{
+    public function run()
+    {
+        $property = 'propertyName';
+        $this->{$property} = 1;
+    }
+}

--- a/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
@@ -11,9 +11,11 @@ use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\NullsafeMethodCall;
+use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\Expression;
 use Rector\Core\Rector\AbstractRector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -143,6 +145,14 @@ CODE_SAMPLE
 
     private function isVariableNamed(Node $node, Variable $variable): bool
     {
+        if ($node instanceof MethodCall && $node->name instanceof Variable && is_string($node->name->name)) {
+            return $this->isName($variable, $node->name->name);
+        }
+
+        if ($node instanceof PropertyFetch && $node->name instanceof Variable && is_string($node->name->name)) {
+            return $this->isName($variable, $node->name->name);
+        }
+
         if (! $node instanceof Variable) {
             return false;
         }

--- a/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
@@ -15,7 +15,6 @@ use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\FunctionLike;
-use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\Expression;
 use Rector\Core\Rector\AbstractRector;
 use Rector\NodeTypeResolver\Node\AttributeKey;


### PR DESCRIPTION
Close #6051