### PR TITLE
InlineConstructorDefaultToPropertyRector Readonly Class

### DIFF
--- a/rules/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector.php
+++ b/rules/CodeQuality/Rector/Class_/InlineConstructorDefaultToPropertyRector.php
@@ -128,7 +128,7 @@ CODE_SAMPLE
                 continue;
             }
             // readonly property cannot have default value
-            if ($classStmt->isReadonly()) {
+            if ($classStmt->isReadonly() || $class->isReadonly()) {
                 continue;
             }
             foreach ($classStmt->props as $propertyProperty) {


### PR DESCRIPTION
PHP Parser does not mark properties as readonly when the class itself is readonly. Therefor we also need to check the class if it's readonly.

This feels like a bug in PHP-Parser though, so I've also opened an issue there. https://github.com/nikic/PHP-Parser/issues/949