### PR TITLE
[Downgrade 7.0] Fix DowngradeAnonymousClassRector bugs and simplify its naming

### DIFF
--- a/rules-tests/DowngradePhp70/Rector/New_/DowngradeAnonymousClassRector/Fixture/class_exist.php.inc
+++ b/rules-tests/DowngradePhp70/Rector/New_/DowngradeAnonymousClassRector/Fixture/class_exist.php.inc
@@ -26,18 +26,16 @@ namespace Rector\Tests\DowngradePhp70\Rector\New_\DowngradeAnonymousClassRector\
 class AnonymousFor_ClassExists
 {
 }
-class AnonymousFor_ClassExists1
+class ClassExists
+{
+    public function run()
+    {
+        return new Anonymous__%s__0();
+    }
+}
+class Anonymous__%s__0
 {
     public function execute()
     {
     }
 }
-class ClassExists
-{
-    public function run()
-    {
-        return new AnonymousFor_ClassExists1();
-    }
-}
-
-?>

--- a/rules-tests/DowngradePhp70/Rector/New_/DowngradeAnonymousClassRector/Fixture/class_in_trait.php.inc
+++ b/rules-tests/DowngradePhp70/Rector/New_/DowngradeAnonymousClassRector/Fixture/class_in_trait.php.inc
@@ -7,7 +7,10 @@ trait ClassInTrait
     public function run()
     {
         $message = 'error';
-        return new class($message) extends \InvalidArgumentException {};
+
+        $first = new class($message) extends \InvalidArgumentException {};
+
+        $second = new class() extends \Exception {};
     }
 }
 
@@ -17,16 +20,20 @@ trait ClassInTrait
 
 namespace Rector\Tests\DowngradePhp70\Rector\New_\DowngradeAnonymousClassRector\Fixture;
 
-class AnonymousFor_ClassInTrait extends \InvalidArgumentException
-{
-}
 trait ClassInTrait
 {
     public function run()
     {
         $message = 'error';
-        return new AnonymousFor_ClassInTrait($message);
+
+        $first = new Anonymous__%s__0($message);
+
+        $second = new Anonymous__%s__1();
     }
 }
-
-?>
+class Anonymous__%s__0 extends \InvalidArgumentException
+{
+}
+class Anonymous__%s__1 extends \Exception
+{
+}

--- a/rules-tests/DowngradePhp70/Rector/New_/DowngradeAnonymousClassRector/Fixture/fixture.php.inc
+++ b/rules-tests/DowngradePhp70/Rector/New_/DowngradeAnonymousClassRector/Fixture/fixture.php.inc
@@ -20,18 +20,16 @@ class Fixture
 
 namespace Rector\Tests\DowngradePhp70\Rector\New_\DowngradeAnonymousClassRector\Fixture;
 
-class AnonymousFor_Fixture
+class Fixture
+{
+    public function run()
+    {
+        return new Anonymous__%s__0();
+    }
+}
+class Anonymous__%s__0
 {
     public function execute()
     {
     }
 }
-class Fixture
-{
-    public function run()
-    {
-        return new AnonymousFor_Fixture();
-    }
-}
-
-?>

