### PR TITLE
Fix nullsafe transpile

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -4927,8 +4927,8 @@ Change nullsafe operator to ternary operator rector
 ```diff
 -$dateAsString = $booking->getStartDate()?->asDateTimeString();
 -$dateAsString = $booking->startDate?->dateTimeString;
-+$dateAsString = $booking->getStartDate() ? $booking->getStartDate()->asDateTimeString() : null;
-+$dateAsString = $booking->startDate ? $booking->startDate->dateTimeString : null;
++$dateAsString = ($_ = $booking->getStartDate()) ? $_->asDateTimeString() : null;
++$dateAsString = ($_ = $booking->startDate) ? $_->dateTimeString : null;
 ```
 
 <br>

--- a/rules-tests/DowngradePhp80/Rector/NullsafeMethodCall/DowngradeNullsafeToTernaryOperatorRector/Fixture/fixture.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/NullsafeMethodCall/DowngradeNullsafeToTernaryOperatorRector/Fixture/fixture.php.inc
@@ -17,6 +17,12 @@ class Fixture
 
         // all are property fetch
         $dateAsString = $booking->getStartDate?->asDateTimeString;
+
+        $getStartDate = true;
+        $bookingGetStartDate = true;
+
+        // previously named vars aren't reused
+        $dateAsString = $booking->getStartDate?->asDateTimeString;
     }
 }
 
@@ -31,16 +37,22 @@ class Fixture
     public function run($booking)
     {
         // with argument
-        $dateAsString = ($_ = $booking->getStartDate($args1)) ? $_->asDateTimeString($arg2) : null;
+        $dateAsString = ($getStartDate = $booking->getStartDate($args1)) ? $getStartDate->asDateTimeString($arg2) : null;
 
         // without argument, one is method call, next property fetch
-        $dateAsString = ($_ = $booking->getStartDate()) ? $_->asDateTimeString : null;
+        $dateAsString = ($getStartDate = $booking->getStartDate()) ? $getStartDate->asDateTimeString : null;
 
         // without argument, one is property call, next method fetch
-        $dateAsString = ($_ = $booking->getStartDate) ? $_->asDateTimeString() : null;
+        $dateAsString = ($bookingGetStartDate = $booking->getStartDate) ? $bookingGetStartDate->asDateTimeString() : null;
 
         // all are property fetch
-        $dateAsString = ($_ = $booking->getStartDate) ? $_->asDateTimeString : null;
+        $dateAsString = ($bookingGetStartDate = $booking->getStartDate) ? $bookingGetStartDate->asDateTimeString : null;
+
+        $getStartDate = true;
+        $bookingGetStartDate = true;
+
+        // previously named vars aren't reused
+        $dateAsString = ($bookingGetStartDate2 = $booking->getStartDate) ? $bookingGetStartDate2->asDateTimeString : null;
     }
 }
 

--- a/rules-tests/DowngradePhp80/Rector/NullsafeMethodCall/DowngradeNullsafeToTernaryOperatorRector/Fixture/fixture.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/NullsafeMethodCall/DowngradeNullsafeToTernaryOperatorRector/Fixture/fixture.php.inc
@@ -31,16 +31,16 @@ class Fixture
     public function run($booking)
     {
         // with argument
-        $dateAsString = $booking->getStartDate($args1) ? $booking->getStartDate($args1)->asDateTimeString($arg2) : null;
+        $dateAsString = ($_ = $booking->getStartDate($args1)) ? $_->asDateTimeString($arg2) : null;
 
         // without argument, one is method call, next property fetch
-        $dateAsString = $booking->getStartDate() ? $booking->getStartDate()->asDateTimeString : null;
+        $dateAsString = ($_ = $booking->getStartDate()) ? $_->asDateTimeString : null;
 
         // without argument, one is property call, next method fetch
-        $dateAsString = $booking->getStartDate ? $booking->getStartDate->asDateTimeString() : null;
+        $dateAsString = ($_ = $booking->getStartDate) ? $_->asDateTimeString() : null;
 
         // all are property fetch
-        $dateAsString = $booking->getStartDate ? $booking->getStartDate->asDateTimeString : null;
+        $dateAsString = ($_ = $booking->getStartDate) ? $_->asDateTimeString : null;
     }
 }
 

--- a/rules-tests/DowngradePhp80/Rector/NullsafeMethodCall/DowngradeNullsafeToTernaryOperatorRector/Fixture/multiple_call.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/NullsafeMethodCall/DowngradeNullsafeToTernaryOperatorRector/Fixture/multiple_call.php.inc
@@ -21,8 +21,8 @@ class MultipleCall
 {
     public function run($object)
     {
-        $result = ($_ = ($_ = $object->multiple($args1)) ? $_->call($args2) : null) ? $_->otherCall($args3) : null;
-        $result = ($_ = ($_ = ($_ = $object->multiple($args1)) ? $_->call($args2) : null) ? $_->otherCall($args3) : null) ? $_->anotherCall($args4) : null;
+        $result = ($call = ($multiple = $object->multiple($args1)) ? $multiple->call($args2) : null) ? $call->otherCall($args3) : null;
+        $result = ($otherCall = ($call = ($multiple = $object->multiple($args1)) ? $multiple->call($args2) : null) ? $call->otherCall($args3) : null) ? $otherCall->anotherCall($args4) : null;
     }
 }
 

