### PR TITLE
Grammar fix

### DIFF
--- a/src/ChangesReporting/Output/ConsoleOutputFormatter.php
+++ b/src/ChangesReporting/Output/ConsoleOutputFormatter.php
@@ -108,6 +108,6 @@ final class ConsoleOutputFormatter implements OutputFormatterInterface
         if ($changeCount === 0) {
             return 'Rector is done!';
         }
-        return \sprintf('%d file%s %s by Rector', $changeCount, $changeCount > 1 ? 's' : '', $configuration->isDryRun() ? 'would have changed (dry-run)' : ($changeCount === 1 ? 'has' : 'have') . ' been changed');
+        return \sprintf('%d file%s %s by Rector', $changeCount, $changeCount > 1 ? 's' : '', $configuration->isDryRun() ? 'would have been changed (dry-run)' : ($changeCount === 1 ? 'has' : 'have') . ' been changed');
     }
 }


### PR DESCRIPTION
Just a small grammar fix. Before:

```
 [OK] XX files would have changed (dry-run) by Rector 
```

After:

```
 [OK] XX files would have been changed (dry-run) by Rector 
```
