### PR TITLE
AnnotationToAttributeRector: ensure bool param in attribute

### DIFF
--- a/packages/PhpAttribute/Printer/PhpAttributeGroupFactory.php
+++ b/packages/PhpAttribute/Printer/PhpAttributeGroupFactory.php
@@ -10,7 +10,9 @@ use PhpParser\Node\Attribute;
 use PhpParser\Node\AttributeGroup;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name\FullyQualified;
+use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprFalseNode;
 use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprIntegerNode;
+use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprTrueNode;
 use PHPStan\PhpDocParser\Ast\Node;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantFloatType;
@@ -102,6 +104,14 @@ final class PhpAttributeGroupFactory
 
         if ($value instanceof ConstantBooleanType) {
             return $value->getValue();
+        }
+
+        if ($value instanceof ConstExprTrueNode) {
+            return true;
+        }
+
+        if ($value instanceof ConstExprFalseNode) {
+            return false;
         }
 
         if ($value instanceof Node) {

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/assert_not_blank.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/assert_not_blank.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class EntityColumnAndAssertNotBlankWithBoolean
+{
+    /**
+     * @Assert\NotBlank(allowNull=true)
+     */
+    public $name;
+
+    /**
+     * @Assert\NotBlank(allowNull=false)
+     */
+    public $surname;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class EntityColumnAndAssertNotBlankWithBoolean
+{
+    #[\Symfony\Component\Validator\Constraints\NotBlank(allowNull: true)]
+    public $name;
+
+    #[\Symfony\Component\Validator\Constraints\NotBlank(allowNull: false)]
+    public $surname;
+}
+
+?>

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/configured_rule.php
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/configured_rule.php
@@ -33,6 +33,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                     'Symfony\Component\Validator\Constraints\Range',
                     'Symfony\Component\Validator\Constraints\Range'
                 ),
+                new AnnotationToAttribute(
+                    'Symfony\Component\Validator\Constraints\NotBlank',
+                    'Symfony\Component\Validator\Constraints\NotBlank'
+                ),
             ]),
         ]]);
 };


### PR DESCRIPTION
Hi, seems AnnotationToAttributeRector has bug if annotation has bool param

```
-    #[\Symfony\Component\Validator\Constraints\NotBlank(allowNull: true)]
+    #[\Symfony\Component\Validator\Constraints\NotBlank(allowNull: 'true')]
```