### PR TITLE
Make ComposerFileProcessor run on composer.json in root automatically

### DIFF
--- a/src/FileSystem/FilesFinder.php
+++ b/src/FileSystem/FilesFinder.php
@@ -86,6 +86,11 @@ final class FilesFinder
             $smartFileInfos[] = new SmartFileInfo($file);
         }
 
+        $composerPath = getcwd() . '/composer.json';
+        if (file_exists($composerPath) && in_array('json', $suffixes, true)) {
+            $smartFileInfos[] = new SmartFileInfo($composerPath);
+        }
+
         $smartFileInfos = array_merge($smartFileInfos, $this->findInDirectories($directories, $suffixes));
         return $this->fileInfosBySourceAndSuffixes[$cacheKey] = $smartFileInfos;
     }

--- a/tests/Application/ApplicationFileProcessor/ApplicationFileProcessorTest.php
+++ b/tests/Application/ApplicationFileProcessor/ApplicationFileProcessorTest.php
@@ -44,7 +44,7 @@ final class ApplicationFileProcessorTest extends AbstractKernelTestCase
     public function test(): void
     {
         $files = $this->fileFactory->createFromPaths([__DIR__ . '/Fixture']);
-        $this->assertCount(2, $files);
+        $this->assertCount(3, $files);
 
         $this->applicationFileProcessor->run($files);
 


### PR DESCRIPTION
In huge refactoring, it was somehow removed so I would like to add it back O:-)
