### PR TITLE
[Php73] Refactor JsonThrowOnErrorRector: change 2nd parameter of json_decode to null and skip on json_last_error, json_last_error_msg

### DIFF
--- a/rules-tests/Php73/Rector/FuncCall/JsonThrowOnErrorRector/Fixture/fixture.php.inc
+++ b/rules-tests/Php73/Rector/FuncCall/JsonThrowOnErrorRector/Fixture/fixture.php.inc
@@ -21,7 +21,7 @@ namespace Rector\Tests\Php73\Rector\FuncCall\JsonThrowOnErrorRector\Fixture;
 function jsonThrowOnError()
 {
     json_encode($content, JSON_THROW_ON_ERROR);
-    json_decode($json, false, 512, JSON_THROW_ON_ERROR);
+    json_decode($json, null, 512, JSON_THROW_ON_ERROR);
 
     json_decode($json, true, 215, JSON_THROW_ON_ERROR);
 

--- a/rules-tests/Php73/Rector/FuncCall/JsonThrowOnErrorRector/Fixture/json_last_error_next_after_return.php.inc
+++ b/rules-tests/Php73/Rector/FuncCall/JsonThrowOnErrorRector/Fixture/json_last_error_next_after_return.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rector\Tests\Php73\Rector\FuncCall\JsonThrowOnErrorRector\Fixture;
+
+function SkipJsonLastErrorNextAfterReturn()
+{
+    json_decode($str);
+    return;
+
+    json_last_error();
+    json_last_error_msg();
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php73\Rector\FuncCall\JsonThrowOnErrorRector\Fixture;
+
+function SkipJsonLastErrorNextAfterReturn()
+{
+    json_decode($str, null, 512, JSON_THROW_ON_ERROR);
+    return;
+
+    json_last_error();
+    json_last_error_msg();
+}
+
+?>

--- a/rules-tests/Php73/Rector/FuncCall/JsonThrowOnErrorRector/Fixture/json_last_error_next_after_return.php.inc
+++ b/rules-tests/Php73/Rector/FuncCall/JsonThrowOnErrorRector/Fixture/json_last_error_next_after_return.php.inc
@@ -2,10 +2,12 @@
 
 namespace Rector\Tests\Php73\Rector\FuncCall\JsonThrowOnErrorRector\Fixture;
 
-function JsonLastErrorNextAfterReturn()
+function JsonLastErrorNextAfterReturn($str)
 {
-    json_decode($str);
-    return;
+    if (rand(0, 1)) {
+        json_decode($str);
+        return;
+    }
 
     json_last_error();
     json_last_error_msg();
@@ -17,10 +19,12 @@ function JsonLastErrorNextAfterReturn()
 
 namespace Rector\Tests\Php73\Rector\FuncCall\JsonThrowOnErrorRector\Fixture;
 
-function JsonLastErrorNextAfterReturn()
+function JsonLastErrorNextAfterReturn($str)
 {
-    json_decode($str, null, 512, JSON_THROW_ON_ERROR);
-    return;
+    if (rand(0, 1)) {
+        json_decode($str, null, 512, JSON_THROW_ON_ERROR);
+        return;
+    }
 
     json_last_error();
     json_last_error_msg();

--- a/rules-tests/Php73/Rector/FuncCall/JsonThrowOnErrorRector/Fixture/json_last_error_next_after_return.php.inc
+++ b/rules-tests/Php73/Rector/FuncCall/JsonThrowOnErrorRector/Fixture/json_last_error_next_after_return.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\Php73\Rector\FuncCall\JsonThrowOnErrorRector\Fixture;
 
-function SkipJsonLastErrorNextAfterReturn()
+function JsonLastErrorNextAfterReturn()
 {
     json_decode($str);
     return;
@@ -17,7 +17,7 @@ function SkipJsonLastErrorNextAfterReturn()
 
 namespace Rector\Tests\Php73\Rector\FuncCall\JsonThrowOnErrorRector\Fixture;
 
-function SkipJsonLastErrorNextAfterReturn()
+function JsonLastErrorNextAfterReturn()
 {
     json_decode($str, null, 512, JSON_THROW_ON_ERROR);
     return;

--- a/rules-tests/Php73/Rector/FuncCall/JsonThrowOnErrorRector/Fixture/json_last_error_next_after_return2.php.inc
+++ b/rules-tests/Php73/Rector/FuncCall/JsonThrowOnErrorRector/Fixture/json_last_error_next_after_return2.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rector\Tests\Php73\Rector\FuncCall\JsonThrowOnErrorRector\Fixture;
+
+function SkipJsonLastErrorNextAfterReturn2()
+{
+    if (rand(0, 1)) {
+        return json_decode($str);
+    }
+
+    json_last_error();
+    json_last_error_msg();
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php73\Rector\FuncCall\JsonThrowOnErrorRector\Fixture;
+
+function SkipJsonLastErrorNextAfterReturn2()
+{
+    if (rand(0, 1)) {
+        return json_decode($str, null, 512, JSON_THROW_ON_ERROR);
+    }
+
+    json_last_error();
+    json_last_error_msg();
+}
+
+?>

--- a/rules-tests/Php73/Rector/FuncCall/JsonThrowOnErrorRector/Fixture/json_last_error_next_after_return2.php.inc
+++ b/rules-tests/Php73/Rector/FuncCall/JsonThrowOnErrorRector/Fixture/json_last_error_next_after_return2.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\Php73\Rector\FuncCall\JsonThrowOnErrorRector\Fixture;
 
-function JsonLastErrorNextAfterReturn2()
+function JsonLastErrorNextAfterReturn2($str)
 {
     if (rand(0, 1)) {
         return json_decode($str);
@@ -18,7 +18,7 @@ function JsonLastErrorNextAfterReturn2()
 
 namespace Rector\Tests\Php73\Rector\FuncCall\JsonThrowOnErrorRector\Fixture;
 
-function JsonLastErrorNextAfterReturn2()
+function JsonLastErrorNextAfterReturn2($str)
 {
     if (rand(0, 1)) {
         return json_decode($str, null, 512, JSON_THROW_ON_ERROR);

--- a/rules-tests/Php73/Rector/FuncCall/JsonThrowOnErrorRector/Fixture/json_last_error_next_after_return2.php.inc
+++ b/rules-tests/Php73/Rector/FuncCall/JsonThrowOnErrorRector/Fixture/json_last_error_next_after_return2.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\Php73\Rector\FuncCall\JsonThrowOnErrorRector\Fixture;
 
-function SkipJsonLastErrorNextAfterReturn2()
+function JsonLastErrorNextAfterReturn2()
 {
     if (rand(0, 1)) {
         return json_decode($str);
@@ -18,7 +18,7 @@ function SkipJsonLastErrorNextAfterReturn2()
 
 namespace Rector\Tests\Php73\Rector\FuncCall\JsonThrowOnErrorRector\Fixture;
 
-function SkipJsonLastErrorNextAfterReturn2()
+function JsonLastErrorNextAfterReturn2()
 {
     if (rand(0, 1)) {
         return json_decode($str, null, 512, JSON_THROW_ON_ERROR);

--- a/rules-tests/Php73/Rector/FuncCall/JsonThrowOnErrorRector/Fixture/skip_json_last_error_next.php.inc
+++ b/rules-tests/Php73/Rector/FuncCall/JsonThrowOnErrorRector/Fixture/skip_json_last_error_next.php.inc
@@ -2,11 +2,10 @@
 
 namespace Rector\Tests\Php73\Rector\FuncCall\JsonThrowOnErrorRector\Fixture;
 
-function SkipJsonLastErrorNext()
+function SkipJsonLastErrorNext2()
 {
     json_decode($str);
-    json_last_error();
-    json_last_error_msg();
+    return json_last_error() === JSON_ERROR_NONE
 }
 
 ?>

--- a/rules-tests/Php73/Rector/FuncCall/JsonThrowOnErrorRector/Fixture/skip_json_last_error_next.php.inc
+++ b/rules-tests/Php73/Rector/FuncCall/JsonThrowOnErrorRector/Fixture/skip_json_last_error_next.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\Php73\Rector\FuncCall\JsonThrowOnErrorRector\Fixture;
 
-function SkipJsonLastErrorNext2()
+function SkipJsonLastErrorNext($str)
 {
     json_decode($str);
     return json_last_error() === JSON_ERROR_NONE;

--- a/rules-tests/Php73/Rector/FuncCall/JsonThrowOnErrorRector/Fixture/skip_json_last_error_next.php.inc
+++ b/rules-tests/Php73/Rector/FuncCall/JsonThrowOnErrorRector/Fixture/skip_json_last_error_next.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\Php73\Rector\FuncCall\JsonThrowOnErrorRector\Fixture;
+
+function SkipJsonLastErrorNext()
+{
+    json_decode($str);
+    json_last_error();
+    json_last_error_msg();
+}
+
+?>

--- a/rules-tests/Php73/Rector/FuncCall/JsonThrowOnErrorRector/Fixture/skip_json_last_error_next.php.inc
+++ b/rules-tests/Php73/Rector/FuncCall/JsonThrowOnErrorRector/Fixture/skip_json_last_error_next.php.inc
@@ -5,7 +5,7 @@ namespace Rector\Tests\Php73\Rector\FuncCall\JsonThrowOnErrorRector\Fixture;
 function SkipJsonLastErrorNext2()
 {
     json_decode($str);
-    return json_last_error() === JSON_ERROR_NONE
+    return json_last_error() === JSON_ERROR_NONE;
 }
 
 ?>

--- a/rules-tests/Php73/Rector/FuncCall/JsonThrowOnErrorRector/Fixture/skip_json_last_error_next2.php.inc
+++ b/rules-tests/Php73/Rector/FuncCall/JsonThrowOnErrorRector/Fixture/skip_json_last_error_next2.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Tests\Php73\Rector\FuncCall\JsonThrowOnErrorRector\Fixture;
+
+function SkipJsonLastErrorNext()
+{
+    json_decode($str);
+    json_last_error();
+    json_last_error_msg();
+}
+
+?>

--- a/rules-tests/Php73/Rector/FuncCall/JsonThrowOnErrorRector/Fixture/skip_json_last_error_next3.php.inc
+++ b/rules-tests/Php73/Rector/FuncCall/JsonThrowOnErrorRector/Fixture/skip_json_last_error_next3.php.inc
@@ -2,9 +2,12 @@
 
 namespace Rector\Tests\Php73\Rector\FuncCall\JsonThrowOnErrorRector\Fixture;
 
-function SkipJsonLastErrorNext2()
+function SkipJsonLastErrorNext3($str)
 {
-    json_decode($str);
+    if (rand(0, 1)) {
+        json_decode($str);
+    }
+
     json_last_error();
     json_last_error_msg();
 }

--- a/rules/Downgrade72/Rector/FuncCall/DowngradeStreamIsattyRector.php
+++ b/rules/Downgrade72/Rector/FuncCall/DowngradeStreamIsattyRector.php
@@ -135,15 +135,15 @@ CODE_SAMPLE
         return $if;
     }
 
-    private function createClosure($node): Closure
+    private function createClosure(FuncCall $funcCall): Closure
     {
-        $if = $this->createIf($node->args[0]->value);
+        $if = $this->createIf($funcCall->args[0]->value);
 
         $function = new Closure();
         $function->params[] = new Param(new Variable('stream'));
         $function->stmts[] = $if;
 
-        $posixIsatty = $this->nodeFactory->createFuncCall('posix_isatty', [$node->args[0]->value]);
+        $posixIsatty = $this->nodeFactory->createFuncCall('posix_isatty', [$funcCall->args[0]->value]);
         $function->stmts[] = new Return_(new ErrorSuppress($posixIsatty));
         return $function;
     }

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -335,12 +335,14 @@ final class BetterNodeFinder
     public function findFirstNext(Node $node, callable $filter): ?Node
     {
         $next = $node->getAttribute(AttributeKey::NEXT_NODE);
-        if ($next instanceof Return_ && $next->expr === null) {
-            return null;
-        }
+        if ($next instanceof Return_) {
+            if ($next->expr === null) {
+                return null;
+            }
 
-        if ($next instanceof Return_ && ! $this->findFirst($next->expr, $filter) instanceof Node) {
-            return null;
+            if (! $this->findFirst($next->expr, $filter) instanceof Node) {
+                return null;
+            }
         }
 
         if ($next instanceof Node) {

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Return_;
 use PhpParser\NodeFinder;
 use Rector\Core\PhpParser\Comparing\NodeComparator;
 use Rector\Core\Util\StaticNodeInstanceOf;
@@ -334,6 +335,14 @@ final class BetterNodeFinder
     public function findFirstNext(Node $node, callable $filter): ?Node
     {
         $next = $node->getAttribute(AttributeKey::NEXT_NODE);
+        if ($next instanceof Return_ && $next->expr === null) {
+            return null;
+        }
+
+        if ($next instanceof Return_ && ! $this->findFirst($next->expr, $filter) instanceof Node) {
+            return null;
+        }
+
         if ($next instanceof Node) {
             $found = $this->findFirst($next, $filter);
             if ($found instanceof Node) {
@@ -344,7 +353,7 @@ final class BetterNodeFinder
         }
 
         $parent = $node->getAttribute(AttributeKey::PARENT_NODE);
-        if ($parent instanceof FunctionLike) {
+        if ($parent instanceof Return_ || $parent instanceof FunctionLike) {
             return null;
         }
 

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -335,11 +335,12 @@ final class BetterNodeFinder
     public function findFirstNext(Node $node, callable $filter): ?Node
     {
         $next = $node->getAttribute(AttributeKey::NEXT_NODE);
-        if ($next instanceof Return_ && $next->expr === null) {
-            return null;
-        }
 
         if ($next instanceof Node) {
+            if ($next instanceof Return_ && $next->expr === null) {
+                return null;
+            }
+
             $found = $this->findFirst($next, $filter);
             if ($found instanceof Node) {
                 return $found;

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -335,7 +335,6 @@ final class BetterNodeFinder
     public function findFirstNext(Node $node, callable $filter): ?Node
     {
         $next = $node->getAttribute(AttributeKey::NEXT_NODE);
-
         if ($next instanceof Node) {
             if ($next instanceof Return_ && $next->expr === null) {
                 return null;

--- a/src/PhpParser/Node/BetterNodeFinder.php
+++ b/src/PhpParser/Node/BetterNodeFinder.php
@@ -335,14 +335,8 @@ final class BetterNodeFinder
     public function findFirstNext(Node $node, callable $filter): ?Node
     {
         $next = $node->getAttribute(AttributeKey::NEXT_NODE);
-        if ($next instanceof Return_) {
-            if ($next->expr === null) {
-                return null;
-            }
-
-            if (! $this->findFirst($next->expr, $filter) instanceof Node) {
-                return null;
-            }
+        if ($next instanceof Return_ && $next->expr === null) {
+            return null;
         }
 
         if ($next instanceof Node) {


### PR DESCRIPTION
- change 2nd parameter of json_decode to null  as default value is null, ref https://www.php.net/manual/en/function.json-decode.php 

- skip when next func call is/are `json_last_error()`, `json_last_error_msg()` as may be used next ref https://3v4l.org/3R5fM