### PR TITLE
Allow execution of process command without registered Rectors, but with NonPhpFileProcessors

### DIFF
--- a/src/Reporting/MissingRectorRulesReporter.php
+++ b/src/Reporting/MissingRectorRulesReporter.php
@@ -36,13 +36,11 @@ final class MissingRectorRulesReporter
             return ! $rector instanceof PostRectorInterface;
         });
 
-        if ($activeRectors !== []) {
-            return null;
+        if ($activeRectors === []) {
+            $this->report();
         }
 
-        $this->report();
-
-        return ShellCode::ERROR;
+        return null;
     }
 
     public function report(): void


### PR DESCRIPTION
Resolves #6087 

Warning is still there if no Rectors are registered, but NonPhpFileProcessors are executed. Only difference is that tha output of command is still 0 (null) and command prints message 
```
[OK] Rector is done!
```
or
```
[OK] X files has been changed by Rector
```