### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,13 +14,12 @@ CONTRIBUTING.md export-ignore
 CHANGELOG.md export-ignore
 CODE_OF_CONDUCT.md export-ignore
 
-# exclude only root dirs, otherwise nette/utils is removed - see https://github.com/TomasVotruba/tomasvotruba.com/pull/1197/checks?check_run_id=2577329283
-/stubs export-ignore
+# exclude only root dirs, otherwise nette/utils is removed
 
+/stubs-rector export-ignore
 docs/ export-ignore
 .github export-ignore
 /e2e export-ignore
 
 # testing Windows spaces - https://help.github.com/en/github/using-git/configuring-git-to-handle-line-endings
 packages/better-php-doc-parser/tests/PhpDocInfo/PhpDocInfoPrinter/FixtureBasic/with_spac.txt text eol=crlf
-


### PR DESCRIPTION
## 📚 Description

- Remove broken link
- Ignore `/stubs-rector` instead of `/stubs` folder (which doesn't exist in the root)