### PR TITLE
[Privatization] Handle Reference Method/Static Call from outside file on ChangeReadOnlyPropertyWithDefaultValueToConstantRector

### DIFF
--- a/packages/NodeCollector/NodeCollector/NodeRepository.php
+++ b/packages/NodeCollector/NodeCollector/NodeRepository.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Rector\NodeCollector\NodeCollector;
 
 use Nette\Utils\Arrays;
-use Nette\Utils\FileSystem;
+use Symplify\SmartFileSystem\SmartFileSystem;
 use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Attribute;
@@ -242,7 +242,7 @@ final class NodeRepository
             }
 
             /** @var string $fileContent */
-            $fileContent = FileSystem::read($fileName);
+            $fileContent = SmartFileSystem::readfile($fileName);
             $nodes = $this->parser->parse($fileContent);
 
             return $this->getClassMethodFromNodes((array) $nodes, $classReflection, $className, $methodName);

--- a/packages/NodeCollector/NodeCollector/NodeRepository.php
+++ b/packages/NodeCollector/NodeCollector/NodeRepository.php
@@ -248,9 +248,8 @@ final class NodeRepository
                 return null;
             }
 
-            /** @var string $fileContent */
             $fileContent = $this->smartFileSystem->readfile($fileName);
-            $nodes = $this->parser->parse($fileContent);
+            $nodes = $this->parser->parse((string) $fileContent);
 
             return $this->getClassMethodFromNodes((array) $nodes, $classReflection, $className, $methodName);
         }

--- a/packages/NodeCollector/NodeCollector/NodeRepository.php
+++ b/packages/NodeCollector/NodeCollector/NodeRepository.php
@@ -6,7 +6,6 @@ namespace Rector\NodeCollector\NodeCollector;
 
 use Nette\Utils\Arrays;
 use Nette\Utils\Strings;
-use PhpParser\Error;
 use PhpParser\Node;
 use PhpParser\Node\Attribute;
 use PhpParser\Node\Expr;
@@ -244,22 +243,6 @@ final class NodeRepository
         }
 
         return $this->getClassMethodOutsideFile($classReflection, $className, $methodName);
-    }
-
-    private function getClassMethodOutsideFile(ClassReflection $classReflection, string $className, string $methodName): ?ClassMethod
-    {
-        if (! $classReflection->hasMethod($methodName) || $classReflection->isBuiltIn()) {
-            return null;
-        }
-
-        $fileName = $classReflection->getFileName();
-        if (! $fileName) {
-            return null;
-        }
-
-        $fileContent = $this->smartFileSystem->readfile($fileName);
-        $nodes = $this->parser->parse($fileContent);
-        return $this->getClassMethodFromNodes((array) $nodes, $classReflection, $className, $methodName);
     }
 
     /**
@@ -533,6 +516,28 @@ final class NodeRepository
         return $this->findClass($classLikeName) ?? $this->findInterface($classLikeName) ?? $this->findTrait(
             $classLikeName
         );
+    }
+
+    private function getClassMethodOutsideFile(
+        ClassReflection $classReflection,
+        string $className,
+        string $methodName
+    ): ?ClassMethod
+    {
+        if (! $classReflection->hasMethod($methodName)) {
+            return null;
+        }
+        if ($classReflection->isBuiltIn()) {
+            return null;
+        }
+        $fileName = $classReflection->getFileName();
+        if (! $fileName) {
+            return null;
+        }
+
+        $fileContent = $this->smartFileSystem->readfile($fileName);
+        $nodes = $this->parser->parse($fileContent);
+        return $this->getClassMethodFromNodes((array) $nodes, $classReflection, $className, $methodName);
     }
 
     /**

--- a/packages/NodeCollector/NodeCollector/NodeRepository.php
+++ b/packages/NodeCollector/NodeCollector/NodeRepository.php
@@ -248,7 +248,7 @@ final class NodeRepository
 
     private function getClassMethodOutsideFile(ClassReflection $classReflection, string $className, string $methodName): ?ClassMethod
     {
-        if (! $classReflection->hasMethod($methodName)) {
+        if (! $classReflection->hasMethod($methodName) || $classReflection->isBuiltIn()) {
             return null;
         }
 
@@ -258,17 +258,8 @@ final class NodeRepository
         }
 
         $fileContent = $this->smartFileSystem->readfile($fileName);
-        try {
-            $nodes = $this->parser->parse($fileContent);
-            return $this->getClassMethodFromNodes((array) $nodes, $classReflection, $className, $methodName);
-        } catch (Error $error) {
-            $isNotSyntaxError = ! Strings::contains($error->getMessage(), 'Syntax error');
-            if ($isNotSyntaxError) {
-                throw $error;
-            }
-        }
-
-        return null;
+        $nodes = $this->parser->parse($fileContent);
+        return $this->getClassMethodFromNodes((array) $nodes, $classReflection, $className, $methodName);
     }
 
     /**

--- a/packages/NodeCollector/NodeCollector/NodeRepository.php
+++ b/packages/NodeCollector/NodeCollector/NodeRepository.php
@@ -24,7 +24,6 @@ use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Interface_;
 use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\Trait_;
-use PhpParser\Parser;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\MixedType;
@@ -42,7 +41,6 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\PHPStanStaticTypeMapper\Utils\TypeUnwrapper;
 use ReflectionMethod;
-use Symplify\SmartFileSystem\SmartFileSystem;
 
 /**
  * This service contains all the parsed nodes. E.g. all the functions, method call, classes, static calls etc. It's
@@ -112,16 +110,6 @@ final class NodeRepository
      */
     private $reflectionProvider;
 
