### PR TITLE
Fix wrong docs for ArgumentRemoverRector

### DIFF
--- a/rules/Removing/Rector/ClassMethod/ArgumentRemoverRector.php
+++ b/rules/Removing/Rector/ClassMethod/ArgumentRemoverRector.php
@@ -37,7 +37,7 @@ CODE_SAMPLE
 $someObject = new SomeClass;
 $someObject->someMethod();
 CODE_SAMPLE
-, [self::REMOVED_ARGUMENTS => [new \Rector\Removing\ValueObject\ArgumentRemover('ExampleClass', 'someMethod', 0, 'true')]])]);
+, [self::REMOVED_ARGUMENTS => [new \Rector\Removing\ValueObject\ArgumentRemover('ExampleClass', 'someMethod', 0, [true])]])]);
     }
     /**
      * @return array<class-string<Node>>


### PR DESCRIPTION
The value to remove has to be enclosed as array.
The value also has to match the type. The example has a boolean `true`.
The example rule now matches that to prevent confusion.

Resolves: #6657