### PR TITLE
fix(82): readonly class rule

### DIFF
--- a/rules/Php82/Rector/Class_/ReadOnlyClassRector.php
+++ b/rules/Php82/Rector/Class_/ReadOnlyClassRector.php
@@ -150,7 +150,7 @@ CODE_SAMPLE
             return \true;
         }
         $parents = $this->resolveParentClassReflections($scope);
-        if (!$class->isFinal()) {
+        if (!$class->isFinal() && !empty($parents)) {
             return !$this->isExtendsReadonlyClass($parents);
         }
         foreach ($parents as $parent) {


### PR DESCRIPTION
Hi,

Readonly class rule seems to not work correctly if class does not have any parents, this should fix it.