-    /**
-     * @var Parser
-     */
-    private $parser;
-
-    /**
-     * @var SmartFileSystem
-     */
-    private $smartFileSystem;
-
     public function __construct(
         ArrayCallableMethodReferenceAnalyzer $arrayCallableMethodReferenceAnalyzer,
         ParsedPropertyFetchNodeCollector $parsedPropertyFetchNodeCollector,
@@ -129,9 +117,7 @@ final class NodeRepository
         ParsedNodeCollector $parsedNodeCollector,
         TypeUnwrapper $typeUnwrapper,
         ReflectionProvider $reflectionProvider,
-        NodeTypeResolver $nodeTypeResolver,
-        Parser $parser,
-        SmartFileSystem $smartFileSystem
+        NodeTypeResolver $nodeTypeResolver
     ) {
         $this->nodeNameResolver = $nodeNameResolver;
         $this->arrayCallableMethodReferenceAnalyzer = $arrayCallableMethodReferenceAnalyzer;
@@ -140,8 +126,6 @@ final class NodeRepository
         $this->typeUnwrapper = $typeUnwrapper;
         $this->reflectionProvider = $reflectionProvider;
         $this->nodeTypeResolver = $nodeTypeResolver;
-        $this->parser = $parser;
-        $this->smartFileSystem = $smartFileSystem;
     }
 
     public function collect(Node $node): void

--- a/packages/NodeCollector/NodeCollector/NodeRepository.php
+++ b/packages/NodeCollector/NodeCollector/NodeRepository.php
@@ -534,7 +534,7 @@ final class NodeRepository
         string $methodName
     ): ?ClassMethod {
         $reflectionClass = $classReflection->getNativeReflection();
-        $shortClassName = $reflectionClass->getShortName();
+        $shortName = $reflectionClass->getShortName();
 
         foreach ($nodes as $node) {
             if ($node instanceof Namespace_) {
@@ -547,7 +547,7 @@ final class NodeRepository
                 }
             }
 
-            $classMethod = $this->getClassMethod($node, $shortClassName, $methodName);
+            $classMethod = $this->getClassMethod($node, $shortName, $methodName);
             if ($classMethod instanceof ClassMethod) {
                 return $classMethod;
             }

--- a/packages/NodeCollector/NodeCollector/NodeRepository.php
+++ b/packages/NodeCollector/NodeCollector/NodeRepository.php
@@ -121,6 +121,11 @@ final class NodeRepository
      */
     private $parser;
 
+    /**
+     * @var SmartFileSystem
+     */
+    private $smartFileSystem;
+
     public function __construct(
         ArrayCallableMethodReferenceAnalyzer $arrayCallableMethodReferenceAnalyzer,
         ParsedPropertyFetchNodeCollector $parsedPropertyFetchNodeCollector,
@@ -129,7 +134,8 @@ final class NodeRepository
         TypeUnwrapper $typeUnwrapper,
         ReflectionProvider $reflectionProvider,
         NodeTypeResolver $nodeTypeResolver,
-        Parser $parser
+        Parser $parser,
+        SmartFileSystem $smartFileSystem
     ) {
         $this->nodeNameResolver = $nodeNameResolver;
         $this->arrayCallableMethodReferenceAnalyzer = $arrayCallableMethodReferenceAnalyzer;
@@ -139,6 +145,7 @@ final class NodeRepository
         $this->reflectionProvider = $reflectionProvider;
         $this->nodeTypeResolver = $nodeTypeResolver;
         $this->parser = $parser;
+        $this->smartFileSystem = $smartFileSystem;
     }
 
     public function collect(Node $node): void
@@ -242,7 +249,7 @@ final class NodeRepository
             }
 
             /** @var string $fileContent */
