### PR TITLE
[Core] Fixes Cache in FilesFinder

### DIFF
--- a/packages/Caching/Application/CachedFileInfoFilterAndReporter.php
+++ b/packages/Caching/Application/CachedFileInfoFilterAndReporter.php
@@ -42,13 +42,9 @@ final class CachedFileInfoFilterAndReporter
      */
     public function filterFileInfos(array $phpFileInfos): array
     {
-        if (! $this->configuration->isCacheEnabled()) {
-            return $phpFileInfos;
-        }
-
-        // cache stuff
-        if ($this->configuration->shouldClearCache()) {
+        if (! $this->configuration->isCacheEnabled() || $this->configuration->shouldClearCache()) {
             $this->changedFilesDetector->clear();
+            return $phpFileInfos;
         }
 
         return $this->unchangedFilesFilter->filterAndJoinWithDependentFileInfos($phpFileInfos);

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Rector\Core\Console\Command;
 
+use Nette\Utils\Strings;
 use PHPStan\Analyser\NodeScopeResolver;
 use Rector\Caching\Detector\ChangedFilesDetector;
 use Rector\ChangesReporting\Output\ConsoleOutputFormatter;
@@ -273,7 +274,11 @@ final class ProcessCommand extends Command
         $filePaths = [];
         foreach ($files as $file) {
             $smartFileInfo = $file->getSmartFileInfo();
-            $filePaths[] = $smartFileInfo->getPathname();
+            $pathName = $smartFileInfo->getPathname();
+
+            if (Strings::endsWith($pathName, '.php')) {
+                $filePaths[] = $pathName;
+            }
         }
 
         $this->nodeScopeResolver->setAnalysedFiles($filePaths);

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -14,7 +14,6 @@ use Rector\Core\Configuration\Configuration;
 use Rector\Core\Configuration\Option;
 use Rector\Core\Console\Output\OutputFormatterCollector;
 use Rector\Core\Exception\ShouldNotHappenException;
-use Rector\Core\FileSystem\PhpFilesFinder;
 use Rector\Core\Reporting\MissingRectorRulesReporter;
 use Rector\Core\StaticReflection\DynamicSourceLocatorDecorator;
 use Rector\Core\ValueObject\Application\File;
@@ -28,7 +27,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symplify\PackageBuilder\Console\ShellCode;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class ProcessCommand extends Command
 {
@@ -46,11 +44,6 @@ final class ProcessCommand extends Command
      * @var OutputFormatterCollector
      */
     private $outputFormatterCollector;
-
-    /**
-     * @var PhpFilesFinder
-     */
-    private $phpFilesFinder;
 
     /**
      * @var ChangedFilesDetector
@@ -97,7 +90,6 @@ final class ProcessCommand extends Command
         ChangedFilesDetector $changedFilesDetector,
         Configuration $configuration,
         OutputFormatterCollector $outputFormatterCollector,
-        PhpFilesFinder $phpFilesFinder,
         MissingRectorRulesReporter $missingRectorRulesReporter,
         ApplicationFileProcessor $applicationFileProcessor,
         FileFactory $fileFactory,
@@ -110,7 +102,6 @@ final class ProcessCommand extends Command
         $this->configuration = $configuration;
         $this->outputFormatterCollector = $outputFormatterCollector;
         $this->changedFilesDetector = $changedFilesDetector;
-        $this->phpFilesFinder = $phpFilesFinder;
         $this->missingRectorRulesReporter = $missingRectorRulesReporter;
 
         parent::__construct();

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -281,7 +281,8 @@ final class ProcessCommand extends Command
     {
         $filePaths = [];
         foreach ($files as $file) {
-            $filePaths[] = $file->getSmartFileInfo()->getPathname();
+            $smartFileInfo = $file->getSmartFileInfo();
+            $filePaths[] = $smartFileInfo->getPathname();
         }
 
         $this->nodeScopeResolver->setAnalysedFiles($filePaths);

--- a/src/FileSystem/FilesFinder.php
+++ b/src/FileSystem/FilesFinder.php
@@ -81,7 +81,7 @@ final class FilesFinder
 
         $cacheKeyPHPSuffix = md5(serialize($source) . serialize(['php']));
 
-        if (isset($this->fileInfosBySourceAndSuffixes[$cacheKeyPHPSuffix])) {
+        if (count($suffixes) > 2 && isset($this->fileInfosBySourceAndSuffixes[$cacheKeyPHPSuffix])) {
             return $this->fileInfosBySourceAndSuffixes[$cacheKeyPHPSuffix];
         }
 

--- a/src/FileSystem/FilesFinder.php
+++ b/src/FileSystem/FilesFinder.php
@@ -176,7 +176,7 @@ final class FilesFinder
 
         $files = [];
         foreach ($smartFileInfos as $smartFileInfo) {
-            $files[] = $smartFileInfo->getRelativeFilePathFromCwd();
+            $files[] = $smartFileInfo->getPathname();
         }
 
         return $files;

--- a/src/FileSystem/FilesFinder.php
+++ b/src/FileSystem/FilesFinder.php
@@ -79,6 +79,12 @@ final class FilesFinder
             return $this->fileInfosBySourceAndSuffixes[$cacheKey];
         }
 
+        $cacheKeyPHPSuffix = md5(serialize($source) . serialize(['php']));
+
+        if (isset($this->fileInfosBySourceAndSuffixes[$cacheKeyPHPSuffix])) {
+            return $this->fileInfosBySourceAndSuffixes[$cacheKeyPHPSuffix];
+        }
+
         $files = $this->fileSystemFilter->filterFiles($source);
         $directories = $this->fileSystemFilter->filterDirectories($source);
 

--- a/src/FileSystem/FilesFinder.php
+++ b/src/FileSystem/FilesFinder.php
@@ -108,6 +108,10 @@ final class FilesFinder
         return $this->getSmartFileInfosFromStringFiles($files);
     }
 
+    /**
+     * @param string[] $files
+     * @return SmartFileInfo[]
+     */
     private function getSmartFileInfosFromStringFiles(array $files): array
     {
         $smartFileInfos = [];
@@ -118,6 +122,11 @@ final class FilesFinder
         return $smartFileInfos;
     }
 
+    /**
+     * @param string[] $source
+     * @param string[] $suffixes
+     * @return SmartFileInfo[]
+     */
     private function collectFileInfos(array $source, array $suffixes): array
     {
         $files = $this->fileSystemFilter->filterFiles($source);

--- a/src/FileSystem/FilesFinder.php
+++ b/src/FileSystem/FilesFinder.php
@@ -79,12 +79,6 @@ final class FilesFinder
             return $this->fileInfosBySourceAndSuffixes[$cacheKey];
         }
 
-        $cacheKeyPHPSuffix = md5(serialize($source) . serialize(['php']));
-
-        if (count($suffixes) > 2 && isset($this->fileInfosBySourceAndSuffixes[$cacheKeyPHPSuffix])) {
-            return $this->fileInfosBySourceAndSuffixes[$cacheKeyPHPSuffix];
-        }
-
         $files = $this->fileSystemFilter->filterFiles($source);
         $directories = $this->fileSystemFilter->filterDirectories($source);
 


### PR DESCRIPTION
Fixes #6389 . It was due to cache key overlapped with next cache key, while `[php]` suffix not checked.