### PR TITLE
[TypedPropertyRector] Do not refactor to `iterable` property type

### DIFF
--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/skip_iterable_property_type.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/skip_iterable_property_type.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+interface HandlerInterface {}
+
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
+
+final class SkipIterablePropertyType
+{
+    /**
+     * @var HandlerInterface[]
+     */
+    private $handlers;
+
+    /**
+     * @param HandlerInterface[] $handlers
+     */
+    public function __construct(iterable $handlers)
+    {
+        $this->handlers = $handlers;
+    }
+}
+?>


### PR DESCRIPTION
# Failing Test for TypedPropertyRector

Based on https://getrector.org/demo/3a8fc4f5-898d-4fb4-8ed3-99dc8312df77

```
Fatal error: Cannot use iterable as iterable because 'iterable' is a special class name
```