### PR TITLE
[NodeTypeResolver] Fixes #6065 Use existing NodeTypeResolver object on Auto Imports short name

### DIFF
--- a/packages/NodeTypeResolver/PhpDocNodeVisitor/NameImportingPhpDocNodeVisitor.php
+++ b/packages/NodeTypeResolver/PhpDocNodeVisitor/NameImportingPhpDocNodeVisitor.php
@@ -112,7 +112,10 @@ final class NameImportingPhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
         // should skip because its already used
         if ($this->useNodesToAddCollector->isShortImported($phpParserNode, $fullyQualifiedObjectType)) {
             if ($this->useNodesToAddCollector->isImportShortable($phpParserNode, $fullyQualifiedObjectType)) {
-                $identifierTypeNode->name = $fullyQualifiedObjectType->getShortName();
+                $newNode = new IdentifierTypeNode($fullyQualifiedObjectType->getShortName());
+                if ($newNode->name !== $identifierTypeNode->name) {
+                    return $newNode;
+                }
                 return $identifierTypeNode;
             }
 
@@ -121,7 +124,10 @@ final class NameImportingPhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
 
         $this->useNodesToAddCollector->addUseImport($phpParserNode, $fullyQualifiedObjectType);
 
-        $identifierTypeNode->name = $fullyQualifiedObjectType->getShortName();
+        $newNode = new IdentifierTypeNode($fullyQualifiedObjectType->getShortName());
+        if ($newNode->name !== $identifierTypeNode->name) {
+            return $newNode;
+        }
         return $identifierTypeNode;
     }
 

--- a/packages/NodeTypeResolver/PhpDocNodeVisitor/NameImportingPhpDocNodeVisitor.php
+++ b/packages/NodeTypeResolver/PhpDocNodeVisitor/NameImportingPhpDocNodeVisitor.php
@@ -112,7 +112,8 @@ final class NameImportingPhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
         // should skip because its already used
         if ($this->useNodesToAddCollector->isShortImported($phpParserNode, $fullyQualifiedObjectType)) {
             if ($this->useNodesToAddCollector->isImportShortable($phpParserNode, $fullyQualifiedObjectType)) {
-                return new IdentifierTypeNode($fullyQualifiedObjectType->getShortName());
+                $identifierTypeNode->name = $fullyQualifiedObjectType->getShortName();
+                return $identifierTypeNode;
             }
 
             return $identifierTypeNode;
@@ -120,7 +121,8 @@ final class NameImportingPhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
 
         $this->useNodesToAddCollector->addUseImport($phpParserNode, $fullyQualifiedObjectType);
 
-        return new IdentifierTypeNode($fullyQualifiedObjectType->getShortName());
+        $identifierTypeNode->name = $fullyQualifiedObjectType->getShortName();
+        return $identifierTypeNode;
     }
 
     private function shouldSkipShortClassName(FullyQualifiedObjectType $fullyQualifiedObjectType): bool


### PR DESCRIPTION
Use existing NodeTypeResolver object and change public name property instead of re-create new object when name is equal. Fixes #6065