### PR TITLE
[Scoped] Keep \Composer\InstalledVersions not prefixed for composer/InstalledVersions.php

### DIFF
--- a/scoper-php70.php
+++ b/scoper-php70.php
@@ -53,7 +53,11 @@ return [
         },
 
         function (string $filePath, string $prefix, string $content): string {
-            if (! Strings::endsWith($filePath, 'vendor/composer/package-versions-deprecated/src/PackageVersions/Versions.php')) {
+            if (
+                ! Strings::endsWith($filePath, 'vendor/composer/package-versions-deprecated/src/PackageVersions/Versions.php')
+                &&
+                ! Strings::endsWith($filePath, 'vendor/composer/InstalledVersions.php')
+            ) {
                 return $content;
             }
 


### PR DESCRIPTION
Based on https://github.com/rectorphp/rector/issues/6079#issuecomment-832429702