### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/along_other_packages.yaml
+++ b/.github/workflows/along_other_packages.yaml
@@ -6,6 +6,9 @@ on:
         branches:
             - main
 
+permissions:
+  contents: read
+
 jobs:
     along_other_packages:
         runs-on: ubuntu-latest

--- a/.github/workflows/bare_run.yaml
+++ b/.github/workflows/bare_run.yaml
@@ -6,6 +6,9 @@ on:
         branches:
             - main
 
+permissions:
+  contents: read
+
 jobs:
     bare_run:
         runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -9,6 +9,9 @@ on:
         branches:
             - main
 
+permissions:
+  contents: read
+
 jobs:
     end_to_end:
         runs-on: ubuntu-latest

--- a/.github/workflows/e2e_diff.yaml
+++ b/.github/workflows/e2e_diff.yaml
@@ -9,6 +9,9 @@ on:
         branches:
             - main
 
+permissions:
+  contents: read
+
 jobs:
     end_to_end_with_diff:
         runs-on: ubuntu-latest

--- a/.github/workflows/e2e_global.yaml
+++ b/.github/workflows/e2e_global.yaml
@@ -6,6 +6,9 @@ on:
         branches:
             - main
 
+permissions:
+  contents: read
+
 jobs:
     end_to_end:
         runs-on: ubuntu-latest

--- a/.github/workflows/e2e_php74.yaml
+++ b/.github/workflows/e2e_php74.yaml
@@ -9,6 +9,9 @@ on:
         branches:
             - main
 
+permissions:
+  contents: read
+
 jobs:
     end_to_end_on_php74:
         runs-on: ubuntu-latest

--- a/.github/workflows/standalone_rule_test.yaml
+++ b/.github/workflows/standalone_rule_test.yaml
@@ -6,6 +6,9 @@ on:
         branches:
             - main
 
+permissions:
+  contents: read
+
 jobs:
     standalone_rule_test:
         runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
