### PR TITLE
[UnionTypesRector] Do not refactor to `DateTime|object` property type

### DIFF
--- a/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/Fixture/object_and_specific_class.php.inc
+++ b/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/Fixture/object_and_specific_class.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rector\Php80\Tests\Rector\FunctionLike\UnionTypesRector\Fixture;
+
+final class ObjectAndSpecificClass
+{
+    /**
+     * @param object|DateTime $message
+     */
+    private function getMessage($message)
+    {
+        if ($message instanceof \DateTime) {
+            // do something special
+        }
+        
+        return $message;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Php80\Tests\Rector\FunctionLike\UnionTypesRector\Fixture;
+
+final class ObjectAndSpecificClass
+{
+    /**
+     * @param object|DateTime $message
+     */
+    private function getMessage(object $message)
+    {
+        if ($message instanceof \DateTime) {
+            // do something special
+        }
+        
+        return $message;
+    }
+}
+?>


### PR DESCRIPTION
# Failing Test for UnionTypesRector

Based on https://getrector.org/demo/ade5aba8-d7bb-4f15-9afc-f83fd9a1b3f9

The change done by Rector gives a fatal error:
```
Fatal error:  Type DateTime|object contains both object and a class type, which is redundant
```