### PR TITLE
[TASK] Add fallback mechanism to load default extensions

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -12,7 +12,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->import(__DIR__ . '/services-packages.php');
     $containerConfigurator->import(__DIR__ . '/parameters.php');
 
-    $extensionConfigResolver = new ExtensionConfigResolver();
+    $extensionConfigResolver = new ExtensionConfigResolver(__DIR__);
     $extensionConfigFiles = $extensionConfigResolver->provide();
     foreach ($extensionConfigFiles as $extensionConfigFile) {
         $containerConfigurator->import($extensionConfigFile->getRealPath());


### PR DESCRIPTION
- If the rector-installer failed or is not executed due to --no-scripts flag at least the old default extensions are loaded

Resolves: #6347