--- a/rules-tests/DowngradePhp80/Rector/NullsafeMethodCall/DowngradeNullsafeToTernaryOperatorRector/Fixture/multiple_call.php.inc
+++ b/rules-tests/DowngradePhp80/Rector/NullsafeMethodCall/DowngradeNullsafeToTernaryOperatorRector/Fixture/multiple_call.php.inc
@@ -21,8 +21,8 @@ class MultipleCall
 {
     public function run($object)
     {
-        $result = ($object->multiple($args1) ? $object->multiple($args1)->call($args2) : null) ? ($object->multiple($args1) ? $object->multiple($args1)->call($args2) : null)->otherCall($args3) : null;
-        $result = (($object->multiple($args1) ? $object->multiple($args1)->call($args2) : null) ? ($object->multiple($args1) ? $object->multiple($args1)->call($args2) : null)->otherCall($args3) : null) ? (($object->multiple($args1) ? $object->multiple($args1)->call($args2) : null) ? ($object->multiple($args1) ? $object->multiple($args1)->call($args2) : null)->otherCall($args3) : null)->anotherCall($args4) : null;
+        $result = ($_ = ($_ = $object->multiple($args1)) ? $_->call($args2) : null) ? $_->otherCall($args3) : null;
+        $result = ($_ = ($_ = ($_ = $object->multiple($args1)) ? $_->call($args2) : null) ? $_->otherCall($args3) : null) ? $_->anotherCall($args4) : null;
     }
 }
 

--- a/rules/DowngradePhp80/Rector/NullsafeMethodCall/DowngradeNullsafeToTernaryOperatorRector.php
+++ b/rules/DowngradePhp80/Rector/NullsafeMethodCall/DowngradeNullsafeToTernaryOperatorRector.php
@@ -50,11 +50,11 @@ CODE_SAMPLE
      */
     public function refactor(Node $node): ?Node
     {
-        $temp_var = new Node\Expr\Variable('_');
+        $tempVar = new Node\Expr\Variable('_');
         $called = $node instanceof NullsafeMethodCall
-            ? new MethodCall($temp_var, $node->name, $node->args)
-            : new PropertyFetch($temp_var, $node->name);
+            ? new MethodCall($tempVar, $node->name, $node->args)
+            : new PropertyFetch($tempVar, $node->name);
 
-        return new Ternary(new Assign($temp_var, $node->var), $called, $this->nodeFactory->createNull());
+        return new Ternary(new Assign($tempVar, $node->var), $called, $this->nodeFactory->createNull());
     }
 }

--- a/rules/DowngradePhp80/Rector/NullsafeMethodCall/DowngradeNullsafeToTernaryOperatorRector.php
+++ b/rules/DowngradePhp80/Rector/NullsafeMethodCall/DowngradeNullsafeToTernaryOperatorRector.php
@@ -42,7 +42,7 @@ $dateAsString = $booking->startDate?->dateTimeString;
 CODE_SAMPLE
 ,
                 <<<'CODE_SAMPLE'
-$dateAsString = ($_ = $booking->getStartDate()) ? $_->asDateTimeString() : null;
+$dateAsString = ($bookingGetStartDate = $booking->getStartDate()) ? $bookingGetStartDate->asDateTimeString() : null;
 $dateAsString = ($_ = $booking->startDate) ? $_->dateTimeString : null;
 CODE_SAMPLE
             ),

--- a/rules/DowngradePhp80/Rector/NullsafeMethodCall/DowngradeNullsafeToTernaryOperatorRector.php
+++ b/rules/DowngradePhp80/Rector/NullsafeMethodCall/DowngradeNullsafeToTernaryOperatorRector.php
@@ -43,7 +43,7 @@ CODE_SAMPLE
 ,
                 <<<'CODE_SAMPLE'
 $dateAsString = ($bookingGetStartDate = $booking->getStartDate()) ? $bookingGetStartDate->asDateTimeString() : null;
-$dateAsString = ($_ = $booking->startDate) ? $_->dateTimeString : null;
+$dateAsString = ($bookingGetStartDate = $booking->startDate) ? $bookingGetStartDate->dateTimeString : null;
 CODE_SAMPLE
             ),
         ]);


### PR DESCRIPTION
It looks like the current transpilation of the PHP 8 null safe operator results in multiple calls to the method which may be undesired and cause subtle bugs. This fixes that by storing the result of the null-check in a temporary variable and relying on PHP's order-of-operations to reuse the same variable name. `$_` may result in a collision with other code, so if there's reason to fear that, perhaps a hash of some kind could be used instead; I'm open to any suggestion.