### PR TITLE
[TypedPropertyRector] Do not refactor to `callable` property type

### DIFF
--- a/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/skip_callable_property_type.php.inc
+++ b/rules-tests/Php74/Rector/Property/TypedPropertyRector/Fixture/skip_callable_property_type.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rector\Php74\Tests\Rector\Property\TypedPropertyRector\Fixture;
+
+final class SkipCallablePropertyType
+{
+    /**
+     * @var callable|DateTimeImmutable
+     */
+    public $startDate;
+}
+?>


### PR DESCRIPTION
# Failing Test for TypedPropertyRector

Based on https://getrector.org/demo/e8724b53-a00c-4f0c-b10f-e4e54be0a664

```
PHP Fatal error:  Property SkipCallablePropertyType::$startDate cannot have type DateTimeImmutable|callable
```