### PR TITLE
[Php73] Skip RegexDashEscapeRector on 3 backslash with next to be escaped

### DIFF
--- a/rules-tests/Php73/Rector/FuncCall/RegexDashEscapeRector/Fixture/skip_three_backslash.php.inc
+++ b/rules-tests/Php73/Rector/FuncCall/RegexDashEscapeRector/Fixture/skip_three_backslash.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rector\Tests\Php73\Rector\FuncCall\RegexDashEscapeRector\Fixture;
+
+class SkipThreeBackslash
+{
+    public function run($text)
+    {
+        preg_match("#\([\w<>=\/\\\,:.\-\s\+]+\)#", $text, $matches);
+    }
+}

--- a/rules/Downgrade72/Rector/FuncCall/DowngradeStreamIsattyRector.php
+++ b/rules/Downgrade72/Rector/FuncCall/DowngradeStreamIsattyRector.php
@@ -135,15 +135,15 @@ CODE_SAMPLE
         return $if;
     }
 
-    private function createClosure($node): Closure
+    private function createClosure(FuncCall $funcCall): Closure
     {
-        $if = $this->createIf($node->args[0]->value);
+        $if = $this->createIf($funcCall->args[0]->value);
 
         $function = new Closure();
         $function->params[] = new Param(new Variable('stream'));
         $function->stmts[] = $if;
 
-        $posixIsatty = $this->nodeFactory->createFuncCall('posix_isatty', [$node->args[0]->value]);
+        $posixIsatty = $this->nodeFactory->createFuncCall('posix_isatty', [$funcCall->args[0]->value]);
         $function->stmts[] = new Return_(new ErrorSuppress($posixIsatty));
         return $function;
     }

