### PR TITLE
Allowing future versions of phpstan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     ],
     "require": {
         "php": "^7.1|^8.0",
-        "phpstan/phpstan": "0.12.96"
+        "phpstan/phpstan": "^0.12.96"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
phpstan 0.12.97 was just released today https://github.com/phpstan/phpstan/releases
So right now, rector cannot be installed :-(