### PR TITLE
add dump_node() helper functoin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,8 @@
         "symplify/skipper": "^9.2.19",
         "symplify/smart-file-system": "^9.2.19",
         "symplify/symfony-php-config": "^9.2.19",
-        "webmozart/assert": "^1.10"
+        "webmozart/assert": "^1.10",
+        "tracy/tracy": "^2.8"
     },
     "require-dev": {
         "symplify/rule-doc-generator": "^9.2.19",
@@ -79,8 +80,7 @@
         "symplify/easy-coding-standard": "^9.2.19",
         "symplify/easy-testing": "^9.2.19",
         "symplify/phpstan-extensions": "^9.2.19",
-        "symplify/phpstan-rules": "^9.2",
-        "tracy/tracy": "^2.8"
+        "symplify/phpstan-rules": "^9.2"
     },
     "replace": {
         "rector/rector-prefixed": "self.version"
@@ -90,7 +90,10 @@
             "Rector\\": ["packages", "rules"],
             "Rector\\Core\\": "src",
             "Rector\\Compiler\\": "utils/compiler/src"
-        }
+        },
+        "files": [
+            "src/functions/node_helper.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {
@@ -118,8 +121,7 @@
             "rules-tests/Restoration/Rector/Use_/RestoreFullyQualifiedNameRector/Source/ShortClassOnly.php",
             "rules-tests/Transform/Rector/FuncCall/FuncCallToMethodCallRector/Source/some_view_function.php",
             "rules-tests/TypeDeclaration/Rector/FunctionLike/ReturnTypeDeclarationRector/Source/MyBar.php",
-            "rules-tests/TypeDeclaration/Rector/Property/CompleteVarDocTypePropertyRector/Source/EventDispatcher.php",
-            "tests/debug_functions.php"
+            "rules-tests/TypeDeclaration/Rector/Property/CompleteVarDocTypePropertyRector/Source/EventDispatcher.php"
         ]
     },
     "scripts": {

--- a/config/services.php
+++ b/config/services.php
@@ -66,6 +66,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             __DIR__ . '/../src/ValueObject',
             __DIR__ . '/../src/Bootstrap',
             __DIR__ . '/../src/PhpParser/Node/CustomNode',
+            __DIR__ . '/../src/functions',
         ]);
 
     $services->alias(SymfonyApplication::class, ConsoleApplication::class);

--- a/src/functions/node_helper.php
+++ b/src/functions/node_helper.php
@@ -4,8 +4,14 @@ declare(strict_types=1);
 
 use PhpParser\Node;
 use PhpParser\PrettyPrinter\Standard;
+use Tracy\Dumper;
 
-require __DIR__ . '/../vendor/autoload.php';
+function dump_node(Node $node, int $depth = 2): void
+{
+    Dumper::dump($node, [
+        Dumper::DEPTH => $depth,
+    ]);
+}
 
 /**
  * @param Node|Node[] $node

--- a/src/functions/node_helper.php
+++ b/src/functions/node_helper.php
@@ -23,10 +23,10 @@ function print_node($node): void
     if (is_array($node)) {
         foreach ($node as $singleNode) {
             $printedContent = $standard->prettyPrint([$singleNode]);
-            dump($printedContent);
+            Dumper::dump($printedContent);
         }
     } else {
         $printedContent = $standard->prettyPrint([$node]);
-        dump($printedContent);
+        Dumper::dump($printedContent);
     }
 }


### PR DESCRIPTION
Closes https://github.com/rectorphp/rector/issues/6186

This is a must have for working with Rector.

```php
dump_node($node);

// second parameter is depth of parameters to dump
dump_node($node, 2);

dump_node($node, 4);
```