### PR TITLE
[Scoper] Patch ParameterSkipper class via scoper-php70 config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
         "php": "^7.3|^8.0",
         "ext-dom": "*",
         "ext-json": "*",
-        "composer/composer": "^2.0",
         "composer/semver": "^3.2",
         "composer/xdebug-handler": "^1.4|^2.0",
         "danielstjules/stringy": "^3.1",

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "php": "^7.3|^8.0",
         "ext-dom": "*",
         "ext-json": "*",
+        "composer/composer": "^2.0",
         "composer/semver": "^3.2",
         "composer/xdebug-handler": "^1.4|^2.0",
         "danielstjules/stringy": "^3.1",

--- a/scoper-php70.php
+++ b/scoper-php70.php
@@ -147,6 +147,18 @@ return [
             return Strings::replace($content, $namespace);
         },
 
+        function (string $filePath, string $prefix, string $content): string {
+            if (! Strings::endsWith($filePath, 'vendor/symplify/autowire-array-parameter/src/Skipper/ParameterSkipper.php')) {
+                return $content;
+            }
+
+            // @see https://regex101.com/r/wcAbLf/1
+            return Strings::replace(
+                $content, '#((private|public|protected)\s+const)#',
+                "const"
+            );
+        },
+
         // unprefix string classes, as they're string on purpose - they have to be checked in original form, not prefixed
         function (string $filePath, string $prefix, string $content): string {
             // skip vendor, expect rector packages

--- a/utils/compiler/src/Command/DowngradePathsCommand.php
+++ b/utils/compiler/src/Command/DowngradePathsCommand.php
@@ -59,7 +59,7 @@ final class DowngradePathsCommand extends Command
 
         $downgradePaths = array_merge([
             // must be separated to cover container get() trait + psr container contract get()
-            'vendor/symfony vendor/psr vendor/symplify/autowire-array-parameter',
+            'vendor/symfony vendor/psr',
             'vendor/symplify vendor/nikic bin src packages rector.php',
         ], $downgradePaths);
 


### PR DESCRIPTION
I installed php 7.0 in my local dev and it seems working ok:

```bash
/opt/homebrew/bin/php php-parallel-lint/parallel-lint rector-prefixed-downgraded-php70 --exclude rector-prefixed-downgraded-php70/stubs --exclude rector-prefixed-downgraded-php70/vendor/symfony/error-handler/Resources --exclude rector-prefixed-downgraded-php70/vendor/symfony/http-kernel/Resources --exclude rector-prefixed-downgraded-php70/vendor/rector/rector-nette/tests --exclude rector-prefixed-downgraded-php70/vendor/symfony/polyfill-mbstring/bootstrap80.php --exclude rector-prefixed-downgraded-php70/vendor/tracy/tracy/examples --exclude rector-prefixed-downgraded-php70/vendor/rector/rector-installer/tests --exclude rector-prefixed-downgraded-php70/vendor/symplify/smart-file-system/tests --exclude rector-prefixed-downgraded-php70/vendor/symfony/http-foundation/Session --exclude rector-prefixed-downgraded-php70/vendor/symfony/var-dumper --exclude rector-prefixed-downgraded-php70/vendor/nette/caching --exclude rector-prefixed-downgraded-php70/vendor/rector/rector-nette/src/Rector/LNumber --exclude rector-prefixed-downgraded-php70/vendor/symfony/http-foundation/Test --exclude rector-prefixed-downgraded-php70/vendor/symplify/simple-php-doc-parser/tests --exclude rector-prefixed-downgraded-php70/vendor/tracy/tracy/src/Tracy/Bar/panels/info.panel.phtml --exclude rector-prefixed-downgraded-php70/vendor/symfony/string/Slugger/AsciiSlugger.php
PHP 7.0.33 | 10 parallel jobs
............................................................   60/3537 (1 %)
............................................................  120/3537 (3 %)
............................................................  180/3537 (5 %)
............................................................  240/3537 (6 %)
............................................................  300/3537 (8 %)
............................................................  360/3537 (10 %)
............................................................  420/3537 (11 %)
............................................................  480/3537 (13 %)
............................................................  540/3537 (15 %)
............................................................  600/3537 (16 %)
............................................................  660/3537 (18 %)
............................................................  720/3537 (20 %)
............................................................  780/3537 (22 %)
............................................................  840/3537 (23 %)
............................................................  900/3537 (25 %)
............................................................  960/3537 (27 %)
............................................................ 1020/3537 (28 %)
............................................................ 1080/3537 (30 %)
............................................................ 1140/3537 (32 %)
............................................................ 1200/3537 (33 %)
............................................................ 1260/3537 (35 %)
............................................................ 1320/3537 (37 %)
............................................................ 1380/3537 (39 %)
............................................................ 1440/3537 (40 %)
............................................................ 1500/3537 (42 %)
............................................................ 1560/3537 (44 %)
............................................................ 1620/3537 (45 %)
............................................................ 1680/3537 (47 %)
............................................................ 1740/3537 (49 %)
............................................................ 1800/3537 (50 %)
............................................................ 1860/3537 (52 %)
............................................................ 1920/3537 (54 %)
............................................................ 1980/3537 (55 %)
............................................................ 2040/3537 (57 %)
............................................................ 2100/3537 (59 %)
............................................................ 2160/3537 (61 %)
............................................................ 2220/3537 (62 %)
............................................................ 2280/3537 (64 %)
............................................................ 2340/3537 (66 %)
............................................................ 2400/3537 (67 %)
............................................................ 2460/3537 (69 %)
............................................................ 2520/3537 (71 %)
............................................................ 2580/3537 (72 %)
............................................................ 2640/3537 (74 %)
............................................................ 2700/3537 (76 %)
............................................................ 2760/3537 (78 %)
............................................................ 2820/3537 (79 %)
............................................................ 2880/3537 (81 %)
............................................................ 2940/3537 (83 %)
............................................................ 3000/3537 (84 %)
............................................................ 3060/3537 (86 %)
............................................................ 3120/3537 (88 %)
............................................................ 3180/3537 (89 %)
............................................................ 3240/3537 (91 %)
............................................................ 3300/3537 (93 %)
............................................................ 3360/3537 (94 %)
............................................................ 3420/3537 (96 %)
............................................................ 3480/3537 (98 %)
.........................................................    3537/3537 (100 %)


Checked 3537 files in 10.9 seconds
No syntax error found
```