--- a/rules/Php73/Rector/FuncCall/RegexDashEscapeRector.php
+++ b/rules/Php73/Rector/FuncCall/RegexDashEscapeRector.php
@@ -21,6 +21,13 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class RegexDashEscapeRector extends AbstractRector
 {
+
+    /**
+     * @var string
+     * @see https://regex101.com/r/BjKZFg/1
+     */
+    private const THREE_BACKSLASH_FOR_ESCAPE_NEXT = '#\\\\\\\[^\\\]#';
+
     /**
      * @var string
      * @see https://regex101.com/r/YgVJFp/1
@@ -86,6 +93,10 @@ CODE_SAMPLE
     private function escapeStringNode(String_ $string): void
     {
         $stringValue = $string->value;
+
+        if (Strings::match($stringValue, self::THREE_BACKSLASH_FOR_ESCAPE_NEXT)) {
+            return;
+        }
 
         if (Strings::match($stringValue, self::LEFT_HAND_UNESCAPED_DASH_REGEX)) {
             $string->value = Strings::replace($stringValue, self::LEFT_HAND_UNESCAPED_DASH_REGEX, '$1\-');

--- a/rules/Php73/Rector/FuncCall/RegexDashEscapeRector.php
+++ b/rules/Php73/Rector/FuncCall/RegexDashEscapeRector.php
@@ -24,9 +24,11 @@ final class RegexDashEscapeRector extends AbstractRector
 
     /**
      * @var string
-     * @see https://regex101.com/r/1e3hoF/1
+     * @see https://regex101.com/r/iQbGgZ/1
+     *
+     * Use {2} as detected only 2 after $this->regexPatternArgumentManipulator->matchCallArgumentWithRegexPattern() call
      */
-    private const THREE_BACKSLASH_FOR_ESCAPE_NEXT_REGEX = '#(?<=[^\\\\])\\\\{3}(?=[^\\\\])#';
+    private const THREE_BACKSLASH_FOR_ESCAPE_NEXT_REGEX = '#(?<=[^\\\\])\\\\{2}(?=[^\\\\])#';
 
     /**
      * @var string

--- a/rules/Php73/Rector/FuncCall/RegexDashEscapeRector.php
+++ b/rules/Php73/Rector/FuncCall/RegexDashEscapeRector.php
@@ -24,9 +24,9 @@ final class RegexDashEscapeRector extends AbstractRector
 
     /**
      * @var string
-     * @see https://regex101.com/r/BjKZFg/1
+     * @see https://regex101.com/r/1e3hoF/1
      */
-    private const THREE_BACKSLASH_FOR_ESCAPE_NEXT_REGEX = '#\\\\\\\[^\\\]#';
+    private const THREE_BACKSLASH_FOR_ESCAPE_NEXT_REGEX = '#[^\\\]\\\\\\\[^\\\]#';
 
     /**
      * @var string
@@ -95,7 +95,7 @@ CODE_SAMPLE
         $stringValue = $string->value;
 
         if (Strings::match($stringValue, self::THREE_BACKSLASH_FOR_ESCAPE_NEXT_REGEX)) {
-            //return;
+            return;
         }
 
         if (Strings::match($stringValue, self::LEFT_HAND_UNESCAPED_DASH_REGEX)) {

--- a/rules/Php73/Rector/FuncCall/RegexDashEscapeRector.php
+++ b/rules/Php73/Rector/FuncCall/RegexDashEscapeRector.php
@@ -26,7 +26,7 @@ final class RegexDashEscapeRector extends AbstractRector
      * @var string
      * @see https://regex101.com/r/BjKZFg/1
      */
-    private const THREE_BACKSLASH_FOR_ESCAPE_NEXT = '#\\\\\\\[^\\\]#';
+    private const THREE_BACKSLASH_FOR_ESCAPE_NEXT_REGEX = '#\\\\\\\[^\\\]#';
 
     /**
      * @var string
@@ -94,8 +94,8 @@ CODE_SAMPLE
     {
         $stringValue = $string->value;
 
-        if (Strings::match($stringValue, self::THREE_BACKSLASH_FOR_ESCAPE_NEXT)) {
-            return;
+        if (Strings::match($stringValue, self::THREE_BACKSLASH_FOR_ESCAPE_NEXT_REGEX)) {
+            //return;
         }
 
         if (Strings::match($stringValue, self::LEFT_HAND_UNESCAPED_DASH_REGEX)) {

--- a/rules/Php73/Rector/FuncCall/RegexDashEscapeRector.php
+++ b/rules/Php73/Rector/FuncCall/RegexDashEscapeRector.php
@@ -26,7 +26,7 @@ final class RegexDashEscapeRector extends AbstractRector
      * @var string
      * @see https://regex101.com/r/1e3hoF/1
      */
-    private const THREE_BACKSLASH_FOR_ESCAPE_NEXT_REGEX = '#[^\\\]\\\\\\\[^\\\]#';
+    private const THREE_BACKSLASH_FOR_ESCAPE_NEXT_REGEX = '#(?<=[^\\\\])\\\\{3}(?=[^\\\\])#';
 
     /**
      * @var string
@@ -84,6 +84,10 @@ CODE_SAMPLE
         }
 
         foreach ($regexArguments as $regexArgument) {
+            if (Strings::match($regexArgument->value, self::THREE_BACKSLASH_FOR_ESCAPE_NEXT_REGEX)) {
+                continue;
+            }
+
             $this->escapeStringNode($regexArgument);
         }
 
@@ -93,10 +97,6 @@ CODE_SAMPLE
     private function escapeStringNode(String_ $string): void
     {
         $stringValue = $string->value;
-
-        if (Strings::match($stringValue, self::THREE_BACKSLASH_FOR_ESCAPE_NEXT_REGEX)) {
-            return;
-        }
 
         if (Strings::match($stringValue, self::LEFT_HAND_UNESCAPED_DASH_REGEX)) {
             $string->value = Strings::replace($stringValue, self::LEFT_HAND_UNESCAPED_DASH_REGEX, '$1\-');


### PR DESCRIPTION
It previously produce invalid regex ref https://regex101.com/r/QkRzuF/1 , also, if passed to `preg_match()`, it will result different data ref https://github.com/codeigniter4/CodeIgniter4/runs/2345676568#step:11:177