--- a/rules-tests/DowngradePhp70/Rector/New_/DowngradeAnonymousClassRector/Fixture/in_closure.php.inc
+++ b/rules-tests/DowngradePhp70/Rector/New_/DowngradeAnonymousClassRector/Fixture/in_closure.php.inc
@@ -17,13 +17,11 @@ function () {
 namespace Rector\Tests\DowngradePhp70\Rector\New_\DowngradeAnonymousClassRector\Fixture;
 
 function () {
-    class AnonymousFor_NotInFunction
-    {
-        public function execute()
-        {
-        }
-    }
-    return new AnonymousFor_NotInFunction();
+    return new Anonymous__%s__0();
 };
-
-?>
+class Anonymous__%s__0
+{
+    public function execute()
+    {
+    }
+}

--- a/rules-tests/DowngradePhp70/Rector/New_/DowngradeAnonymousClassRector/Fixture/in_closure_no_namespace.php.inc
+++ b/rules-tests/DowngradePhp70/Rector/New_/DowngradeAnonymousClassRector/Fixture/in_closure_no_namespace.php.inc
@@ -13,13 +13,11 @@ function () {
 <?php
 
 function () {
-    class AnonymousFor_NotInfunctionNoNamespace
-    {
-        public function execute()
-        {
-        }
-    }
-    return new AnonymousFor_NotInfunctionNoNamespace();
+    return new Anonymous__%s__0();
 };
-
-?>
+class Anonymous__%s__0
+{
+    public function execute()
+    {
+    }
+}

--- a/rules-tests/DowngradePhp70/Rector/New_/DowngradeAnonymousClassRector/Fixture/in_function.php.inc
+++ b/rules-tests/DowngradePhp70/Rector/New_/DowngradeAnonymousClassRector/Fixture/in_function.php.inc
@@ -17,15 +17,13 @@ function inFunction()
 
 namespace Rector\Tests\DowngradePhp70\Rector\New_\DowngradeAnonymousClassRector\Fixture;
 
-class AnonymousFor_inFunction
+function inFunction()
+{
+    return new Anonymous__%s__0();
+}
+class Anonymous__%s__0
 {
     public function execute()
     {
     }
 }
-function inFunction()
-{
-    return new AnonymousFor_inFunction();
-}
-
-?>

--- a/rules-tests/DowngradePhp70/Rector/New_/DowngradeAnonymousClassRector/Fixture/in_function_no_namespace.php.inc
+++ b/rules-tests/DowngradePhp70/Rector/New_/DowngradeAnonymousClassRector/Fixture/in_function_no_namespace.php.inc
@@ -11,13 +11,13 @@ function inFunctionNoNamespace()
 -----
 <?php
 
-class AnonymousFor_inFunctionNoNamespace
+function inFunctionNoNamespace()
+{
+    return new Anonymous__%s__0();
+}
+class Anonymous__%s__0
 {
     public function execute()
     {
     }
-}
-function inFunctionNoNamespace()
-{
-    return new AnonymousFor_inFunctionNoNamespace();
 }

--- a/rules-tests/DowngradePhp70/Rector/New_/DowngradeAnonymousClassRector/Fixture/no_namespace.php.inc
+++ b/rules-tests/DowngradePhp70/Rector/New_/DowngradeAnonymousClassRector/Fixture/no_namespace.php.inc
@@ -14,16 +14,16 @@ class NoNamespace
 -----
 <?php
 
-class AnonymousFor_NoNamespace
-{
-    public function execute()
-    {
-    }
-}
 class NoNamespace
 {
     public function run()
     {
-        return new AnonymousFor_NoNamespace();
+        return new Anonymous__%s__0();
+    }
+}
+class Anonymous__%s__0
+{
+    public function execute()
+    {
     }
 }

--- a/rules-tests/DowngradePhp70/Rector/New_/DowngradeAnonymousClassRector/Fixture/not_in_function.php.inc
+++ b/rules-tests/DowngradePhp70/Rector/New_/DowngradeAnonymousClassRector/Fixture/not_in_function.php.inc
@@ -14,12 +14,10 @@ return new class {
 
 namespace Rector\Tests\DowngradePhp70\Rector\New_\DowngradeAnonymousClassRector\Fixture;
 
-class AnonymousFor_NotInFunction
+return new Anonymous__%s__0();
+class Anonymous__%s__0
 {
     public function execute()
     {
     }
 }
-return new AnonymousFor_NotInFunction();
-
-?>

--- a/rules-tests/DowngradePhp70/Rector/New_/DowngradeAnonymousClassRector/Fixture/not_in_function_no_namespace.php.inc
+++ b/rules-tests/DowngradePhp70/Rector/New_/DowngradeAnonymousClassRector/Fixture/not_in_function_no_namespace.php.inc
@@ -8,10 +8,10 @@ return new class {
 -----
 <?php
 
-class AnonymousFor_NotInfunctionNoNamespace
+return new Anonymous__%s__0();
+class Anonymous__%s__0
 {
     public function execute()
     {
     }
 }
-return new AnonymousFor_NotInfunctionNoNamespace();

--- a/rules-tests/DowngradePhp70/Rector/New_/DowngradeAnonymousClassRector/Fixture/skip_not_anonymous.php.inc
+++ b/rules-tests/DowngradePhp70/Rector/New_/DowngradeAnonymousClassRector/Fixture/skip_not_anonymous.php.inc
@@ -13,5 +13,3 @@ class SkipNotAnonymous
         return new SomeClass($arg1, $arg2);
     }
 }
-
-?>

--- a/rules-tests/DowngradePhp70/Rector/New_/DowngradeAnonymousClassRector/Fixture/with_args.php.inc
+++ b/rules-tests/DowngradePhp70/Rector/New_/DowngradeAnonymousClassRector/Fixture/with_args.php.inc
@@ -20,18 +20,16 @@ class WithArgs
 
 namespace Rector\Tests\DowngradePhp70\Rector\New_\DowngradeAnonymousClassRector\Fixture;
 
-class AnonymousFor_WithArgs
+class WithArgs
+{
+    public function run($arg1, $arg2)
+    {
+        return new Anonymous__%s__0($arg1, $arg2);
+    }
+}
+class Anonymous__%s__0
 {
     public function execute()
     {
     }
 }
-class WithArgs
-{
-    public function run($arg1, $arg2)
-    {
-        return new AnonymousFor_WithArgs($arg1, $arg2);
-    }
-}
-
-?>

--- a/rules/DowngradePhp70/Rector/New_/DowngradeAnonymousClassRector.php
+++ b/rules/DowngradePhp70/Rector/New_/DowngradeAnonymousClassRector.php
@@ -25,12 +25,6 @@ final class DowngradeAnonymousClassRector extends AbstractRector
     private const ANONYMOUS_CLASS_PREFIX = 'Anonymous__';
 
     /**
-     * @see https://regex101.com/r/kF3pRI/1
-     * @var string
-     */
-    private const TEST_PREFIX_REGEX = '#input_(\w[^_]+)_#';
-
-    /**
      * @var ClassAnalyzer
      */
     private $classAnalyzer;


### PR DESCRIPTION
Fixes these bugs :bug: 

- with 2 classes in same file, previous all were named the same - see https://github.com/symplify/easy-coding-standard/blob/3402ffe98ed26247b3479628986f633d3a1084d4/vendor/symfony/service-contracts/ServiceLocatorTrait.php#L23
- with 2 classes in same namespace (different files)


<br>

Changes got inspired by https://github.com/spatie/7to5/blob/master/src/NodeVisitors/AnonymousClassReplacer.php


The new class name is now based on:

- current absolute file path - unique for every file :heavy_check_mark: 
- on number of already added anonymous classes :heavy_check_mark: 