### PR TITLE
Fix php70 on prefixed - skip nullable till phpstan is downgraded

### DIFF
--- a/build/config/config-downgrade.php
+++ b/build/config/config-downgrade.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Rector\Core\Configuration\Option;
 use Rector\Core\Stubs\PHPStanStubLoader;
+use Rector\DowngradePhp71\Rector\FunctionLike\DowngradeNullableTypeDeclarationRector;
 use Rector\Set\ValueObject\DowngradeSetList;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
@@ -13,7 +14,15 @@ $phpStanStubLoader->loadStubs();
 return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters = $containerConfigurator->parameters();
 
-    $parameters->set(Option::SKIP, DowngradeRectorConfig::DEPENDENCY_EXCLUDE_PATHS);
+    $skip = array_merge(
+        DowngradeRectorConfig::DEPENDENCY_EXCLUDE_PATHS,
+        [
+            // should be skipped until phpstan is downgraded to avoid conflict like this https://github.com/rectorphp/rector-prefixed/runs/2422176105#step:4:4
+            DowngradeNullableTypeDeclarationRector::class
+        ]
+    );
+    $parameters->set(Option::SKIP, $skip);
+
     $parameters->set(Option::PHPSTAN_FOR_RECTOR_PATH, __DIR__ . '/phpstan-for-downgrade.neon');
 
     $parameters->set(Option::SETS, [


### PR DESCRIPTION
@samsonasik Just a note, current downgrade set for PHP 7.1 cannot be used with `phpstan.phar`.
It would create return type conflict, as it only downgraded our code but parent class is in `phpstan.phar`

![image](https://user-images.githubusercontent.com/924196/115921268-8e48cb00-a47b-11eb-80d7-ac383f544eb2.png)


The solution is to downgrade https://github.com/phpstan/phpstan-src or unwrap `phpstan.phar` and downgrade it too