### PR TITLE
[DeadCode] Skip expr check from statement on RemoveUnusedVariableAssignRector for Nop stmt

### DIFF
--- a/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/skip_else_nop.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/skip_else_nop.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
+
+class SkipElseNop {
+    public function run(array $params)
+    {
+        $toDate = null;
+        if (isset($params['todate'])) {
+            $toDate = \DateTime::createFromFormat('d.m.Y', $params['todate']);
+        } else {
+            // nop
+        }
+
+        return $toDate;
+    }
+}
+
+?>

--- a/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/skip_if_nop.php.inc
+++ b/rules-tests/DeadCode/Rector/Assign/RemoveUnusedVariableAssignRector/Fixture/skip_if_nop.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rector\Tests\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector\Fixture;
+
+class SkipIfNop {
+    public function run(array $params)
+    {
+        $toDate = null;
+        if (isset($params['todate'])) {
+            // nop
+        } else {
+            $toDate = new \DateTime();
+            $toDate->setTimestamp(strtotime('now - 3 month'));
+        }
+
+        return $toDate;
+    }
+}
+
+?>

--- a/src/PhpParser/Comparing/ConditionSearcher.php
+++ b/src/PhpParser/Comparing/ConditionSearcher.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\If_;
+use PhpParser\Node\Stmt\Nop;
 
 final class ConditionSearcher
 {
@@ -19,7 +20,7 @@ final class ConditionSearcher
 
         // search if for redeclaration of variable
         foreach ($if->stmts as $statementIf) {
-            if (! $statementIf instanceof Expression) {
+            if ($statementIf instanceof Nop) { // Nop stmt doesn't has expr property
                 continue;
             }
 
@@ -52,6 +53,10 @@ final class ConditionSearcher
     {
         /** @var Expression $statementElse */
         foreach ($else->stmts as $statementElse) {
+            if ($statementElse instanceof Nop) { // Nop stmt doesn't has expr property
+                continue;
+            }
+
             if (! $statementElse->expr instanceof Assign) {
                 continue;
             }

--- a/src/PhpParser/Comparing/ConditionSearcher.php
+++ b/src/PhpParser/Comparing/ConditionSearcher.php
@@ -50,8 +50,11 @@ final class ConditionSearcher
 
     private function searchElseForVariableRedeclaration(Assign $assign, Else_ $else): bool
     {
-        /** @var Expression $statementElse */
         foreach ($else->stmts as $statementElse) {
+            if (! $statementElse instanceof Expression) {
+                continue;
+            }
+
             if (! $statementElse->expr instanceof Assign) {
                 continue;
             }

--- a/src/PhpParser/Comparing/ConditionSearcher.php
+++ b/src/PhpParser/Comparing/ConditionSearcher.php
@@ -9,7 +9,6 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\If_;
-use PhpParser\Node\Stmt\Nop;
 
 final class ConditionSearcher
 {
@@ -53,10 +52,6 @@ final class ConditionSearcher
     {
         /** @var Expression $statementElse */
         foreach ($else->stmts as $statementElse) {
-            if (! $statementElse instanceof Expression) {
-                continue;
-            }
-
             if (! $statementElse->expr instanceof Assign) {
                 continue;
             }

--- a/src/PhpParser/Comparing/ConditionSearcher.php
+++ b/src/PhpParser/Comparing/ConditionSearcher.php
@@ -20,7 +20,7 @@ final class ConditionSearcher
 
         // search if for redeclaration of variable
         foreach ($if->stmts as $statementIf) {
-            if ($statementIf instanceof Nop) { // Nop stmt doesn't has expr property
+            if (! $statementIf instanceof Expression) {
                 continue;
             }
 
@@ -53,7 +53,7 @@ final class ConditionSearcher
     {
         /** @var Expression $statementElse */
         foreach ($else->stmts as $statementElse) {
-            if ($statementElse instanceof Nop) { // Nop stmt doesn't has expr property
+            if (! $statementElse instanceof Expression) {
                 continue;
             }
 


### PR DESCRIPTION
Nop stmt doesn't has expr property on next check.