### PR TITLE
[Scoper] Patch : void in vendor via scoper-php70 config

### DIFF
--- a/scoper-php70.php
+++ b/scoper-php70.php
@@ -159,6 +159,18 @@ return [
             );
         },
 
+        function (string $filePath, string $prefix, string $content): string {
+            if (! Strings::contains($filePath, 'vendor/')) {
+                return $content;
+            }
+
+            // @see https://regex101.com/r/r3AJFl/1
+            return Strings::replace(
+                $content, '#\)\s{0,}:\s{0,}void#',
+                ")"
+            );
+        },
+
         // unprefix string classes, as they're string on purpose - they have to be checked in original form, not prefixed
         function (string $filePath, string $prefix, string $content): string {
             // skip vendor, expect rector packages


### PR DESCRIPTION
ref https://github.com/rectorphp/rector-prefixed-php70/runs/2493424282#step:4:6 . Some vendor dependencies seems overlapped make `: void` not updated. use scoper config to patch 