### PR TITLE
Improve docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,17 +34,7 @@ Do you want to **contribute a failing test**? [This tutorial will show you how](
 
 - **1 feature per pull-request**
 - **new features need tests**
-- CI must pass... you can mimic it locally by running
-
-    ```bash
-    composer complete-check
-    ```
-
-- Do you need to fix coding standards?
-
-    ```bash
-    composer fix-cs
-    ```
+- CI must pass
 
 We would be happy to accept PRs that follow these guidelines.
 

--- a/docs/auto_import_names.md
+++ b/docs/auto_import_names.md
@@ -32,7 +32,7 @@ Single short classes are imported too:
 Do you want to keep those?
 
 ```php
-$parameters->set(Option::IMPORT_SHORT_CLASSES, false);
+$rectorConfig->importShortClasses(false);
 ```
 
 <br>

--- a/docs/how_to_add_test_for_rector_rule.md
+++ b/docs/how_to_add_test_for_rector_rule.md
@@ -7,7 +7,7 @@ When using Rector to update your own code, you will typically be using release r
 - Fork https://github.com/rectorphp/rector-src
 - Clone it locally
 - Install dependencies by executing `composer install`
-- Tests your installation by executing `composer fix-cs` and `composer phpstan`
+- Tests your installation by executing `composer check-platform-reqs`
 - Create a new branch for your test
 - Add your test as described below. Note that the rector binary is located at `bin/rector` instead of the typical `vendor/bin/rector`
 - Push the branch


### PR DESCRIPTION
Found some small improvements to the docs:
- It seems like some composer scripts are no longer present, so I removed references to `composer complete-check`, `composer fix-cs` and `composer phpstan`. If you have any way that users can verify their changes locally, let me know.
- `$parameters->set(Option::IMPORT_SHORT_CLASSES, false);` is deprecated and replaced by `$rectorConfig->importShortClasses(false);`
