### PR TITLE
Add check for append in foreach items assignment

### DIFF
--- a/rules/CodeQuality/Rector/Foreach_/ForeachItemsAssignToEmptyArrayToAssignRector.php
+++ b/rules/CodeQuality/Rector/Foreach_/ForeachItemsAssignToEmptyArrayToAssignRector.php
@@ -99,6 +99,9 @@ CODE_SAMPLE
                 continue;
             }
             if ($this->shouldSkip($stmt, $emptyArrayVariables)) {
+                if ($this->isAppend($stmt, $emptyArrayVariables)) {
+                    return null;
+                }
                 continue;
             }
             $assignVariable = $this->foreachAnalyzer->matchAssignItemsOnlyForeachArrayVariable($stmt);


### PR DESCRIPTION
This PR fixes the rule `ForeachItemsAssignToEmptyArrayToAssignRector`, which currently ignores array modifications in skipped foreach loops, leading to incorrect direct assignments that overwrite previously collected data.

Fixes #9587 and probable #9534.