### PR TITLE
Fix wrong example for ArgumentRemoverRector

### DIFF
--- a/docs/rector_rules_overview.md
+++ b/docs/rector_rules_overview.md
@@ -8765,7 +8765,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(ArgumentRemoverRector::class)
         ->call('configure', [[
             ArgumentRemoverRector::REMOVED_ARGUMENTS => ValueObjectInliner::inline([
-                new ArgumentRemover('ExampleClass', 'someMethod', 0, 'true'),
+                new ArgumentRemover('ExampleClass', 'someMethod', 0, ['true']),
             ]),
         ]]);
 };


### PR DESCRIPTION
An array is expected down the road.
Providing an string results in the following error:
```
 [ERROR] Could not process "/Tests/Unit/Controller/AddressControllerTest.php" file, due to:
         "Argument 2 passed to Rector\Removing\Rector\ClassMethod\ArgumentRemoverRector::isArgumentValueMatch() must be
         of the type array, string given, called in
         vendor/rector/rector/rules/Removing/Rector/ClassMethod/ArgumentRemoverRector.php:100". On line: 123
```