### PR TITLE
[DowngradePhp70] Add anonymous class out of trait

### DIFF
--- a/rules-tests/DowngradePhp70/Rector/New_/DowngradeAnonymousClassRector/Fixture/class_in_trait.php.inc
+++ b/rules-tests/DowngradePhp70/Rector/New_/DowngradeAnonymousClassRector/Fixture/class_in_trait.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\New_\DowngradeAnonymousClassRector\Fixture;
+
+trait ClassInTrait
+{
+    public function run()
+    {
+        $message = 'error';
+        return new class($message) extends \InvalidArgumentException {};
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DowngradePhp70\Rector\New_\DowngradeAnonymousClassRector\Fixture;
+
+class AnonymousFor_NotInFunction extends \InvalidArgumentException
+{
+}
+trait ClassInTrait
+{
+    public function run()
+    {
+        $message = 'error';
+        return new AnonymousFor_NotInFunction($message);
+    }
+}
+
+?>

--- a/rules/DowngradePhp70/NodeFactory/ClassFromAnonymousFactory.php
+++ b/rules/DowngradePhp70/NodeFactory/ClassFromAnonymousFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\DowngradePhp70\NodeFactory;
+
+use PhpParser\Node\Stmt\Class_;
+
+final class ClassFromAnonymousFactory
+{
+    public function create(string $className, Class_ $newClass): Class_
+    {
+        return new Class_($className, [
+            'flags' => $newClass->flags,
+            'extends' => $newClass->extends,
+            'implements' => $newClass->implements,
+            'stmts' => $newClass->stmts,
+            'attrGroups' => $newClass->attrGroups,
+        ]);
+    }
+}


### PR DESCRIPTION
Fixes case when trait has an anonmous class in it: https://github.com/symplify/easy-coding-standard/blob/7f89cf493b8140b257bcf38d449c0a33e414e5bb/vendor/symfony/service-contracts/ServiceLocatorTrait.php#L105-L113

<br>

This is invalid PHP

![image](https://user-images.githubusercontent.com/924196/117505547-7f3a4080-af84-11eb-9d05-3758c9f37d07.png)
