### PR TITLE
[CodeQuality] Avoid double negation on UnnecessaryTernaryExpressionRector

### DIFF
--- a/rules-tests/CodeQuality/Rector/Ternary/UnnecessaryTernaryExpressionRector/Fixture/multiple_negation_array.php.inc
+++ b/rules-tests/CodeQuality/Rector/Ternary/UnnecessaryTernaryExpressionRector/Fixture/multiple_negation_array.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Ternary\UnnecessaryTernaryExpressionRector\Fixture;
+
+final class MultipleNegationArray
+{
+    public function run(array $data)
+    {
+        return !! $data ? false : true;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Ternary\UnnecessaryTernaryExpressionRector\Fixture;
+
+final class MultipleNegationArray
+{
+    public function run(array $data)
+    {
+        return ! $data;
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Ternary/UnnecessaryTernaryExpressionRector/Fixture/multiple_negation_array2.php.inc
+++ b/rules-tests/CodeQuality/Rector/Ternary/UnnecessaryTernaryExpressionRector/Fixture/multiple_negation_array2.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Ternary\UnnecessaryTernaryExpressionRector\Fixture;
+
+final class MultipleNegationArray2
+{
+    public function run(array $data)
+    {
+        return !! empty($data) ? false : true;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Ternary\UnnecessaryTernaryExpressionRector\Fixture;
+
+final class MultipleNegationArray2
+{
+    public function run(array $data)
+    {
+        return ! empty($data);
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Ternary/UnnecessaryTernaryExpressionRector/Fixture/multiple_negation_bool.php.inc
+++ b/rules-tests/CodeQuality/Rector/Ternary/UnnecessaryTernaryExpressionRector/Fixture/multiple_negation_bool.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Ternary\UnnecessaryTernaryExpressionRector\Fixture;
+
+final class MultipleNegationBool
+{
+    public function run(bool $data)
+    {
+        return !! $data ? false : true;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Ternary\UnnecessaryTernaryExpressionRector\Fixture;
+
+final class MultipleNegationBool
+{
+    public function run(bool $data)
+    {
+        return ! $data;
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Ternary/UnnecessaryTernaryExpressionRector/Fixture/negation_array.php.inc
+++ b/rules-tests/CodeQuality/Rector/Ternary/UnnecessaryTernaryExpressionRector/Fixture/negation_array.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Ternary\UnnecessaryTernaryExpressionRector\Fixture;
+
+final class NegationArray
+{
+    public function run(array $data)
+    {
+        return ! $data ? false : true;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Ternary\UnnecessaryTernaryExpressionRector\Fixture;
+
+final class NegationArray
+{
+    public function run(array $data)
+    {
+        return (bool) $data;
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Ternary/UnnecessaryTernaryExpressionRector/Fixture/negation_array2.php.inc
+++ b/rules-tests/CodeQuality/Rector/Ternary/UnnecessaryTernaryExpressionRector/Fixture/negation_array2.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Ternary\UnnecessaryTernaryExpressionRector\Fixture;
+
+final class NegationArray2
+{
+    public function run(array $data)
+    {
+        return ! empty($data) ? false : true;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Ternary\UnnecessaryTernaryExpressionRector\Fixture;
+
+final class NegationArray2
+{
+    public function run(array $data)
+    {
+        return empty($data);
+    }
+}
+
+?>

--- a/rules-tests/CodeQuality/Rector/Ternary/UnnecessaryTernaryExpressionRector/Fixture/negation_bool.php.inc
+++ b/rules-tests/CodeQuality/Rector/Ternary/UnnecessaryTernaryExpressionRector/Fixture/negation_bool.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Ternary\UnnecessaryTernaryExpressionRector\Fixture;
+
+final class NegationBool
+{
+    public function run(bool $data)
+    {
+        return ! $data ? false : true;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodeQuality\Rector\Ternary\UnnecessaryTernaryExpressionRector\Fixture;
+
+final class NegationBool
+{
+    public function run(bool $data)
+    {
+        return $data;
+    }
+}
+
+?>

--- a/rules/CodeQuality/Rector/Ternary/UnnecessaryTernaryExpressionRector.php
+++ b/rules/CodeQuality/Rector/Ternary/UnnecessaryTernaryExpressionRector.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Expr\Ternary;
 use PHPStan\Type\BooleanType;
 use Rector\Core\PhpParser\Node\AssignAndBinaryMap;
 use Rector\Core\Rector\AbstractRector;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -105,6 +106,14 @@ final class UnnecessaryTernaryExpressionRector extends AbstractRector
         }
 
         if ($this->valueResolver->isFalse($ifExpression) && $this->valueResolver->isTrue($elseExpression)) {
+            if ($condition instanceof BooleanNot) {
+                if ($this->nodeTypeResolver->isStaticType($condition->expr, BooleanType::class)) {
+                    return $condition->expr;
+                }
+
+                return new Bool_($condition->expr);
+            }
+
             if ($this->nodeTypeResolver->isStaticType($condition, BooleanType::class)) {
                 return new BooleanNot($condition);
             }

--- a/rules/CodeQuality/Rector/Ternary/UnnecessaryTernaryExpressionRector.php
+++ b/rules/CodeQuality/Rector/Ternary/UnnecessaryTernaryExpressionRector.php
@@ -13,7 +13,6 @@ use PhpParser\Node\Expr\Ternary;
 use PHPStan\Type\BooleanType;
 use Rector\Core\PhpParser\Node\AssignAndBinaryMap;
 use Rector\Core\Rector\AbstractRector;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -98,29 +97,39 @@ final class UnnecessaryTernaryExpressionRector extends AbstractRector
     private function processNonBinaryCondition(Expr $ifExpression, Expr $elseExpression, Expr $condition): ?Node
     {
         if ($this->valueResolver->isTrue($ifExpression) && $this->valueResolver->isFalse($elseExpression)) {
-            if ($this->nodeTypeResolver->isStaticType($condition, BooleanType::class)) {
-                return $condition;
-            }
-
-            return new Bool_($condition);
+            return $this->processTrueIfExpressionWithFalseElseExpression($condition);
         }
 
         if ($this->valueResolver->isFalse($ifExpression) && $this->valueResolver->isTrue($elseExpression)) {
-            if ($condition instanceof BooleanNot) {
-                if ($this->nodeTypeResolver->isStaticType($condition->expr, BooleanType::class)) {
-                    return $condition->expr;
-                }
-
-                return new Bool_($condition->expr);
-            }
-
-            if ($this->nodeTypeResolver->isStaticType($condition, BooleanType::class)) {
-                return new BooleanNot($condition);
-            }
-
-            return new BooleanNot(new Bool_($condition));
+            return $this->processFalseIfExpressionWithTrueElseExpression($condition);
         }
 
         return null;
+    }
+
+    private function processTrueIfExpressionWithFalseElseExpression(Expr $condition): Expr
+    {
+        if ($this->nodeTypeResolver->isStaticType($condition, BooleanType::class)) {
+            return $condition;
+        }
+
+        return new Bool_($condition);
+    }
+
+    private function processFalseIfExpressionWithTrueElseExpression(Expr $condition): Expr
+    {
+        if ($condition instanceof BooleanNot) {
+            if ($this->nodeTypeResolver->isStaticType($condition->expr, BooleanType::class)) {
+                return $condition->expr;
+            }
+
+            return new Bool_($condition->expr);
+        }
+
+        if ($this->nodeTypeResolver->isStaticType($condition, BooleanType::class)) {
+            return new BooleanNot($condition);
+        }
+
+        return new BooleanNot(new Bool_($condition));
     }
 }

--- a/rules/CodeQuality/Rector/Ternary/UnnecessaryTernaryExpressionRector.php
+++ b/rules/CodeQuality/Rector/Ternary/UnnecessaryTernaryExpressionRector.php
@@ -99,37 +99,38 @@ final class UnnecessaryTernaryExpressionRector extends AbstractRector
         if ($this->valueResolver->isTrue($ifExpression) && $this->valueResolver->isFalse($elseExpression)) {
             return $this->processTrueIfExpressionWithFalseElseExpression($condition);
         }
-
-        if ($this->valueResolver->isFalse($ifExpression) && $this->valueResolver->isTrue($elseExpression)) {
-            return $this->processFalseIfExpressionWithTrueElseExpression($condition);
+        if (! $this->valueResolver->isFalse($ifExpression)) {
+            return null;
         }
-
-        return null;
+        if (! $this->valueResolver->isTrue($elseExpression)) {
+            return null;
+        }
+        return $this->processFalseIfExpressionWithTrueElseExpression($condition);
     }
 
-    private function processTrueIfExpressionWithFalseElseExpression(Expr $condition): Expr
+    private function processTrueIfExpressionWithFalseElseExpression(Expr $expr): Expr
     {
-        if ($this->nodeTypeResolver->isStaticType($condition, BooleanType::class)) {
-            return $condition;
+        if ($this->nodeTypeResolver->isStaticType($expr, BooleanType::class)) {
+            return $expr;
         }
 
-        return new Bool_($condition);
+        return new Bool_($expr);
     }
 
-    private function processFalseIfExpressionWithTrueElseExpression(Expr $condition): Expr
+    private function processFalseIfExpressionWithTrueElseExpression(Expr $expr): Expr
     {
-        if ($condition instanceof BooleanNot) {
-            if ($this->nodeTypeResolver->isStaticType($condition->expr, BooleanType::class)) {
-                return $condition->expr;
+        if ($expr instanceof BooleanNot) {
+            if ($this->nodeTypeResolver->isStaticType($expr->expr, BooleanType::class)) {
+                return $expr->expr;
             }
 
-            return new Bool_($condition->expr);
+            return new Bool_($expr->expr);
         }
 
-        if ($this->nodeTypeResolver->isStaticType($condition, BooleanType::class)) {
-            return new BooleanNot($condition);
+        if ($this->nodeTypeResolver->isStaticType($expr, BooleanType::class)) {
+            return new BooleanNot($expr);
         }
 
-        return new BooleanNot(new Bool_($condition));
+        return new BooleanNot(new Bool_($expr));
     }
 }


### PR DESCRIPTION
This patch remove double negation for `BooleanNot` got flipped `false ? true`, eg:

```php
return !! $data
```

as refactor result for the following code:

```php
return ! $data ? false : true;
```

to be:

```php
return $data;
```

or 

```php
return (bool) $data;
```

based on the condition type.