### PR TITLE
[php-parser] upgrade to 4.10.5 - add src/constants.php to mimic new PHP 8.1 tokens; update test with unicode

### DIFF
--- a/bin/rector.php
+++ b/bin/rector.php
@@ -9,7 +9,6 @@ use Rector\Core\DependencyInjection\RectorContainerFactory;
 use Rector\Core\HttpKernel\RectorKernel;
 use Symplify\PackageBuilder\Console\ShellCode;
 use Symplify\PackageBuilder\Reflection\PrivatesCaller;
-use Tracy\Debugger;
 
 // @ intentionally: continue anyway
 @ini_set('memory_limit', '-1');
@@ -21,12 +20,14 @@ gc_disable();
 
 define('__RECTOR_RUNNING__', true);
 
+
 // Require Composer autoload.php
 $autoloadIncluder = new AutoloadIncluder();
 $autoloadIncluder->includeDependencyOrRepositoryVendorAutoloadIfExists();
 
-// load local php-parser only in prefixed version
-if (file_exists(__DIR__ . '/../vendor/scoper-autoload.php')) {
+// load local php-parser only in prefixed version or development repository
+$isDevelopmentRepository = file_exists(__DIR__ . '/../.git');
+if (file_exists(__DIR__ . '/../vendor/scoper-autoload.php') || $isDevelopmentRepository) {
     require_once __DIR__ . '/../preload.php';
 }
 

--- a/bin/rector.php
+++ b/bin/rector.php
@@ -25,9 +25,7 @@ define('__RECTOR_RUNNING__', true);
 $autoloadIncluder = new AutoloadIncluder();
 $autoloadIncluder->includeDependencyOrRepositoryVendorAutoloadIfExists();
 
-// load local php-parser only in prefixed version or development repository
-$isDevelopmentRepository = file_exists(__DIR__ . '/../.git');
-if (file_exists(__DIR__ . '/../vendor/scoper-autoload.php') || $isDevelopmentRepository) {
+if (should_include_preload()) {
     require_once __DIR__ . '/../preload.php';
 }
 
@@ -123,4 +121,20 @@ final class AutoloadIncluder
 
         require_once $filePath;
     }
+}
+
+
+// load local php-parser only in prefixed version or development repository
+function should_include_preload(): bool
+{
+    if (file_exists(__DIR__ . '/../vendor/scoper-autoload.php')) {
+        return true;
+    }
+
+    if (! file_exists(__DIR__ . '/../composer.json')) {
+        return false;
+    }
+
+    $composerJsonFileContent = file_get_contents(__DIR__ . '/../composer.json');
+    return strpos($composerJsonFileContent, '"name": "rector/rector"') !== false;
 }

--- a/bin/rector.php
+++ b/bin/rector.php
@@ -25,10 +25,12 @@ define('__RECTOR_RUNNING__', true);
 $autoloadIncluder = new AutoloadIncluder();
 $autoloadIncluder->includeDependencyOrRepositoryVendorAutoloadIfExists();
 
+// load local php-parser only in prefixed version
 if (file_exists(__DIR__ . '/../vendor/scoper-autoload.php')) {
-    // make local php-parser a priority to avoid conflict
     require_once __DIR__ . '/../preload.php';
 }
+
+require_once __DIR__ . '/../src/constants.php';
 
 $autoloadIncluder->loadIfExistsAndNotLoadedYet(__DIR__ . '/../vendor/scoper-autoload.php');
 
@@ -39,11 +41,6 @@ $symfonyStyleFactory = new SymfonyStyleFactory(new PrivatesCaller());
 $symfonyStyle = $symfonyStyleFactory->create();
 
 $rectorConfigsResolver = new RectorConfigsResolver();
-
-// for simpler debugging output
-if (class_exists(Debugger::class)) {
-    Debugger::$maxDepth = 2;
-}
 
 try {
     $bootstrapConfigs = $rectorConfigsResolver->provide();

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "nette/caching": "^3.1",
         "nette/robot-loader": "^3.4",
         "nette/utils": "^3.2",
-        "nikic/php-parser": "4.10.4",
+        "nikic/php-parser": "^4.10.5",
         "phpstan/phpdoc-parser": "^0.5.4",
         "phpstan/phpstan": "^0.12.83",
         "phpstan/phpstan-phpunit": "^0.12.18",

--- a/config/services.php
+++ b/config/services.php
@@ -68,6 +68,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             __DIR__ . '/../src/Bootstrap',
             __DIR__ . '/../src/PhpParser/Node/CustomNode',
             __DIR__ . '/../src/functions',
+            __DIR__ . '/../src/constants.php',
         ]);
 
     $services->alias(SymfonyApplication::class, ConsoleApplication::class);

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -473,3 +473,8 @@ parameters:
         -
             message: '#Use separate function calls with readable variable names#'
             path: src/Application/ActiveRectorsProvider.php
+
+        # skip for define()
+        -
+           message: '#Do not compare call directly, use a variable assign#'
+           path:  src/constants.php

--- a/rules-tests/Php55/Rector/FuncCall/PregReplaceEModifierRector/Fixture/preg_quoted.php.inc
+++ b/rules-tests/Php55/Rector/FuncCall/PregReplaceEModifierRector/Fixture/preg_quoted.php.inc
@@ -21,7 +21,7 @@ class PregQuoted
     public function run($subject)
     {
         preg_replace_callback('/('.preg_quote("a", '/').')/', function ($matches) {
-            return strtoupper("\1");
+            return strtoupper("\x01");
         }, $subject);
     }
 }

--- a/rules-tests/Php72/Rector/FuncCall/CreateFunctionToAnonymousFunctionRector/Fixture/drupal.php.inc
+++ b/rules-tests/Php72/Rector/FuncCall/CreateFunctionToAnonymousFunctionRector/Fixture/drupal.php.inc
@@ -30,7 +30,7 @@ class Drupal
     public function run()
     {
         $replace = function ($m) {
-            $r = "\0{$m[1]}ecursion_features";
+            $r = "\x00{$m[1]}ecursion_features";
             return 's:' . strlen($r . $m[2]) . ':"' . $r . $m[2] . '";';
         };
 

--- a/src/constants.php
+++ b/src/constants.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-
 // mimic missing T_ENUM constant on PHP 8.0-
 if (defined('T_ENUM') === false) {
     define('T_ENUM', 5000);

--- a/src/constants.php
+++ b/src/constants.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+
+// mimic missing T_ENUM constant on PHP 8.0-
+if (defined('T_ENUM') === false) {
+    define('T_ENUM', 5000);
+}
+
+// mimic missing T_NAME_RELATIVE constant on PHP 8.0-
+if (defined('T_NAME_RELATIVE') === false) {
+    define('T_NAME_RELATIVE', 5001);
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 use Rector\Core\Stubs\PHPStanStubLoader;
 
+require_once __DIR__ . '/../src/constants.php';
+
+// make local php-parser a priority to avoid conflict
+require_once __DIR__ . '/../preload.php';
 require_once __DIR__ . '/../vendor/autoload.php';
 
 // silent deprecations, since we test them
@@ -11,9 +15,6 @@ error_reporting(E_ALL ^ E_DEPRECATED);
 
 // performance boost
 gc_disable();
-
-// make local php-parser a priority to avoid conflict
-require_once __DIR__ . '/../preload.php';
 
 $phpStanStubLoader = new PHPStanStubLoader();
 $phpStanStubLoader->loadStubs();


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector/issues/6326