### PR TITLE
Allow `composer/xdebug-handler` v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "ext-dom": "*",
         "ext-json": "*",
         "composer/semver": "^3.2",
-        "composer/xdebug-handler": "^1.4",
+        "composer/xdebug-handler": "^1.4|^2.0",
         "danielstjules/stringy": "^3.1",
         "doctrine/inflector": "^2.0",
         "jean85/pretty-package-versions": "^1.5.1|^2.0.1",


### PR DESCRIPTION
Hopefully this fixes:

```
  Problem 1
    - friendsofphp/php-cs-fixer is locked to version v3.0.0-rc.1 and an update of this package was not requested.
    - rector/rector 0.10.6 requires composer/xdebug-handler ^1.4 -> satisfiable by composer/xdebug-handler[1.4.0, ..., 1.4.6].
    - You can only install one version of a package, so only one of these can be installed: composer/xdebug-handler[1.4.0, ..., 1.4.6, 2.0.0].
    - friendsofphp/php-cs-fixer v3.0.0-rc.1 requires composer/xdebug-handler ^2.0 -> satisfiable by composer/xdebug-handler[2.0.0].
    - Root composer.json requires rector/rector ^0.10.6 -> satisfiable by rector/rector[0.10.6].
```

Not sure if this works. Let's wait for the tests?