### PR TITLE
[CodeQualityStrict] Skip MoveVariableDeclarationNearReferenceRector on pass impure function

### DIFF
--- a/rules-tests/CodeQualityStrict/Rector/Variable/MoveVariableDeclarationNearReferenceRector/Fixture/skip_pass_bcdiv.php.inc
+++ b/rules-tests/CodeQualityStrict/Rector/Variable/MoveVariableDeclarationNearReferenceRector/Fixture/skip_pass_bcdiv.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rector\Tests\CodeQualityStrict\Rector\Variable\MoveVariableDeclarationNearReferenceRector\Fixture;
+
+final class SkipBcscale
+{
+    public function run($data, $options)
+    {
+        $a = bcscale(3);
+        echo bcdiv('105', '6.55957');
+        echo $a;
+    }
+}

--- a/rules-tests/CodeQualityStrict/Rector/Variable/MoveVariableDeclarationNearReferenceRector/Fixture/skip_pass_bcdiv.php.inc
+++ b/rules-tests/CodeQualityStrict/Rector/Variable/MoveVariableDeclarationNearReferenceRector/Fixture/skip_pass_bcdiv.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\CodeQualityStrict\Rector\Variable\MoveVariableDeclarationNearReferenceRector\Fixture;
 
-final class SkipBcscale
+final class SkipPassBcdiv
 {
     public function run($data, $options)
     {

--- a/rules-tests/CodeQualityStrict/Rector/Variable/MoveVariableDeclarationNearReferenceRector/Fixture/skip_pass_json_last_error.php.inc
+++ b/rules-tests/CodeQualityStrict/Rector/Variable/MoveVariableDeclarationNearReferenceRector/Fixture/skip_pass_json_last_error.php.inc
@@ -8,8 +8,7 @@ final class SkipPassJsonLastError
     {
         $result = json_encode($data, $options, 512);
 
-        if (json_last_error())
-        {
+        if (json_last_error()) {
             throw new \Exception();
         }
 

--- a/rules-tests/CodeQualityStrict/Rector/Variable/MoveVariableDeclarationNearReferenceRector/Fixture/skip_pass_json_last_error.php.inc
+++ b/rules-tests/CodeQualityStrict/Rector/Variable/MoveVariableDeclarationNearReferenceRector/Fixture/skip_pass_json_last_error.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rector\Tests\CodeQualityStrict\Rector\Variable\MoveVariableDeclarationNearReferenceRector\Fixture;
+
+final class SkipPassJsonLastError
+{
+    public function run($data, $options)
+    {
+        $result = json_encode($data, $options, 512);
+
+        if (json_last_error())
+        {
+            throw new \Exception();
+        }
+
+        echo $result;
+    }
+}

--- a/rules-tests/CodeQualityStrict/Rector/Variable/MoveVariableDeclarationNearReferenceRector/Fixture/static_call_next_exception.php.inc
+++ b/rules-tests/CodeQualityStrict/Rector/Variable/MoveVariableDeclarationNearReferenceRector/Fixture/static_call_next_exception.php.inc
@@ -9,7 +9,7 @@ class StaticCallNextException
     function myMethod()
     {
         $var = do_something();
-        if (rand(0, 1)) {
+        if (mktime() === false) {
             throw MyException::notFound();
         }
         echo $var;
@@ -28,7 +28,7 @@ class StaticCallNextException
 {
     function myMethod()
     {
-        if (rand(0, 1)) {
+        if (mktime() === false) {
             throw MyException::notFound();
         }
         $var = do_something();

--- a/rules/CodeQualityStrict/Rector/Variable/MoveVariableDeclarationNearReferenceRector.php
+++ b/rules/CodeQualityStrict/Rector/Variable/MoveVariableDeclarationNearReferenceRector.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\CodeQualityStrict\Rector\Variable;
 
-use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrayDimFetch;
@@ -28,6 +27,7 @@ use PhpParser\Node\Stmt\TryCatch;
 use PhpParser\Node\Stmt\While_;
 use PHPStan\Type\ObjectType;
 use Rector\Core\Rector\AbstractRector;
+use Rector\DeadCode\SideEffect\PureFunctionDetector;
 use Rector\NodeNestingScope\NodeFinder\ScopeAwareNodeFinder;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -43,9 +43,15 @@ final class MoveVariableDeclarationNearReferenceRector extends AbstractRector
      */
     private $scopeAwareNodeFinder;
 
-    public function __construct(ScopeAwareNodeFinder $scopeAwareNodeFinder)
+    /**
+     * @var PureFunctionDetector
+     */
+    private $pureFunctionDetector;
+
+    public function __construct(ScopeAwareNodeFinder $scopeAwareNodeFinder, PureFunctionDetector $pureFunctionDetector)
     {
         $this->scopeAwareNodeFinder = $scopeAwareNodeFinder;
+        $this->pureFunctionDetector = $pureFunctionDetector;
     }
 
     public function getRuleDefinition(): RuleDefinition
@@ -297,7 +303,7 @@ CODE_SAMPLE
                 return false;
             }
 
-            return Strings::startsWith($funcName, 'ob_');
+            return ! $this->pureFunctionDetector->detect($n);
         });
     }
 

--- a/rules/DeadCode/SideEffect/PureFunctionDetector.php
+++ b/rules/DeadCode/SideEffect/PureFunctionDetector.php
@@ -100,6 +100,9 @@ final class PureFunctionDetector
 
         // ftp
         'ftp_close',
+
+        // json
+        'json_last_error'
     ];
 
     /**

--- a/rules/DeadCode/SideEffect/PureFunctionDetector.php
+++ b/rules/DeadCode/SideEffect/PureFunctionDetector.php
@@ -105,7 +105,7 @@ final class PureFunctionDetector
         'bcdiv',
 
         // json
-        'json_last_error'
+        'json_last_error',
     ];
 
     /**

--- a/rules/DeadCode/SideEffect/PureFunctionDetector.php
+++ b/rules/DeadCode/SideEffect/PureFunctionDetector.php
@@ -102,10 +102,10 @@ final class PureFunctionDetector
         'ftp_close',
 
         // bcmath
-        'bcdiv',
+        'bcscale', 'bcdiv',
 
         // json
-        'json_last_error',
+        'json_encode', 'json_decode', 'json_last_error',
     ];
 
     /**

--- a/rules/DeadCode/SideEffect/PureFunctionDetector.php
+++ b/rules/DeadCode/SideEffect/PureFunctionDetector.php
@@ -102,10 +102,10 @@ final class PureFunctionDetector
         'ftp_close',
 
         // bcmath
-        'bcdiv', 'bcscale',
+        'bcdiv',
 
         // json
-        'json_encode', 'json_decode', 'json_last_error'
+        'json_last_error'
     ];
 
     /**

--- a/rules/DeadCode/SideEffect/PureFunctionDetector.php
+++ b/rules/DeadCode/SideEffect/PureFunctionDetector.php
@@ -101,8 +101,11 @@ final class PureFunctionDetector
         // ftp
         'ftp_close',
 
+        // bcmath
+        'bcdiv', 'bcscale',
+
         // json
-        'json_last_error'
+        'json_encode', 'json_decode', 'json_last_error'
     ];
 
     /**


### PR DESCRIPTION
use `PureFunctionDetector` service.