### PR TITLE
[ChangeSwitchToMatchRector] Add `default` case when variable is already initialized

### DIFF
--- a/rules-tests/Php80/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/add_default_case_when_variable_is_initialized.php.inc
+++ b/rules-tests/Php80/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/add_default_case_when_variable_is_initialized.php.inc
@@ -1,0 +1,42 @@
+<?php
+
+namespace Rector\Php80\Tests\Rector\Switch_\ChangeSwitchToMatchRector\Fixture;
+
+final class AddDefaultCaseWhenVariableIsInitialized
+{
+    public function getError(int $code) : ?string
+    {
+        $error = null;
+        
+        switch ($code) {
+            case 10:
+                $error = 'code_10';
+                break;
+            case 11:
+                $error = 'code_11';
+                break;
+        }
+
+        return $error;
+    }
+}
+?>
+-----
+<?php
+
+namespace Rector\Php80\Tests\Rector\Switch_\ChangeSwitchToMatchRector\Fixture;
+
+final class AddDefaultCaseWhenVariableIsInitialized
+{
+    public function getError(int $code) : ?string
+    {        
+        $error = match ($code) {
+            10 => 'code_10',
+            11 => 'code_11',
+            default => null,
+        };
+
+        return $error;
+    }
+}
+?>


### PR DESCRIPTION
# Failing Test for ChangeSwitchToMatchRector

Based on https://getrector.org/demo/f7f2ba48-3c19-4fdb-bc0a-e956e037eefd

It's important to add the default case to prevent this error when passing another code:
```
Fatal error: Uncaught UnhandledMatchError: Unhandled match value of type int
```

https://3v4l.org/E64Um