### PR TITLE
Revert "[Scoper] Skip Prefix\Composer\ usage"

### DIFF
--- a/scoper.php
+++ b/scoper.php
@@ -57,14 +57,39 @@ return [
         },
 
         function (string $filePath, string $prefix, string $content): string {
-            if (! Strings::contains($content, $prefix . '\Composer\\')) {
+            if (! Strings::endsWith($filePath, 'vendor/composer/package-versions-deprecated/src/PackageVersions/Versions.php')) {
+                return $content;
+            }
+
+            // see https://regex101.com/r/v8zRMm/1
+            return Strings::replace(
+                $content, '
+                #' . $prefix . '\\\\Composer\\\\InstalledVersions#',
+                'Composer\InstalledVersions'
+            );
+        },
+
+        function (string $filePath, string $prefix, string $content): string {
+            if (! Strings::contains($content, $prefix . '\Composer\Plugin')) {
                 return $content;
             }
 
             return Strings::replace(
                 $content, '
-                #' . $prefix . '\\\\Composer\\\\#',
-                'Composer\\'
+                #' . $prefix . '\\\\Composer\\\\Plugin#',
+                'Composer\Plugin'
+            );
+        },
+
+        function (string $filePath, string $prefix, string $content): string {
+            if (! Strings::contains($content, $prefix . '\Composer\EventDispatcher')) {
+                return $content;
+            }
+
+            return Strings::replace(
+                $content, '
+                #' . $prefix . '\\\\Composer\\\\EventDispatcher#',
+                'Composer\EventDispatcher'
             );
         },
 


### PR DESCRIPTION
Reverts rectorphp/rector#6293 change all `$prefix\Composer\` to `Composer` cause error on php 7.1 scoped. Reverting it.