### PR TITLE
Newly created nodes have no scope

### DIFF
--- a/rules-tests/LeagueEvent/Rector/MethodCall/DispatchStringToObjectRector/config/configured_rule.php
+++ b/rules-tests/LeagueEvent/Rector/MethodCall/DispatchStringToObjectRector/config/configured_rule.php
@@ -3,10 +3,19 @@
 declare(strict_types=1);
 
 use Rector\LeagueEvent\Rector\MethodCall\DispatchStringToObjectRector;
+use Rector\Transform\Rector\Class_\AddInterfaceByParentRector;
+use Rector\Transform\Rector\Class_\AddInterfaceByTraitRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(DispatchStringToObjectRector::class);
+
+    $services->set(AddInterfaceByTraitRector::class)
+        ->call('configure', [[
+            AddInterfaceByTraitRector::INTERFACE_BY_TRAIT => [
+                'SomeTrait' => 'SomeInterface',
+            ],
+        ]]);
 };

--- a/rules/Transform/Rector/Class_/AddInterfaceByTraitRector.php
+++ b/rules/Transform/Rector/Class_/AddInterfaceByTraitRector.php
@@ -70,6 +70,11 @@ CODE_SAMPLE
     {
         /** @var Scope $scope */
         $scope = $node->getAttribute(AttributeKey::SCOPE);
+
+        if ($scope === null) {
+            var_dump('Newly created node has no scope');
+        }
+
         $classReflection = $scope->getClassReflection();
         if (! $classReflection instanceof ClassReflection) {
             return null;


### PR DESCRIPTION
When we create new node with rector, they don't have any scope which is very often used in other rectors this way:

```
/** @var Scope $scope */
$scope = $node->getAttribute(AttributeKey::SCOPE);
$classReflection = $scope->getClassReflection();
```
which causes error: `Error: Call to a member function getClassReflection() on null`

If we run rector second time (when nodes are already created), scope is present and no error is thrown