### PR TITLE
Add failing test fixture for ConsistentPregDelimiterRector. #6161

### DIFF
--- a/rules-tests/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector/Fixture/update_multiline_pcre_extended_pattern.php.inc
+++ b/rules-tests/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector/Fixture/update_multiline_pcre_extended_pattern.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\FuncCall\ConsistentPregDelimiterRector\Fixture;
+
+class UpdateMultilinePcreExtendedPattern
+{
+    public function run()
+    {
+        $file = preg_replace('/^(
+            test
+        )/x', '', $file);
+
+        $file = preg_replace('#^(
+            test
+        )#x', '', $file);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\FuncCall\ConsistentPregDelimiterRector\Fixture;
+
+class UpdateMultilinePcreExtendedPattern
+{
+    public function run()
+    {
+        $file = preg_replace('#^(
+            test
+        )#x', '', $file);
+
+        $file = preg_replace('#^(
+            test
+        )#x', '', $file);
+    }
+}
+
+?>


### PR DESCRIPTION
This test checks for two issues

 - ConsistentPregDelimiterRector does not refactor multi line regular expression in `PCRE_EXTENDED` mode.
 - End delimiter is escaped in multi line regular expressions in `PCRE_EXTENDED` mode