### PR TITLE
[TypedPropertyRector] Handle generic types

### DIFF
--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/generic_object_type.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/generic_object_type.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @template T of object
+ */
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
+
+final class GenericObjectType
+{
+    /**
+     * @var T
+     */
+    private $command;
+    
+    /**
+     * @param T $command
+     */
+    public function __construct(object $command)
+    {
+        $this->command = $command;
+    }
+}
+?>
+-----
+<?php
+
+/**
+ * @template T of object
+ */
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
+
+final class GenericObjectType
+{
+    /**
+     * @var T
+     */
+    private object $command;
+    
+    /**
+     * @param T $command
+     */
+    public function __construct(object $command)
+    {
+        $this->command = $command;
+    }
+}
+?>

--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/generic_object_type.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/generic_object_type.php.inc
@@ -1,10 +1,10 @@
 <?php
 
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
+
 /**
  * @template T of object
  */
-namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
-
 final class GenericObjectType
 {
     /**
@@ -24,11 +24,11 @@ final class GenericObjectType
 -----
 <?php
 
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
+
 /**
  * @template T of object
  */
-namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
-
 final class GenericObjectType
 {
     /**


### PR DESCRIPTION
# Failing Test for TypedPropertyRector

Based on https://getrector.org/demo/675190c7-7853-4f31-812b-0e8249b6d594

It produces `Fatal error:  Duplicate type object is redundant`