### PR TITLE
Introducing Rector Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rector - Instant Upgrades and Automated Refactoring
 
-[![Downloads](https://img.shields.io/packagist/dt/rector/rector.svg?style=flat-square)](https://packagist.org/packages/rector/rector)
+[![Downloads](https://img.shields.io/packagist/dt/rector/rector.svg?style=flat-square)](https://packagist.org/packages/rector/rector) [![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Rector%20Guru-006BFF)](https://gurubase.io/g/rector)
 
 <br>
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Rector Guru](https://gurubase.io/g/rector) to Gurubase. Rector Guru uses the data from this repo and data from the [docs](https://getrector.com/documentation/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Rector Guru", which highlights that Rector now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Rector Guru in Gurubase, just let me know that's totally fine.
