### PR TITLE
ci: bump lock-threads to v6 so the scheduled lock job can run

### DIFF
--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: dessant/lock-threads@v5
+            - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c # v6.0.2
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
The scheduled lock job fails on every run before locking anything. The last 10 runs of `lock.yaml` are all failures, each with:

```
##[error]"github-token" length must be less than or equal to 100 characters long
```

(from run 31923889738; the earlier runs fail identically)

The workflow pins `dessant/lock-threads@v5`, and that version validates its `github-token` input with a 100 character cap in its Joi schema:

```js
'github-token': Joi.string().trim().max(100),
```

The Actions token has grown past 100 characters, so validation rejects it and the action exits before doing any work. The cap raise landed in v6.0.2 specifically: v4, v5.0.x, v6.0.0 and v6.0.1 all still validate `max(100)`, and v6.0.2 moved it to 1000. So v6.0.2 is the first safe pin, and it is what the moving `v6` tag currently points at.

I checked every input this workflow passes against the v6.0.2 schema and all of them exist there unchanged, including their accepted values, so the pin bump is the entire fix. The new pin is the commit the v6.0.2 release tag resolves to, keeping the SHA-pinned style.

I could not run this against the repo since the workflow only triggers on schedule, but the same one-line bump fixed the identical failure elsewhere, and the v6 cohort of repos running this action shows green runs.

