### PR TITLE
add consistentimploderector to php80 rules

### DIFF
--- a/config/set/php80.php
+++ b/config/set/php80.php
@@ -8,6 +8,7 @@ use Rector\Arguments\Rector\FuncCall\FunctionArgumentDefaultValueReplacerRector;
 use Rector\Arguments\ValueObject\ArgumentAdder;
 use Rector\Arguments\ValueObject\ReplaceFuncCallArgumentDefaultValue;
 use Rector\CodeQuality\Rector\ClassMethod\OptionalParametersAfterRequiredRector;
+use Rector\CodingStyle\Rector\FuncCall\ConsistentImplodeRector;
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\StaticCall\RemoveParentCallWithoutParentRector;
 use Rector\Php80\Rector\Catch_\RemoveUnusedVariableInCatchRector;
@@ -28,7 +29,7 @@ use Rector\Renaming\Rector\FuncCall\RenameFunctionRector;
 use Rector\Transform\Rector\StaticCall\StaticCallToFuncCallRector;
 use Rector\Transform\ValueObject\StaticCallToFuncCall;
 return static function (RectorConfig $rectorConfig) : void {
-    $rectorConfig->rules([StrContainsRector::class, StrStartsWithRector::class, StrEndsWithRector::class, StringableForToStringRector::class, ClassOnObjectRector::class, GetDebugTypeRector::class, RemoveUnusedVariableInCatchRector::class, ClassPropertyAssignToConstructorPromotionRector::class, ChangeSwitchToMatchRector::class, RemoveParentCallWithoutParentRector::class, SetStateToStaticRector::class, FinalPrivateToPrivateVisibilityRector::class, AddParamBasedOnParentClassMethodRector::class, MixedTypeRector::class, ClassOnThisVariableObjectRector::class]);
+    $rectorConfig->rules([StrContainsRector::class, StrStartsWithRector::class, StrEndsWithRector::class, StringableForToStringRector::class, ClassOnObjectRector::class, GetDebugTypeRector::class, RemoveUnusedVariableInCatchRector::class, ClassPropertyAssignToConstructorPromotionRector::class, ChangeSwitchToMatchRector::class, RemoveParentCallWithoutParentRector::class, SetStateToStaticRector::class, FinalPrivateToPrivateVisibilityRector::class, AddParamBasedOnParentClassMethodRector::class, MixedTypeRector::class, ClassOnThisVariableObjectRector::class,ConsistentImplodeRector::class]);
     $rectorConfig->ruleWithConfiguration(StaticCallToFuncCallRector::class, [new StaticCallToFuncCall('Nette\\Utils\\Strings', 'startsWith', 'str_starts_with'), new StaticCallToFuncCall('Nette\\Utils\\Strings', 'endsWith', 'str_ends_with'), new StaticCallToFuncCall('Nette\\Utils\\Strings', 'contains', 'str_contains')]);
     // nette\utils and Strings::replace()
     $rectorConfig->ruleWithConfiguration(ArgumentAdderRector::class, [new ArgumentAdder('Nette\\Utils\\Strings', 'replace', 2, 'replacement', '')]);

--- a/rules/Php80/Rector/FuncCall/ConsistentImplodeRector.php
+++ b/rules/Php80/Rector/FuncCall/ConsistentImplodeRector.php
@@ -1,0 +1,100 @@
+<?php
+
+declare (strict_types=1);
+namespace Rector\Php80\Rector\FuncCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Scalar\String_;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Core\ValueObject\PhpVersionFeature;
+use Rector\NodeTypeResolver\TypeAnalyzer\StringTypeAnalyzer;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+/**
+ * @changelog http://php.net/manual/en/function.implode.php#refsect1-function.implode-description
+ * @changelog https://3v4l.org/iYTgh
+ * @see \Rector\Tests\CodingStyle\Rector\FuncCall\ConsistentImplodeRector\ConsistentImplodeRectorTest
+ */
+final class ConsistentImplodeRector extends AbstractRector implements MinPhpVersionInterface
+{
+    /**
+     * @readonly
+     * @var \Rector\NodeTypeResolver\TypeAnalyzer\StringTypeAnalyzer
+     */
+    private $stringTypeAnalyzer;
+    public function __construct(StringTypeAnalyzer $stringTypeAnalyzer)
+    {
+        $this->stringTypeAnalyzer = $stringTypeAnalyzer;
+    }
+    public function getRuleDefinition() : RuleDefinition
+    {
+        return new RuleDefinition('Changes various implode forms to consistent one', [new CodeSample(<<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run(array $items)
+    {
+        $itemsAsStrings = implode($items);
+        $itemsAsStrings = implode($items, '|');
+    }
+}
+CODE_SAMPLE
+            , <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run(array $items)
+    {
+        $itemsAsStrings = implode('', $items);
+        $itemsAsStrings = implode('|', $items);
+    }
+}
+CODE_SAMPLE
+        )]);
+    }
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes() : array
+    {
+        return [FuncCall::class];
+    }
+    /**
+     * @param FuncCall $node
+     */
+    public function refactor(Node $node) : ?Node
+    {
+        if (!$this->isName($node, 'implode')) {
+            return null;
+        }
+        if ($node->isFirstClassCallable()) {
+            return null;
+        }
+        if (\count($node->getArgs()) === 1) {
+            // complete default value ''
+            $node->args[1] = $node->getArgs()[0];
+            $node->args[0] = new Arg(new String_(''));
+            return $node;
+        }
+        $firstArg = $node->getArgs()[0];
+        $firstArgumentValue = $firstArg->value;
+        $firstArgumentType = $this->getType($firstArgumentValue);
+        if ($firstArgumentType->isString()->yes()) {
+            return null;
+        }
+        if (\count($node->getArgs()) !== 2) {
+            return null;
+        }
+        $secondArg = $node->getArgs()[1];
+        if ($this->stringTypeAnalyzer->isStringOrUnionStringOnlyType($secondArg->value)) {
+            $node->args = \array_reverse($node->getArgs());
+            return $node;
+        }
+        return null;
+    }
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::CLASS_ON_OBJECT;
+    }
+}


### PR DESCRIPTION
PHP 8.0 no longer supports passing the separator after the array (https://www.php.net/manual/en/function.implode.php#refsect1-function.implode-changelog).

The ConsistentImplodeRector rule shuold be added to PHP80 rules by default.