### PR TITLE
Update branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "0.15-dev"
+            "dev-main": "0.17-dev"
         }
     },
     "conflict": {


### PR DESCRIPTION
Shouldn't the branch alias be the current developing version? Seems it has been stuck on 0.15 while 0.17 is beging released now.

https://github.com/rectorphp/rector-src/pull/4714