### PR TITLE
[DowngradePhp72] Skip DowngradePregUnmatchedAsNullConstantRector on different flags in BitwiseOr

### DIFF
--- a/rules-tests/DowngradePhp72/Rector/FuncCall/DowngradePregUnmatchedAsNullConstantRector/Fixture/skip_different_flag2.php.inc
+++ b/rules-tests/DowngradePhp72/Rector/FuncCall/DowngradePregUnmatchedAsNullConstantRector/Fixture/skip_different_flag2.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp72\Rector\FuncCall\DowngradePregUnmatchedAsNullConstantRector\Fixture;
+
+class SkipDifferentFlag2
+{
+    public function run()
+    {
+        preg_match('/(a)(b)*(c)/', 'ac', $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
+    }
+}
+
+?>
+

--- a/rules-tests/DowngradePhp72/Rector/FuncCall/DowngradePregUnmatchedAsNullConstantRector/Fixture/skip_different_flag3.php.inc
+++ b/rules-tests/DowngradePhp72/Rector/FuncCall/DowngradePregUnmatchedAsNullConstantRector/Fixture/skip_different_flag3.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp72\Rector\FuncCall\DowngradePregUnmatchedAsNullConstantRector\Fixture;
+
+class SkipDifferentFlag3
+{
+    public function run()
+    {
+        if (!preg_match_all(
+            '~' . self::VARIABLE_REGEX . '~x', $route, $matches,
+            PREG_OFFSET_CAPTURE | PREG_SET_ORDER
+        )) {
+            return [$route];
+        }
+    }
+}
+
+?>
+

--- a/rules/DowngradePhp72/Rector/FuncCall/DowngradePregUnmatchedAsNullConstantRector.php
+++ b/rules/DowngradePhp72/Rector/FuncCall/DowngradePregUnmatchedAsNullConstantRector.php
@@ -86,7 +86,11 @@ final class DowngradePregUnmatchedAsNullConstantRector extends AbstractRector
 
         if ($flags instanceof BitwiseOr) {
             $this->cleanBitWiseOrFlags($node, $flags);
-            return $this->handleEmptyStringToNullMatch($node, $variable);
+            if (! $this->nodeComparator->areNodesEqual($flags, $node->args[3]->value)) {
+                return $this->handleEmptyStringToNullMatch($node, $variable);
+            }
+
+            return null;
         }
 
         if (! $flags instanceof ConstFetch) {

--- a/rules/LeagueEvent/Rector/MethodCall/DispatchStringToObjectRector.php
+++ b/rules/LeagueEvent/Rector/MethodCall/DispatchStringToObjectRector.php
@@ -65,6 +65,9 @@ CODE_SAMPLE
             ]);
     }
 
+    /**
+     * @return array<class-string<Expr>>
+     */
     public function getNodeTypes(): array
     {
         return [MethodCall::class];
@@ -94,12 +97,7 @@ CODE_SAMPLE
         ])) {
             return false;
         }
-
-        if (! $this->getStaticType($methodCall->args[0]->value) instanceof StringType) {
-            return true;
-        }
-
-        return true;
+        return $this->getStaticType($methodCall->args[0]->value) instanceof StringType;
     }
 
     private function updateNode(MethodCall $methodCall): MethodCall
@@ -108,26 +106,26 @@ CODE_SAMPLE
         return $methodCall;
     }
 
-    private function createNewAnonymousEventClass(Expr $eventName): New_
+    private function createNewAnonymousEventClass(Expr $expr): New_
     {
         $implements = [new FullyQualified('League\Event\HasEventName')];
 
         return new New_(new Class_(null, [
             'implements' => $implements,
-            'stmts' => $this->createAnonymousEventClassBody($eventName),
+            'stmts' => $this->createAnonymousEventClassBody($expr),
         ]));
     }
 
     /**
      * @return Stmt[]
      */
-    private function createAnonymousEventClassBody(Expr $eventName): array
+    private function createAnonymousEventClassBody(Expr $expr): array
     {
         return [
             new ClassMethod('eventName', [
                 'flags' => Class_::MODIFIER_PUBLIC,
                 'returnType' => 'string',
-                'stmts' => [new Return_($eventName)],
+                'stmts' => [new Return_($expr)],
             ]),
         ];
     }


### PR DESCRIPTION
Fixes #6074 