### PR TITLE
[Scoper] Downgrade rector.php as well for PHP 7.0 void

### DIFF
--- a/build/downgrade-rector.sh
+++ b/build/downgrade-rector.sh
@@ -30,8 +30,8 @@ for directory in $directories; do
     echo "[NOTE] Downgrading '$directory' directory\n"
 
     # --working-dir is needed, so "SKIP" parameter is applied in absolute path of nested directory
-    php -d memory_limit=-1 bin/rector process $directory --config build/config/config-downgrade.php --working-dir $BUILD_DIRECTORY --ansi
+    #php -d memory_limit=-1 bin/rector process $directory --config build/config/config-downgrade.php --working-dir $BUILD_DIRECTORY --ansi
 done
 
 # 5. downgrade rector.php config as well
-php -d memory_limit=-1 bin/rector process rector.php --config build/config/config-downgrade.php --ansi
+php -d memory_limit=-1 bin/rector process rector.php --config build/config/config-downgrade.php --working-dir rector-build --ansi

--- a/build/downgrade-rector.sh
+++ b/build/downgrade-rector.sh
@@ -20,7 +20,7 @@ BUILD_DIRECTORY=$1
 echo "[NOTE] Running downgrade in '$BUILD_DIRECTORY' directory\n";
 
 # 3. provide directories to downgrade; includes the rector dirs
-directories=$(php -d memory_limit=-1 bin/rector downgrade-paths 7.1 --config build/config/config-downgrade.php --working-dir $BUILD_DIRECTORY --ansi)
+directories=$(php -d memory_limit=-1 bin/rector downgrade-paths 7.0 --config build/config/config-downgrade.php --working-dir $BUILD_DIRECTORY --ansi)
 
 # split array see https://stackoverflow.com/a/1407098/1348344
 export IFS=";"
@@ -32,3 +32,6 @@ for directory in $directories; do
     # --working-dir is needed, so "SKIP" parameter is applied in absolute path of nested directory
     php -d memory_limit=-1 bin/rector process $directory --config build/config/config-downgrade.php --working-dir $BUILD_DIRECTORY --ansi
 done
+
+# 5. downgrade rector.php config as well
+php -d memory_limit=-1 bin/rector process rector.php --config build/config/config-downgrade.php --ansi

--- a/build/target-repository/README.md
+++ b/build/target-repository/README.md
@@ -5,7 +5,7 @@
 
 Do you have conflicts on Rector install? You're in the right place. Prefixed Rector can [be installed even on very old Symfony](https://getrector.org/blog/2020/01/20/how-to-install-rector-despite-composer-conflicts).
 
-Do you have older PHP? Rector prefixed goes down to PHP 7.1, so you can install it even on older projects.
+Do you have older PHP? Rector prefixed goes down to PHP 7.0, so you can install it even on older projects.
 
 ## Install
 

--- a/rector.php
+++ b/rector.php
@@ -21,7 +21,7 @@ use Rector\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symplify\SymfonyPhpConfig\ValueObjectInliner;
 
-return static function (ContainerConfigurator $containerConfigurator) {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $configuration = ValueObjectInliner::inline([

--- a/rector.php
+++ b/rector.php
@@ -21,7 +21,7 @@ use Rector\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symplify\SymfonyPhpConfig\ValueObjectInliner;
 
-return static function (ContainerConfigurator $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator) {
     $services = $containerConfigurator->services();
 
     $configuration = ValueObjectInliner::inline([


### PR DESCRIPTION
part of https://github.com/rectorphp/rector/issues/6176 for handle error in php 7.0:

```bash
PHP Fatal error:  Uncaught TypeError: Return value of RectorPrefix20210420\AutoloadIncluder::loadIfExistsAndNotLoadedYet() must be an instance of RectorPrefix20210420\void, none returned in /home/runner/work/rector-prefixed/rector-prefixed/bin/rector.php:92
Stack trace:
#0 /home/runner/work/rector-prefixed/rector-prefixed/bin/rector.php(58): RectorPrefix20210420\AutoloadIncluder->loadIfExistsAndNotLoadedYet('/home/runner/wo...')
#1 /home/runner/work/rector-prefixed/rector-prefixed/bin/rector.php(23): RectorPrefix20210420\AutoloadIncluder->includeDependencyOrRepositoryVendorAutoloadIfExists()
#2 /home/runner/work/rector-prefixed/rector-prefixed/bin/rector(5): require_once('/home/runner/wo...')
#3 {main}
  thrown in /home/runner/work/rector-prefixed/rector-prefixed/bin/rector.php on line 92
Fatal error: Uncaught TypeError: Return value of RectorPrefix20210420\AutoloadIncluder::loadIfExistsAndNotLoadedYet() must be an instance of RectorPrefix20210420\void, none returned in /home/runner/work/rector-prefixed/rector-prefixed/bin/rector.php:92
Stack trace:
#0 /home/runner/work/rector-prefixed/rector-prefixed/bin/rector.php(58): RectorPrefix20210420\AutoloadIncluder->loadIfExistsAndNotLoadedYet('/home/runner/wo...')
#1 /home/runner/work/rector-prefixed/rector-prefixed/bin/rector.php(23): RectorPrefix20210420\AutoloadIncluder->includeDependencyOrRepositoryVendorAutoloadIfExists()
#2 /home/runner/work/rector-prefixed/rector-prefixed/bin/rector(5): require_once('/home/runner/wo...')
#3 {main}
  thrown in /home/runner/work/rector-prefixed/rector-prefixed/bin/rector.php on line 92
```