### PR TITLE
Declare dependency into intl extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     ],
     "require": {
         "php": "^7.1|^8.0",
+        "ext-intl": "*",
         "phpstan/phpstan": "0.12.93"
     },
     "autoload": {


### PR DESCRIPTION
Upon installing rector, I attempted to run the command specified in the
readme file: `vendor/bin/rector init`. However, this command ended up in
a fatal error that was caused by my PHP environment not having the
intl extension installed.

This change adds this dependency to the composer.json file. This would cause
install processes to complain that the system where it's being installed don't
meet all the requirements, thus, avoiding users to encounter the same
fatal error I encountered, providing the composer command it's not run with the
`ignore-platform-reqs`.