### PR TITLE
Please allow extending BetterStandardPrinter

### DIFF
--- a/src/PhpParser/Printer/BetterStandardPrinter.php
+++ b/src/PhpParser/Printer/BetterStandardPrinter.php
@@ -36,7 +36,7 @@ use Rector\PhpParser\Node\CustomNode\FileWithoutNamespace;
  *
  * @property array<string, array{string, bool, string, null}> $insertionMap
  */
-final class BetterStandardPrinter extends Standard
+class BetterStandardPrinter extends Standard
 {
     /**
      * @var string


### PR DESCRIPTION
I am working on a rector rule which converts a significant portion of the remaining procedural code in Drupal to OOP (run!).

I needed to override `pExpr_Array` but it's not possible currently.

Thanks for your consideration.