### PR TITLE
Add iterable to PHP 7.1 downgrade set

### DIFF
--- a/config/set/downgrade-php71.php
+++ b/config/set/downgrade-php71.php
@@ -6,6 +6,7 @@ use Rector\Core\Configuration\Option;
 use Rector\Core\ValueObject\PhpVersion;
 use Rector\DowngradePhp71\Rector\Array_\SymmetricArrayDestructuringToListRector;
 use Rector\DowngradePhp71\Rector\ClassConst\DowngradeClassConstantVisibilityRector;
+use Rector\DowngradePhp71\Rector\FunctionLike\DowngradeIterablePseudoTypeDeclarationRector;
 use Rector\DowngradePhp71\Rector\FunctionLike\DowngradeNullableTypeDeclarationRector;
 use Rector\DowngradePhp71\Rector\FunctionLike\DowngradeVoidTypeDeclarationRector;
 use Rector\DowngradePhp71\Rector\List_\DowngradeKeysInListRector;
@@ -25,4 +26,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(SymmetricArrayDestructuringToListRector::class);
     $services->set(DowngradeNegativeStringOffsetToStrlenRector::class);
     $services->set(DowngradeKeysInListRector::class);
+    $services->set(DowngradeIterablePseudoTypeDeclarationRector::class);
 };


### PR DESCRIPTION
Fixes `iterable` on PHP 7.0

![image](https://user-images.githubusercontent.com/924196/115619264-f2408780-a2f3-11eb-94c2-c7ca3d7fa4a8.png)
