### PR TITLE
[Scoped] Remove composer.lock after remove ecs,cs,php-cs-fixer

### DIFF
--- a/.github/workflows/build_scoped_rector_php70.yaml
+++ b/.github/workflows/build_scoped_rector_php70.yaml
@@ -37,6 +37,7 @@ jobs:
                     composer remove symplify/easy-coding-standard --dev
                     composer remove symplify/coding-standard --dev --update-with-dependencies
                     composer remove friendsofphp/php-cs-fixer --dev --update-with-dependencies
+                    rm composer.lock
                     composer config repositories.phpstan/phpstan-src vcs https://github.com/phpstan/phpstan-src
                     composer require phpstan/phpstan-src:0.12.85
                     composer require composer/composer


### PR DESCRIPTION
Handle error : 

```bash
  Problem 1
483
    - Root composer.json requires phpstan/phpstan-src 0.12.85 -> satisfiable by phpstan/phpstan-src[0.12.85].
484
    - phpstan/phpstan-src 0.12.85 requires composer/xdebug-handler ^1.3.0 -> found composer/xdebug-handler[1.3.0, ..., 1.4.x-dev] but the package is fixed to 2.0.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
    - 
    - 
 ```