### PR TITLE
Docs: Replace deprecated option w/ `importShortClasses`

### DIFF
--- a/docs/auto_import_names.md
+++ b/docs/auto_import_names.md
@@ -32,7 +32,7 @@ Single short classes are imported too:
 Do you want to keep those?
 
 ```php
-$parameters->set(Option::IMPORT_SHORT_CLASSES, false);
+$parameters->importShortClasses(false);
 ```
 
 <br>


### PR DESCRIPTION
`Option::IMPORT_SHORT_CLASSES` is deprecated and `importShortClasses` should be used.