### PR TITLE
Do not override `error_reporting`

### DIFF
--- a/bin/rector.php
+++ b/bin/rector.php
@@ -17,7 +17,6 @@ use RectorPrefix202505\Symfony\Component\Console\Input\ArgvInput;
 // @ intentionally: continue anyway
 @\ini_set('memory_limit', '-1');
 // Performance boost
-\error_reporting(\E_ALL);
 \ini_set('display_errors', 'stderr');
 \gc_disable();
 \define('__RECTOR_RUNNING__', \true);


### PR DESCRIPTION
Currently under PHP 8.4+ you get a deprecation message spam when running rector, depending on the other dev dependencies that might be installed alongside rector (similar to https://github.com/composer/composer/issues/12285 and https://github.com/symfony/symfony/pull/59975). This is because rector sets `\error_reporting(\E_ALL);` in its `bin/rector.php`.

Is there any particular reason why rector should override the `error_reporting` level defined by the PHP environment?