### PR TITLE
Failing test for removing "unused" code in compact

### DIFF
--- a/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/skip_in_compact.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/skip_in_compact.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
+
+class SkipInCompact
+{
+    public function run()
+    {
+        $value = 'foobar';
+        return compact('value');
+    }
+}
+
+?>


### PR DESCRIPTION
As requested in https://github.com/rectorphp/rector/issues/1238#issuecomment-817266195, a failing test case.

Rector removes a supposedly unused variable, but it's actually used in PHPs `compact()` call, e.g. returning values to a Laravel view like so: `return view('home', compact('value'))` or returning an array (JSON) `return compact('json')`