-            $fileContent = SmartFileSystem::readfile($fileName);
+            $fileContent = $this->smartFileSystem->readfile($fileName);
             $nodes = $this->parser->parse($fileContent);
 
             return $this->getClassMethodFromNodes((array) $nodes, $classReflection, $className, $methodName);

--- a/packages/NodeCollector/NodeCollector/NodeRepository.php
+++ b/packages/NodeCollector/NodeCollector/NodeRepository.php
@@ -243,22 +243,27 @@ final class NodeRepository
             }
         }
 
-        if ($classReflection->hasMethod($methodName)) {
-            $fileName = $classReflection->getFileName();
-            if (! $fileName) {
-                return null;
-            }
+        return $this->getClassMethodOutsideFile($classReflection, $className, $methodName);
+    }
 
-            $fileContent = $this->smartFileSystem->readfile($fileName);
-            try {
-                $nodes = $this->parser->parse($fileContent);
-                return $this->getClassMethodFromNodes((array) $nodes, $classReflection, $className, $methodName);
-            } catch (Error $error) {
-                $isSyntaxError = Strings::contains($error->getMessage(), 'Syntax error');
-                if ($isSyntaxError) {
-                    return null;
-                }
+    private function getClassMethodOutsideFile(ClassReflection $classReflection, string $className, string $methodName): ?ClassMethod
+    {
+        if (! $classReflection->hasMethod($methodName)) {
+            return null;
+        }
 
+        $fileName = $classReflection->getFileName();
+        if (! $fileName) {
+            return null;
+        }
+
+        $fileContent = $this->smartFileSystem->readfile($fileName);
+        try {
+            $nodes = $this->parser->parse($fileContent);
+            return $this->getClassMethodFromNodes((array) $nodes, $classReflection, $className, $methodName);
+        } catch (Error $error) {
+            $isNotSyntaxError = ! Strings::contains($error->getMessage(), 'Syntax error');
+            if ($isNotSyntaxError) {
                 throw $error;
             }
         }

--- a/packages/NodeCollector/NodeCollector/NodeRepository.php
+++ b/packages/NodeCollector/NodeCollector/NodeRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\NodeCollector\NodeCollector;
 
 use Nette\Utils\Arrays;
+use Nette\Utils\FileSystem;
 use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Attribute;
@@ -241,7 +242,7 @@ final class NodeRepository
             }
 
             /** @var string $fileContent */
-            $fileContent = file_get_contents($fileName);
+            $fileContent = FileSystem::read($fileName);
             $nodes = $this->parser->parse($fileContent);
 
             return $this->getClassMethodFromNodes((array) $nodes, $classReflection, $className, $methodName);
@@ -531,15 +532,14 @@ final class NodeRepository
         ClassReflection $classReflection,
         string $className,
         string $methodName
-    ): ?ClassMethod
-    {
-        $nativeReflection = $classReflection->getNativeReflection();
-        $shortClassName = $nativeReflection->getShortName();
+    ): ?ClassMethod {
+        $reflectionClass = $classReflection->getNativeReflection();
+        $shortClassName = $reflectionClass->getShortName();
 
         foreach ($nodes as $node) {
             if ($node instanceof Namespace_) {
                 /** @var Stmt[] $nodeStmts */
-                $nodeStmts   = (array) $node->stmts;
+                $nodeStmts = $node->stmts;
                 $classMethod = $this->getClassMethodFromNodes($nodeStmts, $classReflection, $className, $methodName);
 
                 if ($classMethod instanceof ClassMethod) {

--- a/packages/NodeCollector/NodeCollector/NodeRepository.php
+++ b/packages/NodeCollector/NodeCollector/NodeRepository.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rector\NodeCollector\NodeCollector;
 
 use Nette\Utils\Arrays;
-use Symplify\SmartFileSystem\SmartFileSystem;
 use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Attribute;
@@ -47,6 +46,7 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\PHPStanStaticTypeMapper\Utils\TypeUnwrapper;
 use ReflectionMethod;
+use Symplify\SmartFileSystem\SmartFileSystem;
 
 /**
  * This service contains all the parsed nodes. E.g. all the functions, method call, classes, static calls etc. It's
@@ -249,7 +249,7 @@ final class NodeRepository
             }
 
             $fileContent = $this->smartFileSystem->readfile($fileName);
-            $nodes = $this->parser->parse((string) $fileContent);
+            $nodes = $this->parser->parse($fileContent);
 
             return $this->getClassMethodFromNodes((array) $nodes, $classReflection, $className, $methodName);
         }

--- a/rules-tests/Defluent/Rector/ClassMethod/ReturnThisRemoveRector/Fixture/skip_parent_in_vendor.php.inc
+++ b/rules-tests/Defluent/Rector/ClassMethod/ReturnThisRemoveRector/Fixture/skip_parent_in_vendor.php.inc
@@ -2,7 +2,7 @@
 
 namespace Rector\Tests\Defluent\Rector\ClassMethod\ReturnThisRemoveRector\Fixture;
 
-use Rector\Tests\Defluent\Rector\ClassMethod\ReturnThisRemoveRector\Source\ParentInVendor;
+use Rector\Tests\Defluent\Rector\ClassMethod\ReturnThisRemoveRector\Source\vendor\ParentInVendor;
 
 class SkipParentInVendor extends ParentInVendor
 {

--- a/rules-tests/Defluent/Rector/ClassMethod/ReturnThisRemoveRector/Source/vendor/ParentInVendor.php
+++ b/rules-tests/Defluent/Rector/ClassMethod/ReturnThisRemoveRector/Source/vendor/ParentInVendor.php
@@ -2,9 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rector\Tests\Defluent\Rector\ClassMethod\ReturnThisRemoveRector\Source;
-
-use Rector\Tests\Defluent\Rector\ClassMethod\ReturnThisRemoveRector\Fixture\SkipParentInVendor;
+namespace Rector\Tests\Defluent\Rector\ClassMethod\ReturnThisRemoveRector\Source\vendor;
 
 class ParentInVendor
 {

--- a/rules-tests/Privatization/Rector/Property/ChangeReadOnlyPropertyWithDefaultValueToConstantRector/Fixture/skip_referenced_in_method_call_with_another_class.php.inc
+++ b/rules-tests/Privatization/Rector/Property/ChangeReadOnlyPropertyWithDefaultValueToConstantRector/Fixture/skip_referenced_in_method_call_with_another_class.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rector\Tests\Privatization\Rector\Property\ChangeReadOnlyPropertyWithDefaultValueToConstantRector\Fixture;
+
+use Rector\Tests\Privatization\Rector\Property\ChangeReadOnlyPropertyWithDefaultValueToConstantRector\Source\ReferencedInMethodCall;
+
+class SkipReferencedInMethodCallWithAnotherClass
+{
+    private $value = [];
+
+    public function run()
+    {
+        $referencedInMethodCall = new ReferencedInMethodCall();
+        $referencedInMethodCall->process($this->value);
+    }
+}

--- a/rules-tests/Privatization/Rector/Property/ChangeReadOnlyPropertyWithDefaultValueToConstantRector/Fixture/skip_referenced_in_static_call_with_another_class.php.inc
+++ b/rules-tests/Privatization/Rector/Property/ChangeReadOnlyPropertyWithDefaultValueToConstantRector/Fixture/skip_referenced_in_static_call_with_another_class.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rector\Privatization\Tests\Rector\Property\ChangeReadOnlyPropertyWithDefaultValueToConstantRector\Fixture;
+
+use Rector\Tests\Privatization\Rector\Property\ChangeReadOnlyPropertyWithDefaultValueToConstantRector\Source\ReferencedInStaticCall;
+
+final class SkipReferencedInStaticCallWithAnotherClass
+{
+    private $value = [];
+
+    public function run()
+    {
+        ReferencedInStaticCall::process($this->value);
+    }
+}

--- a/rules-tests/Privatization/Rector/Property/ChangeReadOnlyPropertyWithDefaultValueToConstantRector/Source/ReferencedInMethodCall.php
+++ b/rules-tests/Privatization/Rector/Property/ChangeReadOnlyPropertyWithDefaultValueToConstantRector/Source/ReferencedInMethodCall.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Privatization\Rector\Property\ChangeReadOnlyPropertyWithDefaultValueToConstantRector\Source;
+
+class ReferencedInMethodCall
+{
+    public function process(array &$value)
+    {
+    }
+}

--- a/rules-tests/Privatization/Rector/Property/ChangeReadOnlyPropertyWithDefaultValueToConstantRector/Source/ReferencedInStaticCall.php
+++ b/rules-tests/Privatization/Rector/Property/ChangeReadOnlyPropertyWithDefaultValueToConstantRector/Source/ReferencedInStaticCall.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Privatization\Rector\Property\ChangeReadOnlyPropertyWithDefaultValueToConstantRector\Source;
+
+class ReferencedInStaticCall
+{
+    public static function process(array &$value)
+    {
+    }
+}

--- a/rules/Defluent/ConflictGuard/ParentClassMethodTypeOverrideGuard.php
+++ b/rules/Defluent/ConflictGuard/ParentClassMethodTypeOverrideGuard.php
@@ -57,7 +57,7 @@ final class ParentClassMethodTypeOverrideGuard
         }
 
         $classReflection = $parentClassMethodReflection->getDeclaringClass();
-        return ! Strings::contains($classReflection->getFileName(), 'vendor');
+        return ! Strings::contains((string) $classReflection->getFileName(), 'vendor');
     }
 
     private function getParentClassMethod(ClassMethod $classMethod): ?MethodReflection

--- a/rules/Defluent/ConflictGuard/ParentClassMethodTypeOverrideGuard.php
+++ b/rules/Defluent/ConflictGuard/ParentClassMethodTypeOverrideGuard.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Defluent\ConflictGuard;
 
+use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
@@ -45,7 +46,17 @@ final class ParentClassMethodTypeOverrideGuard
         );
 
         // if null, we're unable to override → skip it
-        return $parentClassMethod !== null;
+        if (! $parentClassMethod instanceof ClassMethod) {
+            return false;
+        }
+
+        $class = $parentClassMethod->getAttribute(AttributeKey::CLASS_NODE);
+        if (! $class instanceof Class_) {
+            return false;
+        }
+
+        $classReflection = $parentClassMethodReflection->getDeclaringClass();
+        return strpos($classReflection->getFileName(), 'vendor') === false;
     }
 
     private function getParentClassMethod(ClassMethod $classMethod): ?MethodReflection

--- a/rules/Defluent/ConflictGuard/ParentClassMethodTypeOverrideGuard.php
+++ b/rules/Defluent/ConflictGuard/ParentClassMethodTypeOverrideGuard.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Rector\Defluent\ConflictGuard;
 
-use Nette\Utils\Strings;
-use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
@@ -47,17 +45,7 @@ final class ParentClassMethodTypeOverrideGuard
         );
 
         // if null, we're unable to override → skip it
-        if (! $parentClassMethod instanceof ClassMethod) {
-            return false;
-        }
-
-        $class = $parentClassMethod->getAttribute(AttributeKey::CLASS_NODE);
-        if (! $class instanceof Class_) {
-            return false;
-        }
-
-        $classReflection = $parentClassMethodReflection->getDeclaringClass();
-        return ! Strings::contains((string) $classReflection->getFileName(), 'vendor');
+        return $parentClassMethod !== null;
     }
 
     private function getParentClassMethod(ClassMethod $classMethod): ?MethodReflection

--- a/rules/Defluent/ConflictGuard/ParentClassMethodTypeOverrideGuard.php
+++ b/rules/Defluent/ConflictGuard/ParentClassMethodTypeOverrideGuard.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Defluent\ConflictGuard;
 
+use Nette\Utils\Strings;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
@@ -56,7 +57,7 @@ final class ParentClassMethodTypeOverrideGuard
         }
 
         $classReflection = $parentClassMethodReflection->getDeclaringClass();
-        return strpos($classReflection->getFileName(), 'vendor') === false;
+        return ! Strings::contains($classReflection->getFileName(), 'vendor');
     }
 
     private function getParentClassMethod(ClassMethod $classMethod): ?MethodReflection

--- a/src/NodeManipulator/PropertyManipulator.php
+++ b/src/NodeManipulator/PropertyManipulator.php
@@ -18,14 +18,12 @@ use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Property;
-use PHPStan\Reflection\ReflectionProvider;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Core\PhpParser\Node\BetterNodeFinder;
 use Rector\Core\PhpParser\NodeFinder\PropertyFetchFinder;
 use Rector\Core\Reflection\FunctionLikeReflectionParser;
 use Rector\NodeCollector\NodeCollector\NodeRepository;
 use Rector\NodeTypeResolver\Node\AttributeKey;
-use Rector\NodeTypeResolver\NodeTypeResolver;
 use Rector\ReadWrite\Guard\VariableToConstantGuard;
 use Rector\ReadWrite\NodeAnalyzer\ReadWritePropertyAnalyzer;
 use Symplify\PackageBuilder\Php\TypeChecker;
@@ -76,16 +74,6 @@ final class PropertyManipulator
     private $nodeRepository;
 
     /**
-     * @var NodeTypeResolver
-     */
-    private $nodeTypeResolver;
-
-    /**
-     * @var ReflectionProvider
-     */
-    private $reflectionProvider;
-
-    /**
      * @var FunctionLikeReflectionParser
      */
     private $functionLikeReflectionParser;
@@ -99,8 +87,6 @@ final class PropertyManipulator
         TypeChecker $typeChecker,
         PropertyFetchFinder $propertyFetchFinder,
         NodeRepository $nodeRepository,
-        NodeTypeResolver $nodeTypeResolver,
-        ReflectionProvider $reflectionProvider,
         FunctionLikeReflectionParser $functionLikeReflectionParser
     ) {
         $this->betterNodeFinder = $betterNodeFinder;
@@ -111,8 +97,6 @@ final class PropertyManipulator
         $this->typeChecker = $typeChecker;
         $this->propertyFetchFinder = $propertyFetchFinder;
         $this->nodeRepository = $nodeRepository;
-        $this->nodeTypeResolver = $nodeTypeResolver;
-        $this->reflectionProvider = $reflectionProvider;
         $this->functionLikeReflectionParser = $functionLikeReflectionParser;
     }
 

--- a/src/NodeManipulator/PropertyManipulator.php
+++ b/src/NodeManipulator/PropertyManipulator.php
@@ -206,6 +206,10 @@ final class PropertyManipulator
             $classMethod = $this->functionLikeReflectionParser->parseCaller($node);
         }
 
+        if (! $classMethod instanceof ClassMethod) {
+            return false;
+        }
+
         $params = $classMethod->getParams();
         foreach ($params as $param) {
             if ($param->byRef) {

--- a/src/Reflection/FunctionLikeReflectionParser.php
+++ b/src/Reflection/FunctionLikeReflectionParser.php
@@ -4,13 +4,23 @@ declare(strict_types=1);
 
 namespace Rector\Core\Reflection;
 
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\NodeFinder;
 use PhpParser\Parser;
+use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\ThisType;
 use Rector\Core\ValueObject\Application\File;
+use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\NodeScopeAndMetadataDecorator;
+use Rector\NodeTypeResolver\NodeTypeResolver;
 use Symplify\SmartFileSystem\SmartFileInfo;
 use Symplify\SmartFileSystem\SmartFileSystem;
 
@@ -36,16 +46,37 @@ final class FunctionLikeReflectionParser
      */
     private $nodeScopeAndMetadataDecorator;
 
+    /**
+     * @var NodeTypeResolver
+     */
+    private $nodeTypeResolver;
+
+    /**
+     * @var NodeNameResolver
+     */
+    private $nodeNameResolver;
+
+    /**
+     * @var ReflectionProvider
+     */
+    private $reflectionProvider;
+
     public function __construct(
         Parser $parser,
         SmartFileSystem $smartFileSystem,
         NodeFinder $nodeFinder,
-        NodeScopeAndMetadataDecorator $nodeScopeAndMetadataDecorator
+        NodeScopeAndMetadataDecorator $nodeScopeAndMetadataDecorator,
+        NodeTypeResolver $nodeTypeResolver,
+        NodeNameResolver $nodeNameResolver,
+        ReflectionProvider $reflectionProvider
     ) {
         $this->parser = $parser;
         $this->smartFileSystem = $smartFileSystem;
         $this->nodeFinder = $nodeFinder;
         $this->nodeScopeAndMetadataDecorator = $nodeScopeAndMetadataDecorator;
+        $this->nodeTypeResolver = $nodeTypeResolver;
+        $this->nodeNameResolver = $nodeNameResolver;
+        $this->reflectionProvider = $reflectionProvider;
     }
 
     public function parseMethodReflection(MethodReflection $methodReflection): ?ClassMethod
@@ -75,5 +106,91 @@ final class FunctionLikeReflectionParser
         }
 
         return $class->getMethod($methodReflection->getName());
+    }
+
+    /**
+     * @param MethodCall|StaticCall $node
+     */
+    public function parseCaller(Node $node): ?ClassMethod
+    {
+        if (! $node instanceof MethodCall && ! $node instanceof StaticCall) {
+            return null;
+        }
+
+        $objectType = $node instanceof MethodCall
+            ? $this->nodeTypeResolver->resolve($node->var)
+            : $this->nodeTypeResolver->resolve($node->class);
+
+        if ($objectType instanceof ThisType) {
+            $objectType = $objectType->getStaticType();
+        }
+
+        $className = $objectType->getClassName();
+        if (! $this->reflectionProvider->hasClass($className)) {
+            return null;
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($className);
+        $methodName = (string) $node->name;
+        if (! $classReflection->hasMethod($methodName)) {
+            return null;
+        }
+
+        if ($classReflection->isBuiltIn()) {
+            return null;
+        }
+
+        $fileName = $classReflection->getFileName();
+        if (! $fileName) {
+            return null;
+        }
+
+        $fileContent = $this->smartFileSystem->readfile($fileName);
+        $nodes = $this->parser->parse($fileContent);
+        return $this->getClassMethodFromNodes((array) $nodes, $classReflection, $className, $methodName);
+    }
+
+    /**
+     * @param Stmt[] $nodes
+     */
+    private function getClassMethodFromNodes(
+        array $nodes,
+        ClassReflection $classReflection,
+        string $className,
+        string $methodName
+    ): ?ClassMethod {
+        $reflectionClass = $classReflection->getNativeReflection();
+        $shortName = $reflectionClass->getShortName();
+
+        foreach ($nodes as $node) {
+            if ($node instanceof Namespace_) {
+                /** @var Stmt[] $nodeStmts */
+                $nodeStmts = $node->stmts;
+                $classMethod = $this->getClassMethodFromNodes($nodeStmts, $classReflection, $className, $methodName);
+
+                if ($classMethod instanceof ClassMethod) {
+                    return $classMethod;
+                }
+            }
+
+            $classMethod = $this->getClassMethod($node, $shortName, $methodName);
+            if ($classMethod instanceof ClassMethod) {
+                return $classMethod;
+            }
+        }
+
+        return null;
+    }
+
+    private function getClassMethod(Stmt $stmt, string $shortClassName, string $methodName): ?ClassMethod
+    {
+        if ($stmt instanceof Class_) {
+            $name = (string) $this->nodeNameResolver->getName($stmt);
+            if ($name === $shortClassName) {
+                return $stmt->getMethod($methodName);
+            }
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
Closes #6214 by update `NodeRepository` to parse outside file if not found in the list of registered class method.