### PR TITLE
[Downgrade PHP 7.1] Fix empty item on SymmetricArrayDestructuringToListRector

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -543,3 +543,4 @@ parameters:
 
         # doc typo in php-parser
         - '#Parameter \#1 \$type of method PhpParser\\Builder\\FunctionLike\:\:setReturnType\(\) expects PhpParser\\Node\\Name\|PhpParser\\Node\\NullableType\|string, PhpParser\\Node\\Name\|PhpParser\\Node\\NullableType\|PhpParser\\Node\\UnionType given#'
+        - '#Parameter \#2 \$args of class PhpParser\\Node\\Expr\\FuncCall constructor expects array<PhpParser\\Node\\Arg\>, array<int, PhpParser\\Node\\Arg\|null\> given#'

--- a/rules-tests/DowngradePhp71/Rector/Array_/SymmetricArrayDestructuringToListRector/Fixture/include_empty.php.inc
+++ b/rules-tests/DowngradePhp71/Rector/Array_/SymmetricArrayDestructuringToListRector/Fixture/include_empty.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp71\Rector\Array_\SymmetricArrayDestructuringToListRector\Fixture;
+
+final class IncludeEmpty
+{
+    public function __construct(array $data)
+    {
+        [, $id1, $name1] = $data;
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp71\Rector\Array_\SymmetricArrayDestructuringToListRector\Fixture;
+
+final class IncludeEmpty
+{
+    public function __construct(array $data)
+    {
+        list(, $id1, $name1) = $data;
+    }
+}
+
+?>

--- a/rules/DowngradePhp71/Rector/Array_/SymmetricArrayDestructuringToListRector.php
+++ b/rules/DowngradePhp71/Rector/Array_/SymmetricArrayDestructuringToListRector.php
@@ -25,7 +25,15 @@ final class SymmetricArrayDestructuringToListRector extends AbstractRector
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Downgrade Symmetric array destructuring to list() function', [
-            new CodeSample('[$id1, $name1] = $data;', 'list($id1, $name1) = $data;'),
+            new CodeSample(
+<<<'CODE_SAMPLE'
+[$id1, $name1] = $data;
+CODE_SAMPLE
+                ,
+<<<'CODE_SAMPLE'
+list($id1, $name1) = $data;
+CODE_SAMPLE
+            ),
         ]);
     }
 
@@ -60,10 +68,10 @@ final class SymmetricArrayDestructuringToListRector extends AbstractRector
         $args = [];
         foreach ($array->items as $arrayItem) {
             if (! $arrayItem instanceof ArrayItem) {
-                continue;
+                $args[] = null;
+            } else {
+                $args[] = new Arg($arrayItem->value);
             }
-
-            $args[] = new Arg($arrayItem->value);
         }
 
         return new FuncCall(new Name('list'), $args);

--- a/rules/DowngradePhp71/Rector/Array_/SymmetricArrayDestructuringToListRector.php
+++ b/rules/DowngradePhp71/Rector/Array_/SymmetricArrayDestructuringToListRector.php
@@ -67,11 +67,7 @@ CODE_SAMPLE
     {
         $args = [];
         foreach ($array->items as $arrayItem) {
-            if (! $arrayItem instanceof ArrayItem) {
-                $args[] = null;
-            } else {
-                $args[] = new Arg($arrayItem->value);
-            }
+            $args[] = $arrayItem instanceof ArrayItem ? new Arg($arrayItem->value) : null;
         }
 
         return new FuncCall(new Name('list'), $args);


### PR DESCRIPTION
Closes https://github.com/rectorphp/rector/issues/6210

See https://3v4l.org/3SYSp