### PR TITLE
[ChangeSwitchToMatchRector] Skip when `switch` does not assigns a variable

### DIFF
--- a/rules-tests/Php80/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/skip_when_switch_does_not_assign_value.php.inc
+++ b/rules-tests/Php80/Rector/Switch_/ChangeSwitchToMatchRector/Fixture/skip_when_switch_does_not_assign_value.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Php80\Tests\Rector\Switch_\ChangeSwitchToMatchRector\Fixture;
+
+final class SkipWhenSwitchDoesNotAssignValue
+{
+    public function run()
+    {
+        switch ($input) {
+            case "a":
+                $ths->a();
+                break;
+            case "b":
+                $ths->b();
+                break;
+        }
+    }
+    public function a() {}
+    public function b() {}
+}
+?>


### PR DESCRIPTION
# Failing Test for ChangeSwitchToMatchRector

Based on https://getrector.org/demo/f6b01d1b-dd26-4fcf-9260-43f850c0d2bc

It should not change this, as the docs clearly say:
```
A match expression returns a value.
```
https://www.php.net/match

This switch does not return a value.