### PR TITLE
Enable MemoryCacheStorage in GitLab CI

### DIFF
--- a/config/parameters.php
+++ b/config/parameters.php
@@ -31,8 +31,8 @@ return static function (\Symfony\Component\DependencyInjection\Loader\Configurat
     $parameters->set(\Rector\Core\Configuration\Option::CACHE_DIR, \sys_get_temp_dir() . '/rector_cached_files');
     // use faster in-memory cache in CI.
     // CI always starts from scratch, therefore IO intensive caching is not worth it
-    $runsInGithubAction = \getenv('GITHUB_ACTION');
-    if ($runsInGithubAction !== \false) {
+    $runsInCI = \getenv('GITHUB_ACTION') || \getenv('GITLAB_CI');
+    if ($runsInCI !== \false) {
         $parameters->set(\Rector\Core\Configuration\Option::CACHE_CLASS, \Rector\Caching\ValueObject\Storage\MemoryCacheStorage::class);
     }
 };


### PR DESCRIPTION
Currently only the ENV `GITHUB_ACTION` is checked, but GitLab CI provides a similar variable: `GITLAB_CI`.

https://docs.gitlab.com/ee/ci/variables/predefined_variables.html

There is also a more generic `CI` variable, but wasn't 100% sure that would be good one as it might be too generic to break things.