### PR TITLE
Add failing test fixture for ChangeReadOnlyPropertyWithDefaultValueToConstantRector

### DIFF
--- a/rules-tests/Privatization/Rector/Property/ChangeReadOnlyPropertyWithDefaultValueToConstantRector/Fixture/skip_referenced_in_static_call.php.inc
+++ b/rules-tests/Privatization/Rector/Property/ChangeReadOnlyPropertyWithDefaultValueToConstantRector/Fixture/skip_referenced_in_static_call.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rector\Privatization\Tests\Rector\Property\ChangeReadOnlyPropertyWithDefaultValueToConstantRector\Fixture;
+
+final class SkipReferencedInStaticCall
+{
+    private $value = [];
+
+    public function run()
+    {
+        self::process($this->value);
+    }
+
+    private static function process(array &$value)
+    {
+    }
+}


### PR DESCRIPTION
# Failing Test for ChangeReadOnlyPropertyWithDefaultValueToConstantRector

Based on https://getrector.org/demo/e87e2831-f782-4fc2-a586-c70df9b829ef