### PR TITLE
[UnionTypesRector] Do not refactor inherited methods

### DIFF
--- a/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/Fixture/some_parent.php.inc
+++ b/rules-tests/Php80/Rector/FunctionLike/UnionTypesRector/Fixture/some_parent.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+namespace Vendor {
+    class SomeParent
+    {
+        public function enqueueAt($at)
+        {
+        }
+    }
+}
+
+namespace App {
+    use Vendor\SomeParent;
+    
+    final class Child extends SomeParent
+    {
+        /**
+         * @param DateTime|int $at
+         */
+        public function enqueueAt($at)
+        {
+        }
+    }
+}
+?>
+


### PR DESCRIPTION
# Failing Test for UnionTypesRector

Based on https://getrector.org/demo/6298a30b-d9f5-4fa0-b1f8-9712b0e98582

```
PHP Fatal error:  Declaration of Child::enqueueAt(DateTime|int $at) must be compatible with SomeParent::enqueueAt($at)
```