### PR TITLE
[DowngradePhp71] Allow downgrade negative offset string on variable/PropertyFetch/StaticPropertyFetch

### DIFF
--- a/rules-tests/DowngradePhp71/Rector/String_/DowngradeNegativeStringOffsetToStrlenRector/Fixture/property_fetch.php.inc
+++ b/rules-tests/DowngradePhp71/Rector/String_/DowngradeNegativeStringOffsetToStrlenRector/Fixture/property_fetch.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp71\Rector\String_\DowngradeNegativeStringOffsetToStrlenRector\Fixture;
+
+class PropertyFetch
+{
+    private $var;
+
+    public function run()
+    {
+        $this->var = 'abc';
+        echo $this->var[-2];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp71\Rector\String_\DowngradeNegativeStringOffsetToStrlenRector\Fixture;
+
+class PropertyFetch
+{
+    private $var;
+
+    public function run()
+    {
+        $this->var = 'abc';
+        echo $this->var[strlen($this->var) - 2];
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp71/Rector/String_/DowngradeNegativeStringOffsetToStrlenRector/Fixture/static_property_fetch.php.inc
+++ b/rules-tests/DowngradePhp71/Rector/String_/DowngradeNegativeStringOffsetToStrlenRector/Fixture/static_property_fetch.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp71\Rector\String_\DowngradeNegativeStringOffsetToStrlenRector\Fixture;
+
+class StaticPropertyFetch
+{
+    private static $var;
+
+    public function run()
+    {
+        self::$var = 'abc';
+        echo self::$var[-2];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp71\Rector\String_\DowngradeNegativeStringOffsetToStrlenRector\Fixture;
+
+class StaticPropertyFetch
+{
+    private static $var;
+
+    public function run()
+    {
+        self::$var = 'abc';
+        echo self::$var[strlen(self::$var) - 2];
+    }
+}
+
+?>

--- a/rules-tests/DowngradePhp71/Rector/String_/DowngradeNegativeStringOffsetToStrlenRector/Fixture/variable.php.inc
+++ b/rules-tests/DowngradePhp71/Rector/String_/DowngradeNegativeStringOffsetToStrlenRector/Fixture/variable.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp71\Rector\String_\DowngradeNegativeStringOffsetToStrlenRector\Fixture;
+
+class Variable
+{
+    public function run(string $var)
+    {
+        echo $var[-2];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp71\Rector\String_\DowngradeNegativeStringOffsetToStrlenRector\Fixture;
+
+class Variable
+{
+    public function run(string $var)
+    {
+        echo $var[strlen($var) - 2];
+    }
+}
+
+?>

--- a/rules/DowngradePhp71/Rector/String_/DowngradeNegativeStringOffsetToStrlenRector.php
+++ b/rules/DowngradePhp71/Rector/String_/DowngradeNegativeStringOffsetToStrlenRector.php
@@ -55,7 +55,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param FuncCall|String|Variable|PropertyFetch|StaticPropertyFetch $node
+     * @param FuncCall|String_|Variable|PropertyFetch|StaticPropertyFetch $node
      */
     public function refactor(Node $node): ?Node
     {

--- a/rules/DowngradePhp71/Rector/String_/DowngradeNegativeStringOffsetToStrlenRector.php
+++ b/rules/DowngradePhp71/Rector/String_/DowngradeNegativeStringOffsetToStrlenRector.php
@@ -9,6 +9,8 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\BinaryOp\Minus;
 use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Expr\UnaryMinus;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Scalar\String_;
@@ -49,7 +51,7 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [String_::class, FuncCall::class, Variable::class];
+        return [String_::class, FuncCall::class, Variable::class, PropertyFetch::class, StaticPropertyFetch::class];
     }
 
     /**

--- a/rules/DowngradePhp71/Rector/String_/DowngradeNegativeStringOffsetToStrlenRector.php
+++ b/rules/DowngradePhp71/Rector/String_/DowngradeNegativeStringOffsetToStrlenRector.php
@@ -51,11 +51,11 @@ CODE_SAMPLE
      */
     public function getNodeTypes(): array
     {
-        return [String_::class, FuncCall::class, Variable::class, PropertyFetch::class, StaticPropertyFetch::class];
+        return [FuncCall::class, String_::class, Variable::class, PropertyFetch::class, StaticPropertyFetch::class];
     }
 
     /**
-     * @param String|FuncCall|Variable|PropertyFetch|StaticPropertyFetch $node
+     * @param FuncCall|String|Variable|PropertyFetch|StaticPropertyFetch $node
      */
     public function refactor(Node $node): ?Node
     {

--- a/rules/DowngradePhp71/Rector/String_/DowngradeNegativeStringOffsetToStrlenRector.php
+++ b/rules/DowngradePhp71/Rector/String_/DowngradeNegativeStringOffsetToStrlenRector.php
@@ -63,13 +63,13 @@ CODE_SAMPLE
             return $this->processForFuncCall($node);
         }
 
-        return $this->processForStringOrVariable($node);
+        return $this->processForStringOrVariableOrProperty($node);
     }
 
     /**
-     * @param String_|Variable $expr
+     * @param String_|Variable|PropertyFetch|StaticPropertyFetch $expr
      */
-    private function processForStringOrVariable(Expr $expr): ?Expr
+    private function processForStringOrVariableOrProperty(Expr $expr): ?Expr
     {
         $nextNode = $expr->getAttribute(AttributeKey::NEXT_NODE);
         if (! $nextNode instanceof UnaryMinus) {

--- a/rules/DowngradePhp71/Rector/String_/DowngradeNegativeStringOffsetToStrlenRector.php
+++ b/rules/DowngradePhp71/Rector/String_/DowngradeNegativeStringOffsetToStrlenRector.php
@@ -55,7 +55,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param String_|FuncCall|Variable $node
+     * @param String|FuncCall|Variable|PropertyFetch|StaticPropertyFetch $node
      */
     public function refactor(Node $node): ?Node
     {


### PR DESCRIPTION
ref https://github.com/rectorphp/rector/pull/6310#issuecomment-831321508 . It is no need `string` type check on variable as if variable is not string, it will got syntax error https://3v4l.org/TM68C