### PR TITLE
AnnotationToAttributeRector: array handling

### DIFF
--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/assert_choice.php.inc
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/Fixture/assert_choice.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class EntityColumnAndAssertChoice
+{
+    /**
+     * @Assert\Choice({"php5", "php7", "php8"})
+     */
+    public $phpVersion;
+
+    /**
+     * @Assert\Choice(choices={"5.0", "5.1", "5.2"})
+     */
+    public $sfVersion;
+
+    /**
+     * @Assert\Choice(choices={2, 3, 5, 7, 11, 13, 17, 19})
+     */
+    public $primeNumbers;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\Php80\Rector\Class_\AnnotationToAttributeRector\Fixture;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class EntityColumnAndAssertChoice
+{
+    #[\Symfony\Component\Validator\Constraints\Choice(['php5', 'php7', 'php8'])]
+    public $phpVersion;
+
+    #[\Symfony\Component\Validator\Constraints\Choice(choices: ['5.0', '5.1', '5.2'])]
+    public $sfVersion;
+
+    #[\Symfony\Component\Validator\Constraints\Choice(choices: [2, 3, 5, 7, 11, 13, 17, 19])]
+    public $primeNumbers;
+}
+
+?>

--- a/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/configured_rule.php
+++ b/rules-tests/Php80/Rector/Class_/AnnotationToAttributeRector/config/configured_rule.php
@@ -37,6 +37,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                     'Symfony\Component\Validator\Constraints\NotBlank',
                     'Symfony\Component\Validator\Constraints\NotBlank'
                 ),
+                new AnnotationToAttribute(
+                    'Symfony\Component\Validator\Constraints\Choice',
+                    'Symfony\Component\Validator\Constraints\Choice'
+                ),
             ]),
         ]]);
 };


### PR DESCRIPTION
There are some issues when handling arrays:

```php
    /**
     * @Assert\Choice(choices={"foo", "bar"})
     */
    public $surname;
```
is converted into
```php
    #[\Symfony\Component\Validator\Constraints\Choice(choices: '{"foo", "bar"}')]
    public $surname;
```

This PR solves it