### PR TITLE
Add real path to filePaths when not false

### DIFF
--- a/src/FileSystem/FilesFinder.php
+++ b/src/FileSystem/FilesFinder.php
@@ -72,7 +72,10 @@ final class FilesFinder
         $this->addFilterWithExcludedPaths($finder);
         $filePaths = [];
         foreach ($finder as $fileInfo) {
-            $filePaths[] = $fileInfo->getRealPath();
+            $path = $fileInfo->getRealPath();
+            if ($path) {
+                $filePaths[] = $path;
+            }
         }
         return $this->unchangedFilesFilter->filterAndJoinWithDependentFileInfos($filePaths);
     }


### PR DESCRIPTION
When I tried to use rector I got TypeError exception. After debugging its cause I got this solution. The problem was that I have some broken symlink directories in my code, and when `getRealPath()` function tried to find path to this symlinks, it returns false. Then other functions that uses `$filePaths` array tries proceed bool variable, they throws TypeError.
I thought it will be nice to check what returns `getRealPath()` function before adding its value to `$filePaths` array.