### PR TITLE
Fix #6161

### DIFF
--- a/rules-tests/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector/Fixture/update_multiline_pcre_extended_pattern.php.inc
+++ b/rules-tests/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector/Fixture/update_multiline_pcre_extended_pattern.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\FuncCall\ConsistentPregDelimiterRector\Fixture;
+
+class UpdateMultilinePcreExtendedPattern
+{
+    public function run()
+    {
+        $file = preg_replace('/^(
+            test
+        )/x', '', $file);
+
+        $file = preg_replace('#^(
+            test
+        )#x', '', $file);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\CodingStyle\Rector\FuncCall\ConsistentPregDelimiterRector\Fixture;
+
+class UpdateMultilinePcreExtendedPattern
+{
+    public function run()
+    {
+        $file = preg_replace('#^(
+            test
+        )#x', '', $file);
+
+        $file = preg_replace('#^(
+            test
+        )#x', '', $file);
+    }
+}
+
+?>

--- a/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
+++ b/rules/CodingStyle/Rector/FuncCall/ConsistentPregDelimiterRector.php
@@ -33,7 +33,7 @@ final class ConsistentPregDelimiterRector extends AbstractRector implements Conf
      *
      * For modifiers see https://www.php.net/manual/en/reference.pcre.pattern.modifiers.php
      */
-    private const INNER_REGEX = '#(?<content>.*?)(?<close>[imsxeADSUXJu]*)$#';
+    private const INNER_REGEX = '#(?<content>.*?)(?<close>[imsxeADSUXJu]*)$#s';
 
     /**
      * All with pattern as 1st argument


### PR DESCRIPTION
`ConsistentPregDelimiterRector` is not refactoring multiline regular expressions, since `PCRE_DOTALL` modifier is not specified.