### PR TITLE
Fix #7795 by skipping extensions not supporting this way to be loaded.

### DIFF
--- a/packages/NodeTypeResolver/DependencyInjection/PHPStanExtensionsConfigResolver.php
+++ b/packages/NodeTypeResolver/DependencyInjection/PHPStanExtensionsConfigResolver.php
@@ -34,7 +34,14 @@ final class PHPStanExtensionsConfigResolver
         }
         $generatedConfigDirectory = \dirname($generatedConfigClassFileName);
         $extensionConfigFiles = [];
-        foreach (GeneratedConfig::EXTENSIONS as $extension) {
+        // Some extensions are unsupported and only work when used by PHPstan directly, so we skip them.
+        $unsupportedExtensions = [
+          'mglaman/phpstan-drupal', // https://github.com/rectorphp/rector/issues/7795
+        ];
+        foreach (GeneratedConfig::EXTENSIONS as $name => $extension) {
+            if (in_array($name, $unsupportedExtensions)) {
+              continue;
+            }
             $fileNames = $extension['extra']['includes'] ?? [];
             foreach ($fileNames as $fileName) {
                 $configFilePath = $generatedConfigDirectory . '/' . $extension['relative_install_path'] . '/' . $fileName;


### PR DESCRIPTION
Skip loading PHPstan extension which are not compatible with the way rector tries to load them.

This is just a hotfix handling the fact that loading extensions like `mglaman/phpstan-drupal` fail when loaded improperly. According to @mglaman they way of loading the extensions is not correct and must be fixed.

No tests changed or added for this fix, as this might only be a temporary change to be used as patch by those affected until a proper fix is available.