### PR TITLE
[RemoveUnusedVariableInCatchRector] Skip when variable is used outside catch

### DIFF
--- a/rules-tests/Php80/Rector/Catch_/RemoveUnusedVariableInCatchRector/Fixture/skip_when_variable_is_used_outside_catch.php.inc
+++ b/rules-tests/Php80/Rector/Catch_/RemoveUnusedVariableInCatchRector/Fixture/skip_when_variable_is_used_outside_catch.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Php80\Tests\Rector\Catch_\RemoveUnusedVariableInCatchRector\Fixture;
+
+final class SkipWhenVariableIsUsedOutsideCatch
+{
+    public function run()
+    {
+        $exception = null;
+        
+        try {
+            DateTime::createFromFormat('u', 234234);
+        } catch (\Exception $exception) {
+            // Store in $exception
+        }
+        
+        // Do other things
+        
+        if ($exception !== null) {
+            // Handle exception cleanup
+        }
+    }
+}
+?>
+


### PR DESCRIPTION
# Failing Test for RemoveUnusedVariableInCatchRector

Based on https://getrector.org/demo/194e0c75-cb30-4f02-a0de-70d32fbe152c

This broke some of my code.... you could argue that this is nasty code anyway, but it is what it is. 