### PR TITLE
[Scoped] Allow PHP 7.0 on rector-prefixed build

### DIFF
--- a/build/config/config-downgrade.php
+++ b/build/config/config-downgrade.php
@@ -21,6 +21,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         DowngradeSetList::PHP_74,
         DowngradeSetList::PHP_73,
         DowngradeSetList::PHP_72,
+        DowngradeSetList::PHP_71,
     ]);
 };
 

--- a/build/target-repository/.github/workflows/bare_run.yaml
+++ b/build/target-repository/.github/workflows/bare_run.yaml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php_version: ['7.1', '7.2', '7.3', '7.4', '8.0']
+                php_version: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
 
         steps:
             -   uses: actions/checkout@v2

--- a/build/target-repository/.github/workflows/finalize_classes.yaml
+++ b/build/target-repository/.github/workflows/finalize_classes.yaml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php_version: ['7.1', '7.2', '7.3', '7.4', '8.0']
+                php_version: ['7.0', 7.1', '7.2', '7.3', '7.4', '8.0']
                 commands:
                     -
                         name: 'Finalize Entity'

--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -1,13 +1,13 @@
 {
     "name": "rector/rector-prefixed",
-    "description": "Prefixed and PHP 7.1 downgraded version of rector/rector",
+    "description": "Prefixed and PHP 7.0 downgraded version of rector/rector",
     "license": "MIT",
     "bin": [
         "bin/rector"
     ],
     "require": {
-        "php": "^7.1|^8.0",
-        "phpstan/phpstan": "^0.12.82"
+        "php": "^7.0|^8.0",
+        "phpstan/phpstan": "^0.9.3 || ^0.12.82"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Part of https://github.com/rectorphp/rector/issues/6079 . I think most of downgrade 7.1 have implemented, lets try to downgrade to 7.0 for rector-prefixed build.