### PR TITLE
NullToStrictStringFuncCallArgRector - Improve checking for 'nullable union types'

### DIFF
--- a/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
+++ b/rules/Php81/Rector/FuncCall/NullToStrictStringFuncCallArgRector.php
@@ -20,6 +20,7 @@ use PHPStan\Type\ErrorType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
 use Rector\Core\NodeAnalyzer\ArgsAnalyzer;
 use Rector\Core\NodeAnalyzer\PropertyFetchAnalyzer;
 use Rector\Core\Rector\AbstractScopeAwareRector;
@@ -159,9 +160,23 @@ CODE_SAMPLE
         if ($type->isString()->yes()) {
             return null;
         }
-        if (!$type instanceof MixedType && !$type instanceof NullType) {
+
+        $isNullable = false;
+        if ($type instanceof NullType) {
+            $isNullable = true;
+        } elseif ($type instanceof UnionType) {
+            foreach ($type->getTypes() as $unionType) {
+                if (is_a($unionType, NullType::class)) {
+                    $isNullable = true;
+                    break;
+                }
+            }
+        }
+
+        if (!$type instanceof MixedType && !$isNullable) {
             return null;
         }
+
         if ($argValue instanceof Encapsed) {
             return null;
         }


### PR DESCRIPTION
Looks like the current code does not pick up union types (e.g., `string|null` or `string|Stringable|null`). If there is a chance of null then the (string) cast should be added there also to prevent risk of PHP 8.2 deprecation errors.