### PR TITLE
Update README to use the new config syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,16 +46,16 @@ use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\SetList;
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector;
 
-return static function (RectorConfig $rectorConfig): void {
+return RectorConfig::configure()
     // register single rule
-    $rectorConfig->rule(TypedPropertyFromStrictConstructorRector::class);
-
+    ->withRules([
+        TypedPropertyFromStrictConstructorRector::class
+    ])
     // here we can define, what sets of rules will be applied
     // tip: use "SetList" class to autocomplete sets with your IDE
-    $rectorConfig->sets([
+    ->withSets([
         SetList::CODE_QUALITY
     ]);
-};
 ```
 
 Then dry run Rector:


### PR DESCRIPTION
Use `RectorConfig::configure()` instead of `static function (RectorConfig $rectorConfig)`

There are related PRs in the 

- Rector-symfony respository: https://github.com/rectorphp/rector-symfony/pull/585
- Rector-phpunit repository: https://github.com/rectorphp/rector-phpunit/pull/314
- Rector-doctrine repository: https://github.com/rectorphp/rector-doctrine/pull/293 