### PR TITLE
[DeadCode] Fix RemoveUnusedVariableAssignRector for variable removal

### DIFF
--- a/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/method_call_only.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/method_call_only.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
+
+final class MethodCallOnly
+{
+    public function cleanFiles()
+    {
+        $value = $this->processSomething();
+    }
+
+    public function processSomething()
+    {
+        return 1000;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
+
+final class MethodCallOnly
+{
+    public function cleanFiles()
+    {
+        $this->processSomething();
+    }
+
+    public function processSomething()
+    {
+        return 1000;
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/config/configured_rule.php
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/config/configured_rule.php
@@ -7,6 +7,5 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
-
     $services->set(RemoveUnusedVariableAssignRector::class);
 };

--- a/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
+++ b/rules/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector.php
@@ -109,6 +109,11 @@ CODE_SAMPLE
             return null;
         }
 
+        if ($node->expr instanceof MethodCall || $node->expr instanceof StaticCall) {
+            // keep the expr, can have side effect
+            return $node->expr;
+        }
+
         $this->removeNode($node);
         return $node;
     }


### PR DESCRIPTION
Fixes case where business logic was accidentaly removed too

![image](https://user-images.githubusercontent.com/924196/114713774-bd4f9600-9d31-11eb-80b8-9158e51b0f14.png)
